### PR TITLE
fix: secure native refresh token rotation

### DIFF
--- a/apps/web/prisma/migrations/20260809170000_add_refresh_token_family_tombstones/migration.sql
+++ b/apps/web/prisma/migrations/20260809170000_add_refresh_token_family_tombstones/migration.sql
@@ -1,0 +1,9 @@
+-- AlterTable
+ALTER TABLE "Session" ADD COLUMN "refreshTokenFamilyId" STRING;
+ALTER TABLE "Session" ADD COLUMN "refreshTokenConsumedAt" TIMESTAMP(3);
+ALTER TABLE "Session" ADD COLUMN "refreshTokenReplacedByToken" STRING;
+ALTER TABLE "Session" ADD COLUMN "refreshTokenRevokedAt" TIMESTAMP(3);
+
+-- CreateIndex
+CREATE INDEX "Session_refreshTokenFamilyId_idx"
+ON "Session"("refreshTokenFamilyId");

--- a/apps/web/prisma/migrations/20260809184500_store_refresh_token_family_state/migration.sql
+++ b/apps/web/prisma/migrations/20260809184500_store_refresh_token_family_state/migration.sql
@@ -24,51 +24,6 @@ CREATE TABLE "NativeRefreshToken" (
     CONSTRAINT "NativeRefreshToken_pkey" PRIMARY KEY ("token")
 );
 
--- Backfill
-INSERT INTO "RefreshTokenFamily" (
-    "id",
-    "userId",
-    "expiresAt",
-    "revokedAt",
-    "createdAt",
-    "updatedAt"
-)
-SELECT
-    "refreshTokenFamilyId",
-    "userId",
-    MAX("expiresAt"),
-    MAX("refreshTokenRevokedAt"),
-    MIN("createdAt"),
-    MAX("updatedAt")
-FROM "Session"
-WHERE "refreshTokenFamilyId" IS NOT NULL
-GROUP BY "refreshTokenFamilyId", "userId";
-
-INSERT INTO "NativeRefreshToken" (
-    "token",
-    "userId",
-    "refreshTokenFamilyId",
-    "expiresAt",
-    "refreshTokenConsumedAt",
-    "refreshTokenReplacedByToken",
-    "createdAt",
-    "updatedAt"
-)
-SELECT
-    "token",
-    "userId",
-    "refreshTokenFamilyId",
-    "expiresAt",
-    "refreshTokenConsumedAt",
-    "refreshTokenReplacedByToken",
-    "createdAt",
-    "updatedAt"
-FROM "Session"
-WHERE "refreshTokenFamilyId" IS NOT NULL;
-
-DELETE FROM "Session"
-WHERE "refreshTokenFamilyId" IS NOT NULL;
-
 -- CreateIndex
 CREATE INDEX "RefreshTokenFamily_userId_idx"
 ON "RefreshTokenFamily"("userId");

--- a/apps/web/prisma/migrations/20260809184500_store_refresh_token_family_state/migration.sql
+++ b/apps/web/prisma/migrations/20260809184500_store_refresh_token_family_state/migration.sql
@@ -1,0 +1,110 @@
+-- CreateTable
+CREATE TABLE "RefreshTokenFamily" (
+    "id" STRING NOT NULL,
+    "userId" STRING NOT NULL,
+    "expiresAt" TIMESTAMP(3) NOT NULL,
+    "revokedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "RefreshTokenFamily_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "NativeRefreshToken" (
+    "token" STRING NOT NULL,
+    "userId" STRING NOT NULL,
+    "refreshTokenFamilyId" STRING NOT NULL,
+    "expiresAt" TIMESTAMP(3) NOT NULL,
+    "refreshTokenConsumedAt" TIMESTAMP(3),
+    "refreshTokenReplacedByToken" STRING,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "NativeRefreshToken_pkey" PRIMARY KEY ("token")
+);
+
+-- Backfill
+INSERT INTO "RefreshTokenFamily" (
+    "id",
+    "userId",
+    "expiresAt",
+    "revokedAt",
+    "createdAt",
+    "updatedAt"
+)
+SELECT
+    "refreshTokenFamilyId",
+    "userId",
+    MAX("expiresAt"),
+    MAX("refreshTokenRevokedAt"),
+    MIN("createdAt"),
+    MAX("updatedAt")
+FROM "Session"
+WHERE "refreshTokenFamilyId" IS NOT NULL
+GROUP BY "refreshTokenFamilyId", "userId";
+
+INSERT INTO "NativeRefreshToken" (
+    "token",
+    "userId",
+    "refreshTokenFamilyId",
+    "expiresAt",
+    "refreshTokenConsumedAt",
+    "refreshTokenReplacedByToken",
+    "createdAt",
+    "updatedAt"
+)
+SELECT
+    "token",
+    "userId",
+    "refreshTokenFamilyId",
+    "expiresAt",
+    "refreshTokenConsumedAt",
+    "refreshTokenReplacedByToken",
+    "createdAt",
+    "updatedAt"
+FROM "Session"
+WHERE "refreshTokenFamilyId" IS NOT NULL;
+
+DELETE FROM "Session"
+WHERE "refreshTokenFamilyId" IS NOT NULL;
+
+-- CreateIndex
+CREATE INDEX "RefreshTokenFamily_userId_idx"
+ON "RefreshTokenFamily"("userId");
+
+-- CreateIndex
+CREATE INDEX "RefreshTokenFamily_expiresAt_idx"
+ON "RefreshTokenFamily"("expiresAt");
+
+-- CreateIndex
+CREATE INDEX "NativeRefreshToken_refreshTokenFamilyId_expiresAt_idx"
+ON "NativeRefreshToken"("refreshTokenFamilyId", "expiresAt");
+
+-- CreateIndex
+CREATE INDEX "NativeRefreshToken_userId_idx"
+ON "NativeRefreshToken"("userId");
+
+-- AddForeignKey
+ALTER TABLE "RefreshTokenFamily"
+ADD CONSTRAINT "RefreshTokenFamily_userId_fkey"
+FOREIGN KEY ("userId") REFERENCES "User"("id")
+ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "NativeRefreshToken"
+ADD CONSTRAINT "NativeRefreshToken_refreshTokenFamilyId_fkey"
+FOREIGN KEY ("refreshTokenFamilyId") REFERENCES "RefreshTokenFamily"("id")
+ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "NativeRefreshToken"
+ADD CONSTRAINT "NativeRefreshToken_userId_fkey"
+FOREIGN KEY ("userId") REFERENCES "User"("id")
+ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AlterTable
+ALTER TABLE "Session" DROP COLUMN "refreshTokenFamilyId";
+ALTER TABLE "Session" DROP COLUMN "refreshTokenConsumedAt";
+ALTER TABLE "Session" DROP COLUMN "refreshTokenReplacedByToken";
+ALTER TABLE "Session" DROP COLUMN "refreshTokenRevokedAt";

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -8,27 +8,29 @@ datasource db {
 }
 
 model User {
-  id                 String               @id @default(uuid())
-  name               String?
-  email              String               @unique
-  image              String?
-  createdAt          DateTime             @default(now())
-  updatedAt          DateTime             @updatedAt
-  emailVerified      Boolean?             @default(false)
-  accounts           Account[]
-  AuditLog           AuditLog[]
-  ConfirmationToken  ConfirmationToken[]
-  Customer           Customer?
-  File               File[]
-  NativeAppAuth      NativeAppAuth[]
-  Package            Package[]
-  passkeys           Passkey[]
-  Profile            Profile?
-  sessions           Session[]
-  SocialProfile      SocialProfile[]
-  UserPackage        UserPackage[]
-  UserPaymentHistory UserPaymentHistory[]
-  Feedback           Feedback[]
+  id                   String               @id @default(uuid())
+  name                 String?
+  email                String               @unique
+  image                String?
+  createdAt            DateTime             @default(now())
+  updatedAt            DateTime             @updatedAt
+  emailVerified        Boolean?             @default(false)
+  accounts             Account[]
+  AuditLog             AuditLog[]
+  ConfirmationToken    ConfirmationToken[]
+  Customer             Customer?
+  File                 File[]
+  NativeAppAuth        NativeAppAuth[]
+  nativeRefreshTokens  NativeRefreshToken[]
+  Package              Package[]
+  passkeys             Passkey[]
+  Profile              Profile?
+  refreshTokenFamilies RefreshTokenFamily[]
+  sessions             Session[]
+  SocialProfile        SocialProfile[]
+  UserPackage          UserPackage[]
+  UserPaymentHistory   UserPaymentHistory[]
+  Feedback             Feedback[]
 }
 
 model Account {
@@ -51,21 +53,45 @@ model Account {
 }
 
 model Session {
-  id                          String    @id @default(uuid())
-  token                       String    @unique(map: "Session_sessionToken_key")
+  id        String   @id @default(uuid())
+  token     String   @unique(map: "Session_sessionToken_key")
+  userId    String
+  expiresAt DateTime
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+  ipAddress String?
+  userAgent String?
+  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+}
+
+model RefreshTokenFamily {
+  id        String               @id
+  userId    String
+  expiresAt DateTime
+  revokedAt DateTime?
+  createdAt DateTime             @default(now())
+  updatedAt DateTime             @updatedAt
+  tokens    NativeRefreshToken[]
+  user      User                 @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([expiresAt])
+  @@index([userId])
+}
+
+model NativeRefreshToken {
+  token                       String             @id
   userId                      String
+  refreshTokenFamilyId        String
   expiresAt                   DateTime
-  createdAt                   DateTime  @default(now())
-  updatedAt                   DateTime  @updatedAt
-  ipAddress                   String?
-  userAgent                   String?
-  refreshTokenFamilyId        String?
   refreshTokenConsumedAt      DateTime?
   refreshTokenReplacedByToken String?
-  refreshTokenRevokedAt       DateTime?
-  user                        User      @relation(fields: [userId], references: [id], onDelete: Cascade)
+  createdAt                   DateTime           @default(now())
+  updatedAt                   DateTime           @updatedAt
+  family                      RefreshTokenFamily @relation(fields: [refreshTokenFamilyId], references: [id], onDelete: Cascade)
+  user                        User               @relation(fields: [userId], references: [id], onDelete: Cascade)
 
-  @@index([refreshTokenFamilyId])
+  @@index([refreshTokenFamilyId, expiresAt])
+  @@index([userId])
 }
 
 model Verification {

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -51,15 +51,21 @@ model Account {
 }
 
 model Session {
-  id        String   @id @default(uuid())
-  token     String   @unique(map: "Session_sessionToken_key")
-  userId    String
-  expiresAt DateTime
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
-  ipAddress String?
-  userAgent String?
-  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  id                          String    @id @default(uuid())
+  token                       String    @unique(map: "Session_sessionToken_key")
+  userId                      String
+  expiresAt                   DateTime
+  createdAt                   DateTime  @default(now())
+  updatedAt                   DateTime  @updatedAt
+  ipAddress                   String?
+  userAgent                   String?
+  refreshTokenFamilyId        String?
+  refreshTokenConsumedAt      DateTime?
+  refreshTokenReplacedByToken String?
+  refreshTokenRevokedAt       DateTime?
+  user                        User      @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([refreshTokenFamilyId])
 }
 
 model Verification {

--- a/packages/api/src/v1/account.ts
+++ b/packages/api/src/v1/account.ts
@@ -16,7 +16,10 @@ import {
   findNativeAppAuthBySessionId,
   updateNativeAppAuthForHandler,
 } from "@beutl/db";
-import { createSession, rotateSessionByToken } from "@beutl/db";
+import {
+  createNativeRefreshToken,
+  rotateNativeRefreshTokenByToken,
+} from "@beutl/db";
 import { isAllowedContinueUrlHost } from "@beutl/core";
 import { sign } from "hono/jwt";
 
@@ -136,7 +139,7 @@ async function createJwtToken(userId: string) {
 
 async function createRefreshToken(userId: string) {
   const prepared = await prepareRefreshToken();
-  await createSession({
+  await createNativeRefreshToken({
     token: prepared.rawToken,
     expiresAt: prepared.expires,
     userId,
@@ -147,8 +150,16 @@ async function createRefreshToken(userId: string) {
 }
 
 async function prepareRefreshToken() {
+  const candidate = createRefreshTokenCandidate();
+  const encToken = await encryptRefreshToken(candidate.rawToken);
+  return {
+    ...candidate,
+    encToken,
+  };
+}
+
+function createRefreshTokenCandidate() {
   const rawToken = crypto.randomUUID();
-  const encToken = await encryptRefreshToken(rawToken);
   const expires = new Date(
     Date.now() +
       1000 *
@@ -162,7 +173,6 @@ async function prepareRefreshToken() {
   }
 
   return {
-    encToken,
     rawToken,
     expires,
   };
@@ -240,8 +250,8 @@ const app = new Hono()
       });
     }
 
-    const replacement = await prepareRefreshToken();
-    const rotation = await rotateSessionByToken({
+    const replacement = createRefreshTokenCandidate();
+    const rotation = await rotateNativeRefreshTokenByToken({
       token: oldDecryptedRefreshToken,
       replacementToken: replacement.rawToken,
       replacementExpiresAt: replacement.expires,
@@ -259,10 +269,9 @@ const app = new Hono()
 
     const { exp: accessTokenExp, token: accessToken } =
       await createJwtToken(rotation.userId);
-    const encryptedRefreshToken =
-      rotation.refreshToken === replacement.rawToken
-        ? replacement.encToken
-        : await encryptRefreshToken(rotation.refreshToken);
+    const encryptedRefreshToken = await encryptRefreshToken(
+      rotation.refreshToken,
+    );
 
     return c.json({
       token: accessToken,

--- a/packages/api/src/v1/account.ts
+++ b/packages/api/src/v1/account.ts
@@ -7,7 +7,7 @@
 import { zValidator } from "@hono/zod-validator";
 import { Hono } from "hono";
 import { z } from "zod";
-import { getUserId, getUserIdFromToken } from "../api/auth";
+import { getUserId } from "../api/auth";
 import { apiErrorResponse } from "../api/error";
 import {
   createNativeAppAuth,
@@ -16,7 +16,7 @@ import {
   findNativeAppAuthBySessionId,
   updateNativeAppAuthForHandler,
 } from "@beutl/db";
-import { createSession, deleteSessionsByToken } from "@beutl/db";
+import { createSession, rotateSessionByToken } from "@beutl/db";
 import { isAllowedContinueUrlHost } from "@beutl/core";
 import { sign } from "hono/jwt";
 
@@ -135,6 +135,18 @@ async function createJwtToken(userId: string) {
 }
 
 async function createRefreshToken(userId: string) {
+  const prepared = await prepareRefreshToken();
+  await createSession({
+    token: prepared.rawToken,
+    expiresAt: prepared.expires,
+    userId,
+    refreshTokenFamilyId: crypto.randomUUID(),
+  });
+
+  return prepared;
+}
+
+async function prepareRefreshToken() {
   const rawToken = crypto.randomUUID();
   const encToken = await encryptRefreshToken(rawToken);
   const expires = new Date(
@@ -145,11 +157,9 @@ async function createRefreshToken(userId: string) {
         24 *
         Number.parseInt(process.env.JWT_REFRESH_TOKEN_EXPIRATION_DAYS ?? "30"),
   );
-  await createSession({
-    token: rawToken,
-    expiresAt: expires,
-    userId: userId,
-  });
+  if (Number.isNaN(expires.getTime())) {
+    throw new Error("JWT_REFRESH_TOKEN_EXPIRATION_DAYS is invalid");
+  }
 
   return {
     encToken,
@@ -221,13 +231,7 @@ const app = new Hono()
     return c.redirect(url.toString());
   })
   .post("/refresh", zValidator("json", refreshTokenSchema), async (c) => {
-    const { refresh_token, token } = c.req.valid("json");
-    const userId = getUserIdFromToken(token);
-    if (!userId) {
-      return c.json(await apiErrorResponse("authenticationIsRequired"), {
-        status: 401,
-      });
-    }
+    const { refresh_token } = c.req.valid("json");
 
     const oldDecryptedRefreshToken = await decryptRefreshToken(refresh_token);
     if (!oldDecryptedRefreshToken) {
@@ -236,23 +240,33 @@ const app = new Hono()
       });
     }
 
-    const oldRefreshTokens = await deleteSessionsByToken({
+    const replacement = await prepareRefreshToken();
+    const rotation = await rotateSessionByToken({
       token: oldDecryptedRefreshToken,
+      replacementToken: replacement.rawToken,
+      replacementExpiresAt: replacement.expires,
+      // Successful decryption is the provenance signal that allows a
+      // pre-family native session to be adopted. Other DB callers omit it.
+      legacyNativeSessionAdoption: {
+        familyId: crypto.randomUUID(),
+      },
     });
-    if (!oldRefreshTokens.count) {
+    if (!rotation) {
       return c.json(await apiErrorResponse("invalidRefreshToken"), {
         status: 401,
       });
     }
 
     const { exp: accessTokenExp, token: accessToken } =
-      await createJwtToken(userId);
-
-    const { encToken } = await createRefreshToken(userId);
+      await createJwtToken(rotation.userId);
+    const encryptedRefreshToken =
+      rotation.refreshToken === replacement.rawToken
+        ? replacement.encToken
+        : await encryptRefreshToken(rotation.refreshToken);
 
     return c.json({
       token: accessToken,
-      refresh_token: encToken,
+      refresh_token: encryptedRefreshToken,
       expiration: accessTokenExp,
     });
   })

--- a/packages/api/src/v1/account.ts
+++ b/packages/api/src/v1/account.ts
@@ -241,7 +241,7 @@ const app = new Hono()
     return c.redirect(url.toString());
   })
   .post("/refresh", zValidator("json", refreshTokenSchema), async (c) => {
-    const { refresh_token } = c.req.valid("json");
+    const { refresh_token, token: _unusedAccessToken } = c.req.valid("json");
 
     const oldDecryptedRefreshToken = await decryptRefreshToken(refresh_token);
     if (!oldDecryptedRefreshToken) {

--- a/packages/api/src/v1/account.ts
+++ b/packages/api/src/v1/account.ts
@@ -160,13 +160,14 @@ async function prepareRefreshToken() {
 
 function createRefreshTokenCandidate() {
   const rawToken = crypto.randomUUID();
+  const expirationDays = Number.parseInt(
+    process.env.JWT_REFRESH_TOKEN_EXPIRATION_DAYS ?? "30",
+  );
+  if (!Number.isFinite(expirationDays) || expirationDays <= 0) {
+    throw new Error("JWT_REFRESH_TOKEN_EXPIRATION_DAYS is invalid");
+  }
   const expires = new Date(
-    Date.now() +
-      1000 *
-        60 *
-        60 *
-        24 *
-        Number.parseInt(process.env.JWT_REFRESH_TOKEN_EXPIRATION_DAYS ?? "30"),
+    Date.now() + 1000 * 60 * 60 * 24 * expirationDays,
   );
   if (Number.isNaN(expires.getTime())) {
     throw new Error("JWT_REFRESH_TOKEN_EXPIRATION_DAYS is invalid");

--- a/packages/db/src/session.ts
+++ b/packages/db/src/session.ts
@@ -1,17 +1,18 @@
 import { getDb } from "./provider";
-import { startTransaction, type PrismaTransaction } from "./transaction";
+import {
+  startRetryableTransaction,
+  type PrismaTransaction,
+} from "./transaction";
 
 export async function createSession({
   token,
   expiresAt,
   userId,
-  refreshTokenFamilyId,
   prisma,
 }: {
   token: string;
   expiresAt: Date;
   userId: string;
-  refreshTokenFamilyId: string;
   prisma?: PrismaTransaction;
 }) {
   const db = prisma ?? await getDb();
@@ -20,7 +21,6 @@ export async function createSession({
       token,
       expiresAt,
       userId,
-      refreshTokenFamilyId,
     },
   });
 }
@@ -40,36 +40,85 @@ export async function deleteSessionsByToken({
   });
 }
 
+export async function createNativeRefreshToken({
+  token,
+  expiresAt,
+  userId,
+  refreshTokenFamilyId,
+  prisma,
+}: {
+  token: string;
+  expiresAt: Date;
+  userId: string;
+  refreshTokenFamilyId: string;
+  prisma?: PrismaTransaction;
+}) {
+  const create = async (db: PrismaTransaction) => {
+    await purgeOneExpiredRefreshTokenFamily(db, new Date());
+    await db.refreshTokenFamily.create({
+      data: {
+        id: refreshTokenFamilyId,
+        userId,
+        expiresAt,
+      },
+    });
+    return await db.nativeRefreshToken.create({
+      data: {
+        token,
+        expiresAt,
+        userId,
+        refreshTokenFamilyId,
+      },
+    });
+  };
+
+  return prisma
+    ? await create(prisma)
+    : await startRetryableTransaction(create);
+}
+
 export const REFRESH_TOKEN_RESPONSE_LOSS_GRACE_MS = 10_000;
 
-type RefreshSession = {
+type NativeRefreshToken = {
   token: string;
   userId: string;
   expiresAt: Date;
-  refreshTokenFamilyId: string | null;
+  refreshTokenFamilyId: string;
   refreshTokenConsumedAt: Date | null;
   refreshTokenReplacedByToken: string | null;
-  refreshTokenRevokedAt: Date | null;
 };
 
-export type RotateSessionResult = {
+type LegacySession = {
+  token: string;
+  userId: string;
+  expiresAt: Date;
+};
+
+type RefreshTokenFamily = {
+  id: string;
+  userId: string;
+  expiresAt: Date;
+  revokedAt: Date | null;
+};
+
+export type RotateNativeRefreshTokenResult = {
   userId: string;
   refreshToken: string;
   refreshTokenExpiresAt: Date;
 };
 
 // This capability must come from a successfully decrypted native refresh
-// request. General session callers must omit it so null-family browser sessions
-// remain outside refresh-token rotation.
+// request. General session callers must omit it so browser sessions cannot be
+// migrated into the native refresh-token store.
 export type LegacyNativeSessionAdoption = {
   familyId: string;
 };
 
-async function findRefreshSession(
+async function findNativeRefreshToken(
   db: PrismaTransaction,
   token: string,
-): Promise<RefreshSession | null> {
-  return await db.session.findUnique({
+): Promise<NativeRefreshToken | null> {
+  return await db.nativeRefreshToken.findUnique({
     where: { token },
     select: {
       token: true,
@@ -78,7 +127,74 @@ async function findRefreshSession(
       refreshTokenFamilyId: true,
       refreshTokenConsumedAt: true,
       refreshTokenReplacedByToken: true,
-      refreshTokenRevokedAt: true,
+    },
+  });
+}
+
+async function findLegacySession(
+  db: PrismaTransaction,
+  token: string,
+): Promise<LegacySession | null> {
+  return await db.session.findUnique({
+    where: { token },
+    select: {
+      token: true,
+      userId: true,
+      expiresAt: true,
+    },
+  });
+}
+
+async function findRefreshTokenFamily(
+  db: PrismaTransaction,
+  familyId: string,
+): Promise<RefreshTokenFamily | null> {
+  return await db.refreshTokenFamily.findUnique({
+    where: { id: familyId },
+    select: {
+      id: true,
+      userId: true,
+      expiresAt: true,
+      revokedAt: true,
+    },
+  });
+}
+
+async function purgeOneExpiredRefreshTokenFamily(
+  db: PrismaTransaction,
+  now: Date,
+) {
+  const expiredFamily = await db.refreshTokenFamily.findFirst({
+    where: {
+      expiresAt: { lte: now },
+    },
+    orderBy: {
+      expiresAt: "asc",
+    },
+    select: {
+      id: true,
+    },
+  });
+  if (expiredFamily) {
+    await db.refreshTokenFamily.deleteMany({
+      where: {
+        id: expiredFamily.id,
+        expiresAt: { lte: now },
+      },
+    });
+  }
+}
+
+async function purgeExpiredRefreshTokenTombstones(
+  db: PrismaTransaction,
+  familyId: string,
+  now: Date,
+) {
+  await db.nativeRefreshToken.deleteMany({
+    where: {
+      refreshTokenFamilyId: familyId,
+      refreshTokenConsumedAt: { not: null },
+      expiresAt: { lte: now },
     },
   });
 }
@@ -88,43 +204,86 @@ async function revokeRefreshTokenFamily(
   familyId: string,
   now: Date,
 ) {
-  await db.session.updateMany({
+  await db.refreshTokenFamily.updateMany({
     where: {
-      refreshTokenFamilyId: familyId,
-      refreshTokenRevokedAt: null,
+      id: familyId,
+      revokedAt: null,
     },
     data: {
-      refreshTokenRevokedAt: now,
+      revokedAt: now,
     },
   });
 }
 
+async function adoptLegacyNativeSession(
+  db: PrismaTransaction,
+  token: string,
+  familyId: string,
+  familyExpiresAt: Date,
+  now: Date,
+): Promise<{
+  refreshToken: NativeRefreshToken;
+  family: RefreshTokenFamily;
+} | null> {
+  const legacySession = await findLegacySession(db, token);
+  if (!legacySession || legacySession.expiresAt <= now) {
+    return null;
+  }
+
+  const family = await db.refreshTokenFamily.create({
+    data: {
+      id: familyId,
+      userId: legacySession.userId,
+      expiresAt: familyExpiresAt,
+    },
+  });
+  const refreshToken = await db.nativeRefreshToken.create({
+    data: {
+      token: legacySession.token,
+      userId: legacySession.userId,
+      expiresAt: legacySession.expiresAt,
+      refreshTokenFamilyId: familyId,
+    },
+  });
+  const deleted = await db.session.deleteMany({
+    where: {
+      token: legacySession.token,
+      userId: legacySession.userId,
+      expiresAt: { gt: now },
+    },
+  });
+  if (deleted.count !== 1) {
+    throw new Error("Legacy native session changed during adoption");
+  }
+
+  return { refreshToken, family };
+}
+
 async function reuseReplacementOrRevokeFamily(
   db: PrismaTransaction,
-  session: RefreshSession,
+  refreshToken: NativeRefreshToken,
+  family: RefreshTokenFamily,
   now: Date,
-): Promise<RotateSessionResult | null> {
-  const familyId = session.refreshTokenFamilyId;
-  const consumedAt = session.refreshTokenConsumedAt;
-  if (!familyId || !consumedAt) {
+): Promise<RotateNativeRefreshTokenResult | null> {
+  const consumedAt = refreshToken.refreshTokenConsumedAt;
+  if (!consumedAt) {
     return null;
   }
   const graceExpiresAt =
     consumedAt.getTime() + REFRESH_TOKEN_RESPONSE_LOSS_GRACE_MS;
   if (
     now.getTime() <= graceExpiresAt &&
-    session.refreshTokenReplacedByToken
+    refreshToken.refreshTokenReplacedByToken
   ) {
-    const replacement = await findRefreshSession(
+    const replacement = await findNativeRefreshToken(
       db,
-      session.refreshTokenReplacedByToken,
+      refreshToken.refreshTokenReplacedByToken,
     );
     if (
-      replacement?.refreshTokenFamilyId === familyId &&
-      replacement.userId === session.userId &&
+      replacement?.refreshTokenFamilyId === family.id &&
+      replacement.userId === refreshToken.userId &&
       replacement.expiresAt > now &&
-      !replacement.refreshTokenConsumedAt &&
-      !replacement.refreshTokenRevokedAt
+      !replacement.refreshTokenConsumedAt
     ) {
       return {
         userId: replacement.userId,
@@ -134,11 +293,11 @@ async function reuseReplacementOrRevokeFamily(
     }
   }
 
-  await revokeRefreshTokenFamily(db, familyId, now);
+  await revokeRefreshTokenFamily(db, family.id, now);
   return null;
 }
 
-export async function rotateSessionByToken({
+export async function rotateNativeRefreshTokenByToken({
   token,
   replacementToken,
   replacementExpiresAt,
@@ -152,91 +311,132 @@ export async function rotateSessionByToken({
   legacyNativeSessionAdoption?: LegacyNativeSessionAdoption;
   now?: Date;
   prisma?: PrismaTransaction;
-}): Promise<RotateSessionResult | null> {
+}): Promise<RotateNativeRefreshTokenResult | null> {
   if (replacementExpiresAt <= now) {
-    throw new RangeError("Replacement session must expire in the future");
+    throw new RangeError("Replacement refresh token must expire in the future");
   }
   if (legacyNativeSessionAdoption?.familyId.length === 0) {
     throw new TypeError("Legacy native session family ID must not be empty");
   }
 
   const rotate = async (db: PrismaTransaction) => {
-    const session = await findRefreshSession(db, token);
-    if (!session || session.refreshTokenRevokedAt) {
-      return null;
-    }
+    let refreshToken = await findNativeRefreshToken(db, token);
+    let family = refreshToken
+      ? await findRefreshTokenFamily(db, refreshToken.refreshTokenFamilyId)
+      : null;
 
-    let familyId = session.refreshTokenFamilyId;
-    if (!familyId) {
-      if (
-        !legacyNativeSessionAdoption ||
-        session.expiresAt <= now ||
-        session.refreshTokenConsumedAt ||
-        session.refreshTokenReplacedByToken
-      ) {
+    if (!refreshToken) {
+      if (!legacyNativeSessionAdoption) {
         return null;
       }
-      familyId = legacyNativeSessionAdoption.familyId;
+      const adopted = await adoptLegacyNativeSession(
+        db,
+        token,
+        legacyNativeSessionAdoption.familyId,
+        replacementExpiresAt,
+        now,
+      );
+      if (!adopted) {
+        return null;
+      }
+      refreshToken = adopted.refreshToken;
+      family = adopted.family;
     }
 
-    if (session.refreshTokenConsumedAt) {
-      return await reuseReplacementOrRevokeFamily(db, session, now);
+    if (family && family.expiresAt <= now) {
+      await db.refreshTokenFamily.deleteMany({
+        where: {
+          id: family.id,
+          expiresAt: { lte: now },
+        },
+      });
+      return null;
     }
-    if (session.expiresAt <= now) {
+    if (
+      !family ||
+      family.userId !== refreshToken.userId ||
+      family.revokedAt
+    ) {
       return null;
     }
 
-    const consumed = await db.session.updateMany({
+    await purgeOneExpiredRefreshTokenFamily(db, now);
+    if (refreshToken.refreshTokenConsumedAt) {
+      return await reuseReplacementOrRevokeFamily(
+        db,
+        refreshToken,
+        family,
+        now,
+      );
+    }
+    if (refreshToken.expiresAt <= now) {
+      return null;
+    }
+
+    const consumed = await db.nativeRefreshToken.updateMany({
       where: {
-        token: session.token,
-        refreshTokenFamilyId: session.refreshTokenFamilyId,
+        token: refreshToken.token,
+        refreshTokenFamilyId: refreshToken.refreshTokenFamilyId,
         refreshTokenConsumedAt: null,
-        refreshTokenRevokedAt: null,
         expiresAt: { gt: now },
       },
       data: {
-        refreshTokenFamilyId: familyId,
         refreshTokenConsumedAt: now,
         refreshTokenReplacedByToken: replacementToken,
       },
     });
     if (consumed.count !== 1) {
-      const current = await findRefreshSession(db, token);
+      const current = await findNativeRefreshToken(db, token);
       if (
-        current?.refreshTokenFamilyId &&
-        (session.refreshTokenFamilyId === null ||
-          current.refreshTokenFamilyId === familyId) &&
-        current.refreshTokenConsumedAt &&
-        !current.refreshTokenRevokedAt
+        current?.refreshTokenFamilyId === family.id &&
+        current.refreshTokenConsumedAt
       ) {
-        return await reuseReplacementOrRevokeFamily(db, current, now);
+        const currentFamily = await findRefreshTokenFamily(
+          db,
+          current.refreshTokenFamilyId,
+        );
+        if (
+          currentFamily &&
+          currentFamily.userId === current.userId &&
+          !currentFamily.revokedAt &&
+          currentFamily.expiresAt > now
+        ) {
+          return await reuseReplacementOrRevokeFamily(
+            db,
+            current,
+            currentFamily,
+            now,
+          );
+        }
       }
       return null;
     }
 
-    await db.session.updateMany({
+    await db.refreshTokenFamily.updateMany({
       where: {
-        refreshTokenFamilyId: familyId,
+        id: family.id,
+        revokedAt: null,
         expiresAt: { lt: replacementExpiresAt },
       },
       data: {
         expiresAt: replacementExpiresAt,
       },
     });
-    await db.session.create({
+    await db.nativeRefreshToken.create({
       data: {
         token: replacementToken,
         expiresAt: replacementExpiresAt,
-        userId: session.userId,
-        refreshTokenFamilyId: familyId,
+        userId: refreshToken.userId,
+        refreshTokenFamilyId: family.id,
       },
     });
+    await purgeExpiredRefreshTokenTombstones(db, family.id, now);
     return {
-      userId: session.userId,
+      userId: refreshToken.userId,
       refreshToken: replacementToken,
       refreshTokenExpiresAt: replacementExpiresAt,
     };
   };
 
-  return prisma ? await rotate(prisma) : await startTransaction(rotate);
+  return prisma ? await rotate(prisma) : await startRetryableTransaction(rotate);
 }

--- a/packages/db/src/session.ts
+++ b/packages/db/src/session.ts
@@ -3,6 +3,11 @@ import {
   startRetryableTransaction,
   type PrismaTransaction,
 } from "./transaction";
+import { Prisma } from "@prisma/client";
+
+export const REFRESH_TOKEN_RESPONSE_LOSS_GRACE_MS = 10_000;
+export const REFRESH_TOKEN_FAMILY_MAX_LIFETIME_MS =
+  90 * 24 * 60 * 60 * 1000;
 
 export async function createSession({
   token,
@@ -54,18 +59,25 @@ export async function createNativeRefreshToken({
   prisma?: PrismaTransaction;
 }) {
   const create = async (db: PrismaTransaction) => {
-    await purgeOneExpiredRefreshTokenFamily(db, new Date());
+    const now = new Date();
+    const effectiveExpiresAt = new Date(
+      Math.min(
+        expiresAt.getTime(),
+        now.getTime() + REFRESH_TOKEN_FAMILY_MAX_LIFETIME_MS,
+      ),
+    );
+    await purgeOneExpiredRefreshTokenFamily(db, now);
     await db.refreshTokenFamily.create({
       data: {
         id: refreshTokenFamilyId,
         userId,
-        expiresAt,
+        expiresAt: effectiveExpiresAt,
       },
     });
     return await db.nativeRefreshToken.create({
       data: {
         token,
-        expiresAt,
+        expiresAt: effectiveExpiresAt,
         userId,
         refreshTokenFamilyId,
       },
@@ -76,8 +88,6 @@ export async function createNativeRefreshToken({
     ? await create(prisma)
     : await startRetryableTransaction(create);
 }
-
-export const REFRESH_TOKEN_RESPONSE_LOSS_GRACE_MS = 10_000;
 
 type NativeRefreshToken = {
   token: string;
@@ -99,6 +109,7 @@ type RefreshTokenFamily = {
   userId: string;
   expiresAt: Date;
   revokedAt: Date | null;
+  createdAt: Date;
 };
 
 export type RotateNativeRefreshTokenResult = {
@@ -156,6 +167,7 @@ async function findRefreshTokenFamily(
       userId: true,
       expiresAt: true,
       revokedAt: true,
+      createdAt: true,
     },
   });
 }
@@ -343,17 +355,21 @@ export async function rotateNativeRefreshTokenByToken({
       family = adopted.family;
     }
 
-    if (family && family.expiresAt <= now) {
+    if (!family) {
+      return null;
+    }
+    const familyMaxExpiresAt = new Date(
+      family.createdAt.getTime() + REFRESH_TOKEN_FAMILY_MAX_LIFETIME_MS,
+    );
+    if (family.expiresAt <= now || familyMaxExpiresAt <= now) {
       await db.refreshTokenFamily.deleteMany({
         where: {
           id: family.id,
-          expiresAt: { lte: now },
         },
       });
       return null;
     }
     if (
-      !family ||
       family.userId !== refreshToken.userId ||
       family.revokedAt
     ) {
@@ -372,6 +388,11 @@ export async function rotateNativeRefreshTokenByToken({
     if (refreshToken.expiresAt <= now) {
       return null;
     }
+
+    const effectiveReplacementExpiresAt =
+      replacementExpiresAt < familyMaxExpiresAt
+        ? replacementExpiresAt
+        : familyMaxExpiresAt;
 
     const consumed = await db.nativeRefreshToken.updateMany({
       where: {
@@ -416,16 +437,15 @@ export async function rotateNativeRefreshTokenByToken({
       where: {
         id: family.id,
         revokedAt: null,
-        expiresAt: { lt: replacementExpiresAt },
       },
       data: {
-        expiresAt: replacementExpiresAt,
+        expiresAt: effectiveReplacementExpiresAt,
       },
     });
     await db.nativeRefreshToken.create({
       data: {
         token: replacementToken,
-        expiresAt: replacementExpiresAt,
+        expiresAt: effectiveReplacementExpiresAt,
         userId: refreshToken.userId,
         refreshTokenFamilyId: family.id,
       },
@@ -434,9 +454,13 @@ export async function rotateNativeRefreshTokenByToken({
     return {
       userId: refreshToken.userId,
       refreshToken: replacementToken,
-      refreshTokenExpiresAt: replacementExpiresAt,
+      refreshTokenExpiresAt: effectiveReplacementExpiresAt,
     };
   };
 
-  return prisma ? await rotate(prisma) : await startRetryableTransaction(rotate);
+  return prisma
+    ? await rotate(prisma)
+    : await startRetryableTransaction(rotate, {
+        isolationLevel: Prisma.TransactionIsolationLevel.Serializable,
+      });
 }

--- a/packages/db/src/session.ts
+++ b/packages/db/src/session.ts
@@ -1,15 +1,17 @@
 import { getDb } from "./provider";
-import type { PrismaTransaction } from "./transaction";
+import { startTransaction, type PrismaTransaction } from "./transaction";
 
 export async function createSession({
   token,
   expiresAt,
   userId,
+  refreshTokenFamilyId,
   prisma,
 }: {
   token: string;
   expiresAt: Date;
   userId: string;
+  refreshTokenFamilyId: string;
   prisma?: PrismaTransaction;
 }) {
   const db = prisma ?? await getDb();
@@ -18,6 +20,7 @@ export async function createSession({
       token,
       expiresAt,
       userId,
+      refreshTokenFamilyId,
     },
   });
 }
@@ -35,4 +38,205 @@ export async function deleteSessionsByToken({
       token,
     },
   });
+}
+
+export const REFRESH_TOKEN_RESPONSE_LOSS_GRACE_MS = 10_000;
+
+type RefreshSession = {
+  token: string;
+  userId: string;
+  expiresAt: Date;
+  refreshTokenFamilyId: string | null;
+  refreshTokenConsumedAt: Date | null;
+  refreshTokenReplacedByToken: string | null;
+  refreshTokenRevokedAt: Date | null;
+};
+
+export type RotateSessionResult = {
+  userId: string;
+  refreshToken: string;
+  refreshTokenExpiresAt: Date;
+};
+
+// This capability must come from a successfully decrypted native refresh
+// request. General session callers must omit it so null-family browser sessions
+// remain outside refresh-token rotation.
+export type LegacyNativeSessionAdoption = {
+  familyId: string;
+};
+
+async function findRefreshSession(
+  db: PrismaTransaction,
+  token: string,
+): Promise<RefreshSession | null> {
+  return await db.session.findUnique({
+    where: { token },
+    select: {
+      token: true,
+      userId: true,
+      expiresAt: true,
+      refreshTokenFamilyId: true,
+      refreshTokenConsumedAt: true,
+      refreshTokenReplacedByToken: true,
+      refreshTokenRevokedAt: true,
+    },
+  });
+}
+
+async function revokeRefreshTokenFamily(
+  db: PrismaTransaction,
+  familyId: string,
+  now: Date,
+) {
+  await db.session.updateMany({
+    where: {
+      refreshTokenFamilyId: familyId,
+      refreshTokenRevokedAt: null,
+    },
+    data: {
+      refreshTokenRevokedAt: now,
+    },
+  });
+}
+
+async function reuseReplacementOrRevokeFamily(
+  db: PrismaTransaction,
+  session: RefreshSession,
+  now: Date,
+): Promise<RotateSessionResult | null> {
+  const familyId = session.refreshTokenFamilyId;
+  const consumedAt = session.refreshTokenConsumedAt;
+  if (!familyId || !consumedAt) {
+    return null;
+  }
+  const graceExpiresAt =
+    consumedAt.getTime() + REFRESH_TOKEN_RESPONSE_LOSS_GRACE_MS;
+  if (
+    now.getTime() <= graceExpiresAt &&
+    session.refreshTokenReplacedByToken
+  ) {
+    const replacement = await findRefreshSession(
+      db,
+      session.refreshTokenReplacedByToken,
+    );
+    if (
+      replacement?.refreshTokenFamilyId === familyId &&
+      replacement.userId === session.userId &&
+      replacement.expiresAt > now &&
+      !replacement.refreshTokenConsumedAt &&
+      !replacement.refreshTokenRevokedAt
+    ) {
+      return {
+        userId: replacement.userId,
+        refreshToken: replacement.token,
+        refreshTokenExpiresAt: replacement.expiresAt,
+      };
+    }
+  }
+
+  await revokeRefreshTokenFamily(db, familyId, now);
+  return null;
+}
+
+export async function rotateSessionByToken({
+  token,
+  replacementToken,
+  replacementExpiresAt,
+  legacyNativeSessionAdoption,
+  now = new Date(),
+  prisma,
+}: {
+  token: string;
+  replacementToken: string;
+  replacementExpiresAt: Date;
+  legacyNativeSessionAdoption?: LegacyNativeSessionAdoption;
+  now?: Date;
+  prisma?: PrismaTransaction;
+}): Promise<RotateSessionResult | null> {
+  if (replacementExpiresAt <= now) {
+    throw new RangeError("Replacement session must expire in the future");
+  }
+  if (legacyNativeSessionAdoption?.familyId.length === 0) {
+    throw new TypeError("Legacy native session family ID must not be empty");
+  }
+
+  const rotate = async (db: PrismaTransaction) => {
+    const session = await findRefreshSession(db, token);
+    if (!session || session.refreshTokenRevokedAt) {
+      return null;
+    }
+
+    let familyId = session.refreshTokenFamilyId;
+    if (!familyId) {
+      if (
+        !legacyNativeSessionAdoption ||
+        session.expiresAt <= now ||
+        session.refreshTokenConsumedAt ||
+        session.refreshTokenReplacedByToken
+      ) {
+        return null;
+      }
+      familyId = legacyNativeSessionAdoption.familyId;
+    }
+
+    if (session.refreshTokenConsumedAt) {
+      return await reuseReplacementOrRevokeFamily(db, session, now);
+    }
+    if (session.expiresAt <= now) {
+      return null;
+    }
+
+    const consumed = await db.session.updateMany({
+      where: {
+        token: session.token,
+        refreshTokenFamilyId: session.refreshTokenFamilyId,
+        refreshTokenConsumedAt: null,
+        refreshTokenRevokedAt: null,
+        expiresAt: { gt: now },
+      },
+      data: {
+        refreshTokenFamilyId: familyId,
+        refreshTokenConsumedAt: now,
+        refreshTokenReplacedByToken: replacementToken,
+      },
+    });
+    if (consumed.count !== 1) {
+      const current = await findRefreshSession(db, token);
+      if (
+        current?.refreshTokenFamilyId &&
+        (session.refreshTokenFamilyId === null ||
+          current.refreshTokenFamilyId === familyId) &&
+        current.refreshTokenConsumedAt &&
+        !current.refreshTokenRevokedAt
+      ) {
+        return await reuseReplacementOrRevokeFamily(db, current, now);
+      }
+      return null;
+    }
+
+    await db.session.updateMany({
+      where: {
+        refreshTokenFamilyId: familyId,
+        expiresAt: { lt: replacementExpiresAt },
+      },
+      data: {
+        expiresAt: replacementExpiresAt,
+      },
+    });
+    await db.session.create({
+      data: {
+        token: replacementToken,
+        expiresAt: replacementExpiresAt,
+        userId: session.userId,
+        refreshTokenFamilyId: familyId,
+      },
+    });
+    return {
+      userId: session.userId,
+      refreshToken: replacementToken,
+      refreshTokenExpiresAt: replacementExpiresAt,
+    };
+  };
+
+  return prisma ? await rotate(prisma) : await startTransaction(rotate);
 }

--- a/packages/db/src/transaction.ts
+++ b/packages/db/src/transaction.ts
@@ -1,9 +1,15 @@
 import { getDb } from "./provider";
-import type { PrismaClient } from "@prisma/client";
+import type { Prisma, PrismaClient } from "@prisma/client";
 
 export type PrismaTransaction = Parameters<
   Parameters<typeof PrismaClient.prototype.$transaction>[0]
 >[0];
+
+export type PrismaTransactionOptions = {
+  maxWait?: number;
+  timeout?: number;
+  isolationLevel?: Prisma.TransactionIsolationLevel;
+};
 
 const MAX_TRANSACTION_ATTEMPTS = 5;
 
@@ -45,11 +51,12 @@ export const startTransaction = async <T>(
 // become safe to repeat when the failed transaction is rolled back.
 export const startRetryableTransaction = async <T>(
   callback: (tx: PrismaTransaction) => Promise<T>,
+  options?: PrismaTransactionOptions,
 ) => {
   const db = await getDb();
   for (let attempt = 1; ; attempt++) {
     try {
-      return await db.$transaction(callback);
+      return await db.$transaction(callback, options);
     } catch (error) {
       if (
         attempt >= MAX_TRANSACTION_ATTEMPTS ||

--- a/packages/db/src/transaction.ts
+++ b/packages/db/src/transaction.ts
@@ -5,7 +5,50 @@ export type PrismaTransaction = Parameters<
   Parameters<typeof PrismaClient.prototype.$transaction>[0]
 >[0];
 
-export const startTransaction = async <T>(callback: (tx: PrismaTransaction) => Promise<T>) => {
+const MAX_TRANSACTION_ATTEMPTS = 5;
+
+function isRetryableWriteConflict(error: unknown): boolean {
+  if (typeof error !== "object" || error === null) {
+    return false;
+  }
+  if ("code" in error && error.code === "P2034") {
+    return true;
+  }
+  if (
+    "cause" in error &&
+    typeof error.cause === "object" &&
+    error.cause !== null &&
+    "kind" in error.cause &&
+    error.cause.kind === "TransactionWriteConflict"
+  ) {
+    return true;
+  }
+  if (
+    "meta" in error &&
+    typeof error.meta === "object" &&
+    error.meta !== null &&
+    "driverAdapterError" in error.meta
+  ) {
+    return isRetryableWriteConflict(error.meta.driverAdapterError);
+  }
+  return false;
+}
+
+export const startTransaction = async <T>(
+  callback: (tx: PrismaTransaction) => Promise<T>,
+) => {
   const db = await getDb();
-  return db.$transaction(callback);
+  for (let attempt = 1; ; attempt++) {
+    try {
+      return await db.$transaction(callback);
+    } catch (error) {
+      if (
+        attempt >= MAX_TRANSACTION_ATTEMPTS ||
+        !isRetryableWriteConflict(error)
+      ) {
+        throw error;
+      }
+      await new Promise((resolve) => setTimeout(resolve, attempt * 10));
+    }
+  }
 };

--- a/packages/db/src/transaction.ts
+++ b/packages/db/src/transaction.ts
@@ -38,6 +38,15 @@ export const startTransaction = async <T>(
   callback: (tx: PrismaTransaction) => Promise<T>,
 ) => {
   const db = await getDb();
+  return await db.$transaction(callback);
+};
+
+// The callback may be replayed and must contain only database operations that
+// become safe to repeat when the failed transaction is rolled back.
+export const startRetryableTransaction = async <T>(
+  callback: (tx: PrismaTransaction) => Promise<T>,
+) => {
+  const db = await getDb();
   for (let attempt = 1; ; attempt++) {
     try {
       return await db.$transaction(callback);

--- a/tests/contract/email-update.test.ts
+++ b/tests/contract/email-update.test.ts
@@ -1,0 +1,90 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  addAuditLog: vi.fn(),
+  consumeConfirmationToken: vi.fn(),
+  getLanguage: vi.fn(),
+  revalidatePath: vi.fn(),
+  startTransaction: vi.fn(),
+  transaction: { kind: "transaction" },
+  updateCustomerEmailIfExist: vi.fn(),
+  updateUserEmail: vi.fn(),
+}));
+
+vi.mock("next/headers", () => ({ headers: vi.fn() }));
+vi.mock("next/cache", () => ({ revalidatePath: mocks.revalidatePath }));
+vi.mock("@/resend", () => ({ sendEmail: vi.fn() }));
+vi.mock("@/lib/auth-guard", () => ({ authenticated: vi.fn() }));
+vi.mock("@beutl/i18n", () => ({ getTranslation: vi.fn() }));
+vi.mock("@/lib/lang-utils", () => ({ getLanguage: mocks.getLanguage }));
+vi.mock("@beutl/db", () => ({
+  existsUserByEmail: vi.fn(),
+  existsUserById: vi.fn(),
+  startTransaction: mocks.startTransaction,
+  updateUserEmail: mocks.updateUserEmail,
+}));
+vi.mock("@/lib/customer", () => ({
+  updateCustomerEmailIfExist: mocks.updateCustomerEmailIfExist,
+}));
+vi.mock("@/lib/audit-log", () => ({
+  addAuditLog: mocks.addAuditLog,
+  auditLogActions: {
+    account: {
+      emailChanged: "emailChanged",
+      sentEmailChangeConfirmation: "sentEmailChangeConfirmation",
+    },
+  },
+}));
+vi.mock("@/lib/confirmation-token-flow", () => ({
+  consumeConfirmationToken: mocks.consumeConfirmationToken,
+  issueConfirmationToken: vi.fn(),
+}));
+
+import { updateEmail } from "../../apps/web/src/app/[lang]/(manage-account)/account/manage/email/actions";
+
+describe("email update", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getLanguage.mockResolvedValue("en");
+    mocks.consumeConfirmationToken.mockResolvedValue({
+      valid: true,
+      tokenData: {
+        userId: "user-id",
+        identifier: "new@example.com",
+      },
+    });
+    mocks.startTransaction.mockImplementation(async (callback) =>
+      callback(mocks.transaction),
+    );
+    mocks.updateUserEmail.mockResolvedValue(undefined);
+  });
+
+  it("reports failure and skips success effects when Stripe rejects", async () => {
+    mocks.updateCustomerEmailIfExist.mockRejectedValue(
+      new Error("Stripe unavailable"),
+    );
+    const log = vi.spyOn(console, "error").mockImplementation(() => {});
+    let redirectError: unknown;
+
+    try {
+      await updateEmail("token", "new@example.com");
+    } catch (error) {
+      redirectError = error;
+    } finally {
+      log.mockRestore();
+    }
+
+    expect(redirectError).toMatchObject({
+      message: "NEXT_REDIRECT",
+      digest: expect.stringContaining("status=emailUpdateFailed"),
+    });
+    expect(mocks.startTransaction).toHaveBeenCalledTimes(1);
+    expect(mocks.updateCustomerEmailIfExist).toHaveBeenCalledWith({
+      userId: "user-id",
+      email: "new@example.com",
+      prisma: mocks.transaction,
+    });
+    expect(mocks.addAuditLog).not.toHaveBeenCalled();
+    expect(mocks.revalidatePath).not.toHaveBeenCalled();
+  });
+});

--- a/tests/contract/refresh-token-auth.test.ts
+++ b/tests/contract/refresh-token-auth.test.ts
@@ -86,25 +86,32 @@ describe("v1 refresh-token rotation", () => {
     delete process.env.JWT_REFRESH_TOKEN_EXPIRATION_DAYS;
   });
 
-  it("assigns a family only to the initial native refresh session", async () => {
+  it("stores the initial native refresh token outside Better Auth sessions", async () => {
     await issueCredentials("session-owner");
 
     expect(store.all()).toHaveLength(1);
+    expect(store.allSessions()).toHaveLength(0);
     expect(store.all()[0]).toMatchObject({
       userId: "session-owner",
       refreshTokenFamilyId: expect.any(String),
       refreshTokenConsumedAt: null,
       refreshTokenReplacedByToken: null,
-      refreshTokenRevokedAt: null,
+    });
+    expect(store.allFamilies()).toHaveLength(1);
+    expect(store.allFamilies()[0]).toMatchObject({
+      userId: "session-owner",
+      revokedAt: null,
     });
   });
 
   it("adopts a pre-deployment native session on its first refresh", async () => {
     const credentials = await issueCredentials("legacy-session-owner");
     const legacySession = store.all()[0];
-    store.update(legacySession.token, {
-      refreshTokenFamilyId: null,
-    });
+    const oldFamilyId = legacySession.refreshTokenFamilyId!;
+    store.moveNativeTokenToLegacySession(legacySession.token);
+    store.deleteFamily(oldFamilyId);
+    expect(store.all()).toHaveLength(0);
+    expect(store.allSessions()).toHaveLength(1);
 
     const response = await post("/refresh", {
       refresh_token: credentials.refresh_token,
@@ -113,12 +120,12 @@ describe("v1 refresh-token rotation", () => {
 
     expect(response.status).toBe(200);
     expect(store.all()).toHaveLength(2);
+    expect(store.allSessions()).toHaveLength(0);
     const adoptedParent = store.get(legacySession.token);
     expect(adoptedParent).toMatchObject({
       userId: "legacy-session-owner",
       refreshTokenFamilyId: expect.any(String),
       refreshTokenConsumedAt: NOW,
-      refreshTokenRevokedAt: null,
     });
     expect(
       store.get(adoptedParent!.refreshTokenReplacedByToken!),
@@ -126,7 +133,6 @@ describe("v1 refresh-token rotation", () => {
       userId: "legacy-session-owner",
       refreshTokenFamilyId: adoptedParent!.refreshTokenFamilyId,
       refreshTokenConsumedAt: null,
-      refreshTokenRevokedAt: null,
     });
   });
 
@@ -155,22 +161,28 @@ describe("v1 refresh-token rotation", () => {
     store.update(session.token, {
       expiresAt: new Date(Date.now() - 1),
     });
+    const encrypt = vi.spyOn(crypto.subtle, "encrypt");
 
-    const response = await post("/refresh", {
-      refresh_token: credentials.refresh_token,
-      token: credentials.token,
-    });
+    try {
+      const response = await post("/refresh", {
+        refresh_token: credentials.refresh_token,
+        token: credentials.token,
+      });
 
-    expect(response.status).toBe(401);
-    expect(store.all()).toHaveLength(1);
+      expect(response.status).toBe(401);
+      expect(store.all()).toHaveLength(1);
+      expect(encrypt).not.toHaveBeenCalled();
+    } finally {
+      encrypt.mockRestore();
+    }
   });
 
   it("returns one child to concurrent legacy refresh callers", async () => {
     const credentials = await issueCredentials("session-owner");
     const legacySession = store.all()[0];
-    store.update(legacySession.token, {
-      refreshTokenFamilyId: null,
-    });
+    const oldFamilyId = legacySession.refreshTokenFamilyId!;
+    store.moveNativeTokenToLegacySession(legacySession.token);
+    store.deleteFamily(oldFamilyId);
     const body = {
       refresh_token: credentials.refresh_token,
       token: credentials.token,
@@ -182,6 +194,7 @@ describe("v1 refresh-token rotation", () => {
     ]);
     expect(responses.map((response) => response.status)).toEqual([200, 200]);
     expect(store.all()).toHaveLength(2);
+    expect(store.allSessions()).toHaveLength(0);
     expect(
       store.all().filter((session) => !session.refreshTokenConsumedAt),
     ).toHaveLength(1);
@@ -196,7 +209,7 @@ describe("v1 refresh-token rotation", () => {
       },
     ]);
     setDbProvider(async () => store.prisma as never);
-    const before = store.get("better-auth-browser-token");
+    const before = store.getSession("better-auth-browser-token");
     const log = vi.spyOn(console, "error").mockImplementation(() => {});
 
     try {
@@ -206,8 +219,9 @@ describe("v1 refresh-token rotation", () => {
       });
 
       expect(response.status).toBe(401);
-      expect(store.get("better-auth-browser-token")).toEqual(before);
-      expect(store.all()).toHaveLength(1);
+      expect(store.getSession("better-auth-browser-token")).toEqual(before);
+      expect(store.allSessions()).toHaveLength(1);
+      expect(store.all()).toHaveLength(0);
     } finally {
       log.mockRestore();
     }
@@ -234,6 +248,82 @@ describe("v1 refresh-token rotation", () => {
     ).toHaveLength(1);
   });
 
+  it("extends only the family record when rotating repeatedly", async () => {
+    const credentials = await issueCredentials("session-owner");
+    const original = store.all()[0];
+
+    const firstResponse = await post("/refresh", {
+      refresh_token: credentials.refresh_token,
+      token: credentials.token,
+    });
+    expect(firstResponse.status).toBe(200);
+    const firstCredentials = (await firstResponse.json()) as Credentials;
+    const firstChild = store
+      .all()
+      .find((session) => !session.refreshTokenConsumedAt)!;
+    const firstChildExpiresAt = firstChild.expiresAt;
+
+    vi.setSystemTime(new Date(NOW.getTime() + 24 * 60 * 60 * 1000));
+    const secondResponse = await post("/refresh", {
+      refresh_token: firstCredentials.refresh_token,
+      token: firstCredentials.token,
+    });
+
+    expect(secondResponse.status).toBe(200);
+    expect(store.allSessions()).toHaveLength(0);
+    expect(store.get(original.token)?.expiresAt).toEqual(original.expiresAt);
+    expect(store.get(firstChild.token)?.expiresAt).toEqual(firstChildExpiresAt);
+    expect(
+      store.getFamily(original.refreshTokenFamilyId!)?.expiresAt,
+    ).toEqual(new Date(NOW.getTime() + 31 * 24 * 60 * 60 * 1000));
+  });
+
+  it("retains tombstones until token expiry and then purges them", async () => {
+    const initialCredentials = await issueCredentials("session-owner");
+    const original = store.all()[0];
+
+    const firstResponse = await post("/refresh", {
+      refresh_token: initialCredentials.refresh_token,
+      token: initialCredentials.token,
+    });
+    const firstCredentials = (await firstResponse.json()) as Credentials;
+
+    vi.setSystemTime(new Date(NOW.getTime() + 29 * 24 * 60 * 60 * 1000));
+    const secondResponse = await post("/refresh", {
+      refresh_token: firstCredentials.refresh_token,
+      token: firstCredentials.token,
+    });
+    expect(secondResponse.status).toBe(200);
+    const secondCredentials = (await secondResponse.json()) as Credentials;
+    expect(store.get(original.token)).not.toBeNull();
+
+    vi.setSystemTime(new Date(NOW.getTime() + 31 * 24 * 60 * 60 * 1000));
+    const thirdResponse = await post("/refresh", {
+      refresh_token: secondCredentials.refresh_token,
+      token: secondCredentials.token,
+    });
+
+    expect(thirdResponse.status).toBe(200);
+    expect(store.get(original.token)).toBeNull();
+    expect(store.all()).toHaveLength(2);
+  });
+
+  it("purges one expired family when issuing new credentials", async () => {
+    await issueCredentials("expired-family-owner");
+    const expiredFamily = store.allFamilies()[0];
+    store.updateFamily(expiredFamily.id, {
+      expiresAt: new Date(NOW.getTime() - 1),
+    });
+
+    await issueCredentials("new-family-owner");
+
+    expect(store.getFamily(expiredFamily.id)).toBeNull();
+    expect(store.allFamilies()).toHaveLength(1);
+    expect(store.allFamilies()[0].userId).toBe("new-family-owner");
+    expect(store.all()).toHaveLength(1);
+    expect(store.all()[0].userId).toBe("new-family-owner");
+  });
+
   it("revokes the family when the parent is replayed after grace", async () => {
     const credentials = await issueCredentials("session-owner");
     const body = {
@@ -249,8 +339,10 @@ describe("v1 refresh-token rotation", () => {
 
     expect((await post("/refresh", body)).status).toBe(401);
     expect(
-      store.all().every((session) => session.refreshTokenRevokedAt !== null),
-    ).toBe(true);
+      store.getFamily(store.all()[0].refreshTokenFamilyId!)?.revokedAt,
+    ).toEqual(
+      new Date(NOW.getTime() + REFRESH_TOKEN_RESPONSE_LOSS_GRACE_MS + 1),
+    );
     expect(
       (
         await post("/refresh", {

--- a/tests/contract/refresh-token-auth.test.ts
+++ b/tests/contract/refresh-token-auth.test.ts
@@ -1,0 +1,263 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { decode, sign } from "hono/jwt";
+import { createSessionPrisma } from "../stubs/session-prisma";
+
+const NAME_IDENTIFIER_CLAIM =
+  "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier";
+const NOW = new Date("2026-08-09T00:00:00.000Z");
+
+const mocks = vi.hoisted(() => ({
+  findNativeAppAuthBySessionId: vi.fn(),
+}));
+
+vi.mock("@beutl/i18n", () => ({
+  getTranslation: async () => ({ t: (key: string) => key }),
+}));
+
+vi.mock("@beutl/db", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@beutl/db")>();
+  return {
+    ...actual,
+    createNativeAppAuth: vi.fn(),
+    deleteNativeAppAuthBySessionId: vi.fn(),
+    findNativeAppAuthById: vi.fn(),
+    findNativeAppAuthBySessionId: mocks.findNativeAppAuthBySessionId,
+    updateNativeAppAuthForHandler: vi.fn(),
+  };
+});
+
+import {
+  REFRESH_TOKEN_RESPONSE_LOSS_GRACE_MS,
+  setDbProvider,
+} from "@beutl/db";
+import account from "../../packages/api/src/v1/account";
+
+async function post(path: string, body: Record<string, unknown>) {
+  return await account.request(`https://beutl.example${path}`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+type Credentials = {
+  token: string;
+  refresh_token: string;
+};
+
+describe("v1 refresh-token rotation", () => {
+  let store: ReturnType<typeof createSessionPrisma>;
+
+  async function issueCredentials(userId: string): Promise<Credentials> {
+    mocks.findNativeAppAuthBySessionId.mockResolvedValueOnce({
+      code: "authorization-code",
+      codeExpires: new Date(Date.now() + 60_000),
+      continueUrl: "https://app.example/continue",
+      sessionId: "native-session",
+      userId,
+    });
+    const response = await post("/code2jwt", {
+      code: "authorization-code",
+      session_id: "native-session",
+    });
+    expect(response.status).toBe(200);
+    return (await response.json()) as Credentials;
+  }
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    vi.clearAllMocks();
+    store = createSessionPrisma();
+    setDbProvider(async () => store.prisma as never);
+    process.env.JWT_SECRET = "refresh-test-secret";
+    process.env.JWT_ISSUER = "https://beutl.example";
+    process.env.JWT_AUDIENCE = "beutl";
+    process.env.JWT_EXPIRATION_MINUTES = "5";
+    process.env.JWT_REFRESH_TOKEN_EXPIRATION_DAYS = "30";
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    delete process.env.JWT_SECRET;
+    delete process.env.JWT_ISSUER;
+    delete process.env.JWT_AUDIENCE;
+    delete process.env.JWT_EXPIRATION_MINUTES;
+    delete process.env.JWT_REFRESH_TOKEN_EXPIRATION_DAYS;
+  });
+
+  it("assigns a family only to the initial native refresh session", async () => {
+    await issueCredentials("session-owner");
+
+    expect(store.all()).toHaveLength(1);
+    expect(store.all()[0]).toMatchObject({
+      userId: "session-owner",
+      refreshTokenFamilyId: expect.any(String),
+      refreshTokenConsumedAt: null,
+      refreshTokenReplacedByToken: null,
+      refreshTokenRevokedAt: null,
+    });
+  });
+
+  it("adopts a pre-deployment native session on its first refresh", async () => {
+    const credentials = await issueCredentials("legacy-session-owner");
+    const legacySession = store.all()[0];
+    store.update(legacySession.token, {
+      refreshTokenFamilyId: null,
+    });
+
+    const response = await post("/refresh", {
+      refresh_token: credentials.refresh_token,
+      token: credentials.token,
+    });
+
+    expect(response.status).toBe(200);
+    expect(store.all()).toHaveLength(2);
+    const adoptedParent = store.get(legacySession.token);
+    expect(adoptedParent).toMatchObject({
+      userId: "legacy-session-owner",
+      refreshTokenFamilyId: expect.any(String),
+      refreshTokenConsumedAt: NOW,
+      refreshTokenRevokedAt: null,
+    });
+    expect(
+      store.get(adoptedParent!.refreshTokenReplacedByToken!),
+    ).toMatchObject({
+      userId: "legacy-session-owner",
+      refreshTokenFamilyId: adoptedParent!.refreshTokenFamilyId,
+      refreshTokenConsumedAt: null,
+      refreshTokenRevokedAt: null,
+    });
+  });
+
+  it("ignores a forged victim claim and mints for the session owner", async () => {
+    const credentials = await issueCredentials("session-owner");
+    const forgedVictimToken = await sign(
+      { [NAME_IDENTIFIER_CLAIM]: "victim" },
+      process.env.JWT_SECRET as string,
+    );
+
+    const response = await post("/refresh", {
+      refresh_token: credentials.refresh_token,
+      token: forgedVictimToken,
+    });
+
+    expect(response.status).toBe(200);
+    const refreshed = (await response.json()) as { token: string };
+    expect(decode(refreshed.token).payload[NAME_IDENTIFIER_CLAIM]).toBe(
+      "session-owner",
+    );
+  });
+
+  it("rejects an expired refresh session", async () => {
+    const credentials = await issueCredentials("session-owner");
+    const session = store.all()[0];
+    store.update(session.token, {
+      expiresAt: new Date(Date.now() - 1),
+    });
+
+    const response = await post("/refresh", {
+      refresh_token: credentials.refresh_token,
+      token: credentials.token,
+    });
+
+    expect(response.status).toBe(401);
+    expect(store.all()).toHaveLength(1);
+  });
+
+  it("returns one child to concurrent legacy refresh callers", async () => {
+    const credentials = await issueCredentials("session-owner");
+    const legacySession = store.all()[0];
+    store.update(legacySession.token, {
+      refreshTokenFamilyId: null,
+    });
+    const body = {
+      refresh_token: credentials.refresh_token,
+      token: credentials.token,
+    };
+
+    const responses = await Promise.all([
+      post("/refresh", body),
+      post("/refresh", body),
+    ]);
+    expect(responses.map((response) => response.status)).toEqual([200, 200]);
+    expect(store.all()).toHaveLength(2);
+    expect(
+      store.all().filter((session) => !session.refreshTokenConsumedAt),
+    ).toHaveLength(1);
+  });
+
+  it("does not adopt a plaintext Better Auth browser session", async () => {
+    store = createSessionPrisma([
+      {
+        token: "better-auth-browser-token",
+        userId: "browser-user",
+        expiresAt: new Date(Date.now() + 60_000),
+      },
+    ]);
+    setDbProvider(async () => store.prisma as never);
+    const before = store.get("better-auth-browser-token");
+    const log = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    try {
+      const response = await post("/refresh", {
+        refresh_token: "better-auth-browser-token",
+        token: "unused-browser-access-token",
+      });
+
+      expect(response.status).toBe(401);
+      expect(store.get("better-auth-browser-token")).toEqual(before);
+      expect(store.all()).toHaveLength(1);
+    } finally {
+      log.mockRestore();
+    }
+  });
+
+  it("reuses the child for a bounded response-loss retry", async () => {
+    const credentials = await issueCredentials("session-owner");
+    const body = {
+      refresh_token: credentials.refresh_token,
+      token: credentials.token,
+    };
+
+    const first = await post("/refresh", body);
+    vi.setSystemTime(
+      new Date(NOW.getTime() + REFRESH_TOKEN_RESPONSE_LOSS_GRACE_MS),
+    );
+    const retry = await post("/refresh", body);
+
+    expect(first.status).toBe(200);
+    expect(retry.status).toBe(200);
+    expect(store.all()).toHaveLength(2);
+    expect(
+      store.all().filter((session) => !session.refreshTokenConsumedAt),
+    ).toHaveLength(1);
+  });
+
+  it("revokes the family when the parent is replayed after grace", async () => {
+    const credentials = await issueCredentials("session-owner");
+    const body = {
+      refresh_token: credentials.refresh_token,
+      token: credentials.token,
+    };
+    const attackerResponse = await post("/refresh", body);
+    const attackerCredentials =
+      (await attackerResponse.json()) as Credentials;
+    vi.setSystemTime(
+      new Date(NOW.getTime() + REFRESH_TOKEN_RESPONSE_LOSS_GRACE_MS + 1),
+    );
+
+    expect((await post("/refresh", body)).status).toBe(401);
+    expect(
+      store.all().every((session) => session.refreshTokenRevokedAt !== null),
+    ).toBe(true);
+    expect(
+      (
+        await post("/refresh", {
+          refresh_token: attackerCredentials.refresh_token,
+          token: attackerCredentials.token,
+        })
+      ).status,
+    ).toBe(401);
+  });
+});

--- a/tests/contract/refresh-token-auth.test.ts
+++ b/tests/contract/refresh-token-auth.test.ts
@@ -27,6 +27,7 @@ vi.mock("@beutl/db", async (importOriginal) => {
 });
 
 import {
+  REFRESH_TOKEN_FAMILY_MAX_LIFETIME_MS,
   REFRESH_TOKEN_RESPONSE_LOSS_GRACE_MS,
   setDbProvider,
 } from "@beutl/db";
@@ -104,6 +105,18 @@ describe("v1 refresh-token rotation", () => {
     });
   });
 
+  it("caps the initial refresh-token lifetime at 90 days", async () => {
+    process.env.JWT_REFRESH_TOKEN_EXPIRATION_DAYS = "120";
+
+    await issueCredentials("session-owner");
+
+    const absoluteExpiry = new Date(
+      NOW.getTime() + REFRESH_TOKEN_FAMILY_MAX_LIFETIME_MS,
+    );
+    expect(store.allFamilies()[0].expiresAt).toEqual(absoluteExpiry);
+    expect(store.all()[0].expiresAt).toEqual(absoluteExpiry);
+  });
+
   it("adopts a pre-deployment native session on its first refresh", async () => {
     const credentials = await issueCredentials("legacy-session-owner");
     const legacySession = store.all()[0];
@@ -134,7 +147,38 @@ describe("v1 refresh-token rotation", () => {
       refreshTokenFamilyId: adoptedParent!.refreshTokenFamilyId,
       refreshTokenConsumedAt: null,
     });
+    expect(store.allTransactionOptions().at(-1)).toEqual({
+      isolationLevel: "Serializable",
+    });
   });
+
+  it.each(["0", "-1", "invalid"])(
+    "rejects an invalid refresh-token expiration of %s days",
+    async (expirationDays) => {
+      process.env.JWT_REFRESH_TOKEN_EXPIRATION_DAYS = expirationDays;
+      mocks.findNativeAppAuthBySessionId.mockResolvedValueOnce({
+        code: "authorization-code",
+        codeExpires: new Date(Date.now() + 60_000),
+        continueUrl: "https://app.example/continue",
+        sessionId: "native-session",
+        userId: "session-owner",
+      });
+      const log = vi.spyOn(console, "error").mockImplementation(() => {});
+
+      try {
+        const response = await post("/code2jwt", {
+          code: "authorization-code",
+          session_id: "native-session",
+        });
+
+        expect(response.status).toBe(500);
+        expect(store.allFamilies()).toHaveLength(0);
+        expect(store.all()).toHaveLength(0);
+      } finally {
+        log.mockRestore();
+      }
+    },
+  );
 
   it("ignores a forged victim claim and mints for the session owner", async () => {
     const credentials = await issueCredentials("session-owner");
@@ -276,6 +320,42 @@ describe("v1 refresh-token rotation", () => {
     expect(
       store.getFamily(original.refreshTokenFamilyId!)?.expiresAt,
     ).toEqual(new Date(NOW.getTime() + 31 * 24 * 60 * 60 * 1000));
+  });
+
+  it("caps a refresh-token family at 90 days from creation", async () => {
+    const credentials = await issueCredentials("session-owner");
+    const original = store.all()[0];
+    const familyId = original.refreshTokenFamilyId;
+    store.updateFamily(familyId, {
+      createdAt: new Date(
+        NOW.getTime() -
+          REFRESH_TOKEN_FAMILY_MAX_LIFETIME_MS +
+          24 * 60 * 60 * 1000,
+      ),
+    });
+
+    const response = await post("/refresh", {
+      refresh_token: credentials.refresh_token,
+      token: credentials.token,
+    });
+
+    expect(response.status).toBe(200);
+    const refreshed = (await response.json()) as Credentials;
+    const absoluteExpiry = new Date(NOW.getTime() + 24 * 60 * 60 * 1000);
+    expect(store.getFamily(familyId)?.expiresAt).toEqual(absoluteExpiry);
+    expect(
+      store.all().find((token) => !token.refreshTokenConsumedAt)?.expiresAt,
+    ).toEqual(absoluteExpiry);
+
+    vi.setSystemTime(absoluteExpiry);
+    const expiredResponse = await post("/refresh", {
+      refresh_token: refreshed.refresh_token,
+      token: refreshed.token,
+    });
+
+    expect(expiredResponse.status).toBe(401);
+    expect(store.getFamily(familyId)).toBeNull();
+    expect(store.all()).toHaveLength(0);
   });
 
   it("retains tombstones until token expiry and then purges them", async () => {

--- a/tests/contract/transaction-retry.test.ts
+++ b/tests/contract/transaction-retry.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi } from "vitest";
+import { setDbProvider, startTransaction } from "@beutl/db";
+
+describe("database transactions", () => {
+  it("retries CockroachDB write conflicts", async () => {
+    const transaction = vi
+      .fn()
+      .mockRejectedValueOnce(
+        Object.assign(new Error("write conflict"), { code: "P2034" }),
+      )
+      .mockRejectedValueOnce(
+        Object.assign(new Error("write conflict"), { code: "P2034" }),
+      )
+      .mockImplementation(async (callback) => callback({}));
+    setDbProvider(async () => ({ $transaction: transaction }) as never);
+
+    const result = await startTransaction(async () => "completed");
+
+    expect(result).toBe("completed");
+    expect(transaction).toHaveBeenCalledTimes(3);
+  });
+
+  it("does not retry non-conflict failures", async () => {
+    const transaction = vi.fn().mockRejectedValue(new Error("invalid data"));
+    setDbProvider(async () => ({ $transaction: transaction }) as never);
+
+    await expect(startTransaction(async () => "unused")).rejects.toThrow(
+      "invalid data",
+    );
+    expect(transaction).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries adapter write conflicts raised while committing", async () => {
+    const adapterConflict = Object.assign(
+      new Error("TransactionWriteConflict"),
+      {
+        name: "DriverAdapterError",
+        cause: { kind: "TransactionWriteConflict" },
+      },
+    );
+    const transaction = vi
+      .fn()
+      .mockRejectedValueOnce(adapterConflict)
+      .mockImplementation(async (callback) => callback({}));
+    setDbProvider(async () => ({ $transaction: transaction }) as never);
+
+    const result = await startTransaction(async () => "completed");
+
+    expect(result).toBe("completed");
+    expect(transaction).toHaveBeenCalledTimes(2);
+  });
+});

--- a/tests/contract/transaction-retry.test.ts
+++ b/tests/contract/transaction-retry.test.ts
@@ -28,9 +28,9 @@ describe("database transactions", () => {
     const transaction = vi.fn().mockRejectedValue(new Error("invalid data"));
     setDbProvider(async () => ({ $transaction: transaction }) as never);
 
-    await expect(startTransaction(async () => "unused")).rejects.toThrow(
-      "invalid data",
-    );
+    await expect(
+      startRetryableTransaction(async () => "unused"),
+    ).rejects.toThrow("invalid data");
     expect(transaction).toHaveBeenCalledTimes(1);
   });
 

--- a/tests/contract/transaction-retry.test.ts
+++ b/tests/contract/transaction-retry.test.ts
@@ -34,6 +34,30 @@ describe("database transactions", () => {
     expect(transaction).toHaveBeenCalledTimes(1);
   });
 
+  it("passes interactive transaction options to every attempt", async () => {
+    const transaction = vi
+      .fn()
+      .mockRejectedValueOnce(
+        Object.assign(new Error("write conflict"), { code: "P2034" }),
+      )
+      .mockImplementation(async (callback) => callback({}));
+    setDbProvider(async () => ({ $transaction: transaction }) as never);
+    const options = { isolationLevel: "Serializable" as const };
+
+    await startRetryableTransaction(async () => "completed", options);
+
+    expect(transaction).toHaveBeenNthCalledWith(
+      1,
+      expect.any(Function),
+      options,
+    );
+    expect(transaction).toHaveBeenNthCalledWith(
+      2,
+      expect.any(Function),
+      options,
+    );
+  });
+
   it("retries adapter write conflicts raised while committing", async () => {
     const adapterConflict = Object.assign(
       new Error("TransactionWriteConflict"),

--- a/tests/contract/transaction-retry.test.ts
+++ b/tests/contract/transaction-retry.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
-import { setDbProvider, startTransaction } from "@beutl/db";
+import {
+  setDbProvider,
+  startRetryableTransaction,
+  startTransaction,
+} from "@beutl/db";
 
 describe("database transactions", () => {
   it("retries CockroachDB write conflicts", async () => {
@@ -14,7 +18,7 @@ describe("database transactions", () => {
       .mockImplementation(async (callback) => callback({}));
     setDbProvider(async () => ({ $transaction: transaction }) as never);
 
-    const result = await startTransaction(async () => "completed");
+    const result = await startRetryableTransaction(async () => "completed");
 
     expect(result).toBe("completed");
     expect(transaction).toHaveBeenCalledTimes(3);
@@ -44,9 +48,25 @@ describe("database transactions", () => {
       .mockImplementation(async (callback) => callback({}));
     setDbProvider(async () => ({ $transaction: transaction }) as never);
 
-    const result = await startTransaction(async () => "completed");
+    const result = await startRetryableTransaction(async () => "completed");
 
     expect(result).toBe("completed");
     expect(transaction).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not replay ordinary transaction callbacks", async () => {
+    const conflict = Object.assign(new Error("write conflict"), {
+      code: "P2034",
+    });
+    const callback = vi.fn(async () => "unused");
+    const transaction = vi.fn(async (run) => {
+      await run({});
+      throw conflict;
+    });
+    setDbProvider(async () => ({ $transaction: transaction }) as never);
+
+    await expect(startTransaction(callback)).rejects.toBe(conflict);
+    expect(transaction).toHaveBeenCalledTimes(1);
+    expect(callback).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/stubs/session-prisma.ts
+++ b/tests/stubs/session-prisma.ts
@@ -1,0 +1,200 @@
+export type SessionRecord = {
+  id: string;
+  token: string;
+  userId: string;
+  expiresAt: Date;
+  createdAt: Date;
+  updatedAt: Date;
+  ipAddress: string | null;
+  userAgent: string | null;
+  refreshTokenFamilyId: string | null;
+  refreshTokenConsumedAt: Date | null;
+  refreshTokenReplacedByToken: string | null;
+  refreshTokenRevokedAt: Date | null;
+};
+
+export type SessionSeed = Pick<
+  SessionRecord,
+  "token" | "userId" | "expiresAt"
+> &
+  Partial<Omit<SessionRecord, "token" | "userId" | "expiresAt">>;
+
+function cloneSession(session: SessionRecord): SessionRecord {
+  return {
+    ...session,
+    expiresAt: new Date(session.expiresAt),
+    createdAt: new Date(session.createdAt),
+    updatedAt: new Date(session.updatedAt),
+    refreshTokenConsumedAt: session.refreshTokenConsumedAt
+      ? new Date(session.refreshTokenConsumedAt)
+      : null,
+    refreshTokenRevokedAt: session.refreshTokenRevokedAt
+      ? new Date(session.refreshTokenRevokedAt)
+      : null,
+  };
+}
+
+function matchesWhere(
+  session: SessionRecord,
+  where: Record<string, unknown>,
+): boolean {
+  return Object.entries(where).every(([key, expected]) => {
+    if (expected === undefined) {
+      return true;
+    }
+
+    const actual = session[key as keyof SessionRecord];
+    if (
+      actual instanceof Date &&
+      typeof expected === "object" &&
+      expected !== null &&
+      !(expected instanceof Date)
+    ) {
+      const filter = expected as {
+        gt?: Date;
+        gte?: Date;
+        lt?: Date;
+        lte?: Date;
+      };
+      return (
+        (filter.gt === undefined || actual > filter.gt) &&
+        (filter.gte === undefined || actual >= filter.gte) &&
+        (filter.lt === undefined || actual < filter.lt) &&
+        (filter.lte === undefined || actual <= filter.lte)
+      );
+    }
+    if (actual instanceof Date && expected instanceof Date) {
+      return actual.getTime() === expected.getTime();
+    }
+    return actual === expected;
+  });
+}
+
+export function createSessionPrisma(initial: SessionSeed[] = []) {
+  let nextId = 1;
+  const records = new Map<string, SessionRecord>();
+
+  const toRecord = (seed: SessionSeed): SessionRecord => {
+    const timestamp = new Date();
+    return {
+      id: seed.id ?? `session-${nextId++}`,
+      token: seed.token,
+      userId: seed.userId,
+      expiresAt: new Date(seed.expiresAt),
+      createdAt: seed.createdAt ? new Date(seed.createdAt) : timestamp,
+      updatedAt: seed.updatedAt ? new Date(seed.updatedAt) : timestamp,
+      ipAddress: seed.ipAddress ?? null,
+      userAgent: seed.userAgent ?? null,
+      refreshTokenFamilyId: seed.refreshTokenFamilyId ?? null,
+      refreshTokenConsumedAt: seed.refreshTokenConsumedAt
+        ? new Date(seed.refreshTokenConsumedAt)
+        : null,
+      refreshTokenReplacedByToken:
+        seed.refreshTokenReplacedByToken ?? null,
+      refreshTokenRevokedAt: seed.refreshTokenRevokedAt
+        ? new Date(seed.refreshTokenRevokedAt)
+        : null,
+    };
+  };
+
+  for (const seed of initial) {
+    records.set(seed.token, toRecord(seed));
+  }
+
+  const session = {
+    findUnique: async ({ where }: { where: { token: string } }) => {
+      const record = records.get(where.token);
+      return record ? cloneSession(record) : null;
+    },
+    create: async ({ data }: { data: SessionSeed }) => {
+      if (records.has(data.token)) {
+        throw new Error(`Duplicate session token: ${data.token}`);
+      }
+      const record = toRecord(data);
+      records.set(record.token, record);
+      return cloneSession(record);
+    },
+    updateMany: async ({
+      where,
+      data,
+    }: {
+      where: Record<string, unknown>;
+      data: Partial<SessionRecord>;
+    }) => {
+      let count = 0;
+      for (const [token, record] of records) {
+        if (!matchesWhere(record, where)) {
+          continue;
+        }
+        records.set(
+          token,
+          cloneSession({
+            ...record,
+            ...data,
+            updatedAt: new Date(),
+          }),
+        );
+        count++;
+      }
+      return { count };
+    },
+    deleteMany: async ({ where }: { where: Record<string, unknown> }) => {
+      let count = 0;
+      for (const [token, record] of records) {
+        if (matchesWhere(record, where)) {
+          records.delete(token);
+          count++;
+        }
+      }
+      return { count };
+    },
+  };
+
+  let transactionQueue = Promise.resolve();
+  const prisma = {
+    session,
+    $transaction: async <T>(
+      callback: (transaction: { session: typeof session }) => Promise<T>,
+    ) => {
+      const previous = transactionQueue;
+      let release!: () => void;
+      transactionQueue = new Promise<void>((resolve) => {
+        release = resolve;
+      });
+      await previous;
+
+      const snapshot = new Map(
+        [...records].map(([token, record]) => [token, cloneSession(record)]),
+      );
+      try {
+        return await callback({ session });
+      } catch (error) {
+        records.clear();
+        for (const [token, record] of snapshot) {
+          records.set(token, record);
+        }
+        throw error;
+      } finally {
+        release();
+      }
+    },
+  };
+
+  return {
+    prisma,
+    get(token: string) {
+      const record = records.get(token);
+      return record ? cloneSession(record) : null;
+    },
+    all() {
+      return [...records.values()].map(cloneSession);
+    },
+    update(token: string, data: Partial<SessionRecord>) {
+      const record = records.get(token);
+      if (!record) {
+        throw new Error(`Unknown session token: ${token}`);
+      }
+      records.set(token, cloneSession({ ...record, ...data }));
+    },
+  };
+}

--- a/tests/stubs/session-prisma.ts
+++ b/tests/stubs/session-prisma.ts
@@ -7,10 +7,26 @@ export type SessionRecord = {
   updatedAt: Date;
   ipAddress: string | null;
   userAgent: string | null;
-  refreshTokenFamilyId: string | null;
+};
+
+export type NativeRefreshTokenRecord = {
+  token: string;
+  userId: string;
+  expiresAt: Date;
+  refreshTokenFamilyId: string;
   refreshTokenConsumedAt: Date | null;
   refreshTokenReplacedByToken: string | null;
-  refreshTokenRevokedAt: Date | null;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+export type RefreshTokenFamilyRecord = {
+  id: string;
+  userId: string;
+  expiresAt: Date;
+  revokedAt: Date | null;
+  createdAt: Date;
+  updatedAt: Date;
 };
 
 export type SessionSeed = Pick<
@@ -19,23 +35,62 @@ export type SessionSeed = Pick<
 > &
   Partial<Omit<SessionRecord, "token" | "userId" | "expiresAt">>;
 
+type NativeRefreshTokenSeed = Pick<
+  NativeRefreshTokenRecord,
+  "token" | "userId" | "expiresAt" | "refreshTokenFamilyId"
+> &
+  Partial<
+    Omit<
+      NativeRefreshTokenRecord,
+      "token" | "userId" | "expiresAt" | "refreshTokenFamilyId"
+    >
+  >;
+
+type RefreshTokenFamilySeed = Pick<
+  RefreshTokenFamilyRecord,
+  "id" | "userId" | "expiresAt"
+> &
+  Partial<
+    Omit<RefreshTokenFamilyRecord, "id" | "userId" | "expiresAt">
+  >;
+
 function cloneSession(session: SessionRecord): SessionRecord {
   return {
     ...session,
     expiresAt: new Date(session.expiresAt),
     createdAt: new Date(session.createdAt),
     updatedAt: new Date(session.updatedAt),
-    refreshTokenConsumedAt: session.refreshTokenConsumedAt
-      ? new Date(session.refreshTokenConsumedAt)
-      : null,
-    refreshTokenRevokedAt: session.refreshTokenRevokedAt
-      ? new Date(session.refreshTokenRevokedAt)
+  };
+}
+
+function cloneNativeRefreshToken(
+  refreshToken: NativeRefreshTokenRecord,
+): NativeRefreshTokenRecord {
+  return {
+    ...refreshToken,
+    expiresAt: new Date(refreshToken.expiresAt),
+    createdAt: new Date(refreshToken.createdAt),
+    updatedAt: new Date(refreshToken.updatedAt),
+    refreshTokenConsumedAt: refreshToken.refreshTokenConsumedAt
+      ? new Date(refreshToken.refreshTokenConsumedAt)
       : null,
   };
 }
 
-function matchesWhere(
-  session: SessionRecord,
+function cloneFamily(
+  family: RefreshTokenFamilyRecord,
+): RefreshTokenFamilyRecord {
+  return {
+    ...family,
+    expiresAt: new Date(family.expiresAt),
+    revokedAt: family.revokedAt ? new Date(family.revokedAt) : null,
+    createdAt: new Date(family.createdAt),
+    updatedAt: new Date(family.updatedAt),
+  };
+}
+
+function matchesWhere<T extends Record<string, unknown>>(
+  record: T,
   where: Record<string, unknown>,
 ): boolean {
   return Object.entries(where).every(([key, expected]) => {
@@ -43,7 +98,16 @@ function matchesWhere(
       return true;
     }
 
-    const actual = session[key as keyof SessionRecord];
+    const actual = record[key as keyof T];
+    if (
+      typeof expected === "object" &&
+      expected !== null &&
+      !(expected instanceof Date) &&
+      "not" in expected &&
+      actual === expected.not
+    ) {
+      return false;
+    }
     if (
       actual instanceof Date &&
       typeof expected === "object" &&
@@ -70,14 +134,16 @@ function matchesWhere(
   });
 }
 
-export function createSessionPrisma(initial: SessionSeed[] = []) {
-  let nextId = 1;
-  const records = new Map<string, SessionRecord>();
+export function createSessionPrisma(initialSessions: SessionSeed[] = []) {
+  let nextSessionId = 1;
+  const sessions = new Map<string, SessionRecord>();
+  const refreshTokens = new Map<string, NativeRefreshTokenRecord>();
+  const families = new Map<string, RefreshTokenFamilyRecord>();
 
-  const toRecord = (seed: SessionSeed): SessionRecord => {
+  const toSessionRecord = (seed: SessionSeed): SessionRecord => {
     const timestamp = new Date();
     return {
-      id: seed.id ?? `session-${nextId++}`,
+      id: seed.id ?? `session-${nextSessionId++}`,
       token: seed.token,
       userId: seed.userId,
       expiresAt: new Date(seed.expiresAt),
@@ -85,50 +151,99 @@ export function createSessionPrisma(initial: SessionSeed[] = []) {
       updatedAt: seed.updatedAt ? new Date(seed.updatedAt) : timestamp,
       ipAddress: seed.ipAddress ?? null,
       userAgent: seed.userAgent ?? null,
-      refreshTokenFamilyId: seed.refreshTokenFamilyId ?? null,
+    };
+  };
+
+  const toNativeRefreshTokenRecord = (
+    seed: NativeRefreshTokenSeed,
+  ): NativeRefreshTokenRecord => {
+    const timestamp = new Date();
+    return {
+      token: seed.token,
+      userId: seed.userId,
+      expiresAt: new Date(seed.expiresAt),
+      refreshTokenFamilyId: seed.refreshTokenFamilyId,
       refreshTokenConsumedAt: seed.refreshTokenConsumedAt
         ? new Date(seed.refreshTokenConsumedAt)
         : null,
       refreshTokenReplacedByToken:
         seed.refreshTokenReplacedByToken ?? null,
-      refreshTokenRevokedAt: seed.refreshTokenRevokedAt
-        ? new Date(seed.refreshTokenRevokedAt)
-        : null,
+      createdAt: seed.createdAt ? new Date(seed.createdAt) : timestamp,
+      updatedAt: seed.updatedAt ? new Date(seed.updatedAt) : timestamp,
     };
   };
 
-  for (const seed of initial) {
-    records.set(seed.token, toRecord(seed));
+  const toFamilyRecord = (
+    seed: RefreshTokenFamilySeed,
+  ): RefreshTokenFamilyRecord => {
+    const timestamp = new Date();
+    return {
+      id: seed.id,
+      userId: seed.userId,
+      expiresAt: new Date(seed.expiresAt),
+      revokedAt: seed.revokedAt ? new Date(seed.revokedAt) : null,
+      createdAt: seed.createdAt ? new Date(seed.createdAt) : timestamp,
+      updatedAt: seed.updatedAt ? new Date(seed.updatedAt) : timestamp,
+    };
+  };
+
+  for (const seed of initialSessions) {
+    sessions.set(seed.token, toSessionRecord(seed));
   }
 
   const session = {
     findUnique: async ({ where }: { where: { token: string } }) => {
-      const record = records.get(where.token);
+      const record = sessions.get(where.token);
       return record ? cloneSession(record) : null;
     },
     create: async ({ data }: { data: SessionSeed }) => {
-      if (records.has(data.token)) {
+      if (sessions.has(data.token)) {
         throw new Error(`Duplicate session token: ${data.token}`);
       }
-      const record = toRecord(data);
-      records.set(record.token, record);
+      const record = toSessionRecord(data);
+      sessions.set(record.token, record);
       return cloneSession(record);
+    },
+    deleteMany: async ({ where }: { where: Record<string, unknown> }) => {
+      let count = 0;
+      for (const [token, record] of sessions) {
+        if (matchesWhere(record, where)) {
+          sessions.delete(token);
+          count++;
+        }
+      }
+      return { count };
+    },
+  };
+
+  const nativeRefreshToken = {
+    findUnique: async ({ where }: { where: { token: string } }) => {
+      const record = refreshTokens.get(where.token);
+      return record ? cloneNativeRefreshToken(record) : null;
+    },
+    create: async ({ data }: { data: NativeRefreshTokenSeed }) => {
+      if (refreshTokens.has(data.token)) {
+        throw new Error(`Duplicate native refresh token: ${data.token}`);
+      }
+      const record = toNativeRefreshTokenRecord(data);
+      refreshTokens.set(record.token, record);
+      return cloneNativeRefreshToken(record);
     },
     updateMany: async ({
       where,
       data,
     }: {
       where: Record<string, unknown>;
-      data: Partial<SessionRecord>;
+      data: Partial<NativeRefreshTokenRecord>;
     }) => {
       let count = 0;
-      for (const [token, record] of records) {
+      for (const [token, record] of refreshTokens) {
         if (!matchesWhere(record, where)) {
           continue;
         }
-        records.set(
+        refreshTokens.set(
           token,
-          cloneSession({
+          cloneNativeRefreshToken({
             ...record,
             ...data,
             updatedAt: new Date(),
@@ -140,11 +255,84 @@ export function createSessionPrisma(initial: SessionSeed[] = []) {
     },
     deleteMany: async ({ where }: { where: Record<string, unknown> }) => {
       let count = 0;
-      for (const [token, record] of records) {
+      for (const [token, record] of refreshTokens) {
         if (matchesWhere(record, where)) {
-          records.delete(token);
+          refreshTokens.delete(token);
           count++;
         }
+      }
+      return { count };
+    },
+  };
+
+  const refreshTokenFamily = {
+    findUnique: async ({ where }: { where: { id: string } }) => {
+      const family = families.get(where.id);
+      return family ? cloneFamily(family) : null;
+    },
+    findFirst: async ({
+      where,
+      orderBy,
+    }: {
+      where: Record<string, unknown>;
+      orderBy: { expiresAt: "asc" | "desc" };
+    }) => {
+      const matches = [...families.values()]
+        .filter((family) => matchesWhere(family, where))
+        .sort((left, right) => {
+          const direction = orderBy.expiresAt === "asc" ? 1 : -1;
+          return (
+            direction *
+            (left.expiresAt.getTime() - right.expiresAt.getTime())
+          );
+        });
+      return matches[0] ? cloneFamily(matches[0]) : null;
+    },
+    create: async ({ data }: { data: RefreshTokenFamilySeed }) => {
+      if (families.has(data.id)) {
+        throw new Error(`Duplicate refresh token family: ${data.id}`);
+      }
+      const family = toFamilyRecord(data);
+      families.set(family.id, family);
+      return cloneFamily(family);
+    },
+    updateMany: async ({
+      where,
+      data,
+    }: {
+      where: Record<string, unknown>;
+      data: Partial<RefreshTokenFamilyRecord>;
+    }) => {
+      let count = 0;
+      for (const [id, family] of families) {
+        if (!matchesWhere(family, where)) {
+          continue;
+        }
+        families.set(
+          id,
+          cloneFamily({
+            ...family,
+            ...data,
+            updatedAt: new Date(),
+          }),
+        );
+        count++;
+      }
+      return { count };
+    },
+    deleteMany: async ({ where }: { where: Record<string, unknown> }) => {
+      let count = 0;
+      for (const [id, family] of families) {
+        if (!matchesWhere(family, where)) {
+          continue;
+        }
+        families.delete(id);
+        for (const [token, refreshToken] of refreshTokens) {
+          if (refreshToken.refreshTokenFamilyId === id) {
+            refreshTokens.delete(token);
+          }
+        }
+        count++;
       }
       return { count };
     },
@@ -153,8 +341,14 @@ export function createSessionPrisma(initial: SessionSeed[] = []) {
   let transactionQueue = Promise.resolve();
   const prisma = {
     session,
+    nativeRefreshToken,
+    refreshTokenFamily,
     $transaction: async <T>(
-      callback: (transaction: { session: typeof session }) => Promise<T>,
+      callback: (transaction: {
+        session: typeof session;
+        nativeRefreshToken: typeof nativeRefreshToken;
+        refreshTokenFamily: typeof refreshTokenFamily;
+      }) => Promise<T>,
     ) => {
       const previous = transactionQueue;
       let release!: () => void;
@@ -163,15 +357,36 @@ export function createSessionPrisma(initial: SessionSeed[] = []) {
       });
       await previous;
 
-      const snapshot = new Map(
-        [...records].map(([token, record]) => [token, cloneSession(record)]),
+      const sessionSnapshot = new Map(
+        [...sessions].map(([token, record]) => [token, cloneSession(record)]),
+      );
+      const refreshTokenSnapshot = new Map(
+        [...refreshTokens].map(([token, record]) => [
+          token,
+          cloneNativeRefreshToken(record),
+        ]),
+      );
+      const familySnapshot = new Map(
+        [...families].map(([id, family]) => [id, cloneFamily(family)]),
       );
       try {
-        return await callback({ session });
+        return await callback({
+          session,
+          nativeRefreshToken,
+          refreshTokenFamily,
+        });
       } catch (error) {
-        records.clear();
-        for (const [token, record] of snapshot) {
-          records.set(token, record);
+        sessions.clear();
+        for (const [token, record] of sessionSnapshot) {
+          sessions.set(token, record);
+        }
+        refreshTokens.clear();
+        for (const [token, record] of refreshTokenSnapshot) {
+          refreshTokens.set(token, record);
+        }
+        families.clear();
+        for (const [id, family] of familySnapshot) {
+          families.set(id, family);
         }
         throw error;
       } finally {
@@ -183,18 +398,62 @@ export function createSessionPrisma(initial: SessionSeed[] = []) {
   return {
     prisma,
     get(token: string) {
-      const record = records.get(token);
-      return record ? cloneSession(record) : null;
+      const record = refreshTokens.get(token);
+      return record ? cloneNativeRefreshToken(record) : null;
     },
     all() {
-      return [...records.values()].map(cloneSession);
+      return [...refreshTokens.values()].map(cloneNativeRefreshToken);
     },
-    update(token: string, data: Partial<SessionRecord>) {
-      const record = records.get(token);
+    update(token: string, data: Partial<NativeRefreshTokenRecord>) {
+      const record = refreshTokens.get(token);
       if (!record) {
-        throw new Error(`Unknown session token: ${token}`);
+        throw new Error(`Unknown native refresh token: ${token}`);
       }
-      records.set(token, cloneSession({ ...record, ...data }));
+      refreshTokens.set(
+        token,
+        cloneNativeRefreshToken({ ...record, ...data }),
+      );
+    },
+    getSession(token: string) {
+      const record = sessions.get(token);
+      return record ? cloneSession(record) : null;
+    },
+    allSessions() {
+      return [...sessions.values()].map(cloneSession);
+    },
+    moveNativeTokenToLegacySession(token: string) {
+      const refreshToken = refreshTokens.get(token);
+      if (!refreshToken) {
+        throw new Error(`Unknown native refresh token: ${token}`);
+      }
+      refreshTokens.delete(token);
+      sessions.set(
+        token,
+        toSessionRecord({
+          token,
+          userId: refreshToken.userId,
+          expiresAt: refreshToken.expiresAt,
+          createdAt: refreshToken.createdAt,
+          updatedAt: refreshToken.updatedAt,
+        }),
+      );
+    },
+    getFamily(id: string) {
+      const family = families.get(id);
+      return family ? cloneFamily(family) : null;
+    },
+    allFamilies() {
+      return [...families.values()].map(cloneFamily);
+    },
+    deleteFamily(id: string) {
+      families.delete(id);
+    },
+    updateFamily(id: string, data: Partial<RefreshTokenFamilyRecord>) {
+      const family = families.get(id);
+      if (!family) {
+        throw new Error(`Unknown refresh token family: ${id}`);
+      }
+      families.set(id, cloneFamily({ ...family, ...data }));
     },
   };
 }

--- a/tests/stubs/session-prisma.ts
+++ b/tests/stubs/session-prisma.ts
@@ -139,6 +139,9 @@ export function createSessionPrisma(initialSessions: SessionSeed[] = []) {
   const sessions = new Map<string, SessionRecord>();
   const refreshTokens = new Map<string, NativeRefreshTokenRecord>();
   const families = new Map<string, RefreshTokenFamilyRecord>();
+  const transactionOptions: Array<
+    { isolationLevel?: string } | undefined
+  > = [];
 
   const toSessionRecord = (seed: SessionSeed): SessionRecord => {
     const timestamp = new Date();
@@ -349,7 +352,9 @@ export function createSessionPrisma(initialSessions: SessionSeed[] = []) {
         nativeRefreshToken: typeof nativeRefreshToken;
         refreshTokenFamily: typeof refreshTokenFamily;
       }) => Promise<T>,
+      options?: { isolationLevel?: string },
     ) => {
+      transactionOptions.push(options ? { ...options } : undefined);
       const previous = transactionQueue;
       let release!: () => void;
       transactionQueue = new Promise<void>((resolve) => {
@@ -454,6 +459,11 @@ export function createSessionPrisma(initialSessions: SessionSeed[] = []) {
         throw new Error(`Unknown refresh token family: ${id}`);
       }
       families.set(id, cloneFamily({ ...family, ...data }));
+    },
+    allTransactionOptions() {
+      return transactionOptions.map((options) =>
+        options ? { ...options } : undefined,
+      );
     },
   };
 }


### PR DESCRIPTION
## Summary

- derive the refreshed identity from the persisted refresh session
- rotate native refresh tokens atomically with family tombstones and replay detection
- reject expired or revoked sessions and retry CockroachDB write conflicts
- add route-level regression coverage for subject confusion, expiration, concurrency, and replay

## Root cause

The refresh flow trusted identity claims supplied by the request instead of binding credential issuance to the owner of the persisted refresh session. Session consumption also did not enforce expiration.

## Deployment

Apply the included Prisma migration before deploying the API. After deployment, revoke existing native sessions or rotate `JWT_SECRET` so credentials issued before this fix cannot remain active.

## Checks

- `corepack pnpm test` (26 tests passed)
- `corepack pnpm --filter @beutl/api build`
- `corepack pnpm --filter @beutl/web exec prisma validate --schema prisma/schema.prisma`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security & Authentication**
  * Refresh tokens now use secure rotation and family tracking.
  * Expired, reused, revoked, or invalid refresh tokens are rejected.
  * Suspicious token reuse can invalidate the associated token family.
  * Existing valid sessions can transition to the updated refresh-token system.

* **Reliability**
  * Refresh operations are more resilient to concurrent requests and temporary database conflicts.
  * Improved handling prevents duplicate refreshes during brief response-loss scenarios.

* **Bug Fixes**
  * Browser sessions cannot be used as native refresh tokens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->