### PR TITLE
fix: enforce private file access controls

### DIFF
--- a/apps/web/src/app/api/contents/[fileId]/route.ts
+++ b/apps/web/src/app/api/contents/[fileId]/route.ts
@@ -60,7 +60,7 @@ export async function GET(
       headers: {
         "Content-Type": file.mimeType || "application/octet-stream",
         "Content-Length": object.size.toString(),
-        ...contentCacheHeaders(access.isPublic),
+        ...contentCacheHeaders(access.canUsePublicCache),
       },
       status: 200,
     });

--- a/apps/web/src/app/api/contents/[fileId]/route.ts
+++ b/apps/web/src/app/api/contents/[fileId]/route.ts
@@ -1,23 +1,24 @@
-import { auth } from "@/lib/better-auth";
-import { findFileForContentAccess } from "@beutl/db";
-import { existsUserPaymentHistory } from "@beutl/db";
+import { resolveContentAccess } from "@beutl/core";
+import {
+  existsUserPaymentHistory,
+  findFileForContentAccess,
+} from "@beutl/db";
+import { tryGetUserIdFromHeaders } from "@beutl/api";
 import { getCloudflareContext } from "@opennextjs/cloudflare";
 import { NextResponse, type NextRequest } from "next/server";
-import { tryGetUserIdFromHeaders } from "@beutl/api";
+import { auth } from "@/lib/better-auth";
+import { contentCacheHeaders } from "@/lib/content-cache";
 
-export async function GET(request: NextRequest, props: { params: Promise<{ fileId: string }> }) {
-  const params = await props.params;
-
-  const {
-    fileId
-  } = params;
-
+export async function GET(
+  request: NextRequest,
+  props: { params: Promise<{ fileId: string }> },
+) {
+  const { fileId } = await props.params;
   const session = await auth.api.getSession({ headers: request.headers });
-  const userId = session?.user?.id || await tryGetUserIdFromHeaders(request.headers);
+  const userId =
+    session?.user?.id ?? (await tryGetUserIdFromHeaders(request.headers));
 
   const file = await findFileForContentAccess({ id: fileId });
-  let cacheControl = "private";
-
   if (!file) {
     return NextResponse.json(
       {
@@ -25,97 +26,65 @@ export async function GET(request: NextRequest, props: { params: Promise<{ fileI
       },
       {
         status: 404,
+        headers: contentCacheHeaders(false),
       },
     );
   }
 
-  let allowed = false;
-  if (file.visibility === "PUBLIC") {
-    allowed = true;
-    cacheControl = "public";
-  }
-  if (file.visibility === "PRIVATE") {
-    allowed = userId === file.userId;
-  }
-  if (file.visibility === "DEDICATED") {
-    if (file.Package.length !== 0) {
-      allowed = file.Package.some(
-        (pkg) => pkg.published || pkg.userId === userId,
-      );
-      cacheControl = file.Package.some((pkg) => pkg.published) ? "public" : "private";
-    }
-    if (file.Profile) {
-      allowed = true;
-      cacheControl = "public";
-    }
-    if (file.PackageScreenshot.length !== 0) {
-      allowed = file.PackageScreenshot.some(
-        (screenshot) =>
-          screenshot.package.published ||
-          screenshot.package.userId === userId,
-      );
-      cacheControl = file.PackageScreenshot.some((screenshot) => screenshot.package.published) ? "public" : "private";
-    }
-    if (file.Release.length !== 0) {
-      cacheControl = "no-store";
-      allowed = file.Release.some(
-        (release) =>
-          (release.published && release.package.published) ||
-          release.package.userId === userId,
-      );
-      if (allowed) {
-        const pkg = file.Release.find((r) => r.package)?.package;
-        // 価格が設定されている時、購入者のみアクセス可能
-        if (pkg?.packagePricing[0]?.id) {
-          if (
-            !(await existsUserPaymentHistory({
-              userId: userId || undefined,
-              packageId: pkg.id,
-            }))
-          ) {
-            return NextResponse.json(
-              {
-                message: "支払いが必要です",
-              },
-              {
-                status: 403,
-              },
-            );
-          }
-        }
-      }
-    }
-  }
+  const access = await resolveContentAccess({
+    file,
+    userId,
+    hasPurchasedPackage: async (packageId) =>
+      await existsUserPaymentHistory({
+        userId: userId ?? undefined,
+        packageId,
+      }),
+  });
 
-  if (allowed) {
+  if (access.outcome === "allowed") {
     const bucket = getCloudflareContext().env.BEUTL_R2_BUCKET;
-    const res = await bucket.get(file.objectKey);
-    if (!res) {
+    const object = await bucket.get(file.objectKey);
+    if (!object) {
       return NextResponse.json(
         {
           message: "ファイルが見つかりません",
         },
         {
           status: 404,
+          headers: contentCacheHeaders(false),
         },
       );
     }
 
-    return new NextResponse(res.body, {
+    return new NextResponse(object.body, {
       headers: {
         "Content-Type": file.mimeType || "application/octet-stream",
-        "Content-Length": res.size.toString(),
-        "Cache-Control": cacheControl !== "no-store" ? `${cacheControl}, max-age=31536000, immutable` : cacheControl,
+        "Content-Length": object.size.toString(),
+        ...contentCacheHeaders(access.isPublic),
       },
       status: 200,
     });
   }
+
+  if (access.outcome === "payment-required") {
+    return NextResponse.json(
+      {
+        message: "支払いが必要です",
+      },
+      {
+        status: 403,
+        headers: contentCacheHeaders(false),
+      },
+    );
+  }
+
   return NextResponse.json(
     {
       message: "アクセスが拒否されました",
     },
     {
       status: 403,
+      headers: contentCacheHeaders(false),
     },
   );
 }

--- a/apps/web/src/app/api/contents/[fileId]/route.ts
+++ b/apps/web/src/app/api/contents/[fileId]/route.ts
@@ -80,10 +80,10 @@ export async function GET(
 
   return NextResponse.json(
     {
-      message: "アクセスが拒否されました",
+      message: "ファイルが見つかりません",
     },
     {
-      status: 403,
+      status: 404,
       headers: contentCacheHeaders(false),
     },
   );

--- a/apps/web/src/lib/content-cache.ts
+++ b/apps/web/src/lib/content-cache.ts
@@ -1,0 +1,8 @@
+export function contentCacheHeaders(isPublic: boolean): Record<string, string> {
+  return isPublic
+    ? { "Cache-Control": "public, max-age=31536000, immutable" }
+    : {
+        "Cache-Control": "no-store",
+        Vary: "Cookie, Authorization",
+      };
+}

--- a/apps/web/src/lib/content-cache.ts
+++ b/apps/web/src/lib/content-cache.ts
@@ -1,5 +1,5 @@
-export function contentCacheHeaders(isPublic: boolean): Record<string, string> {
-  return isPublic
+export function contentCacheHeaders(canUsePublicCache: boolean): Record<string, string> {
+  return canUsePublicCache
     ? { "Cache-Control": "public, max-age=31536000, immutable" }
     : {
         "Cache-Control": "no-store",

--- a/packages/api/src/v3/files.ts
+++ b/packages/api/src/v3/files.ts
@@ -2,17 +2,8 @@ import { Hono } from "hono";
 import { getUserId } from "../api/auth";
 import { apiErrorResponse } from "../api/error";
 import { getContentUrl } from "../content-url";
-import { findFileForApi } from "@beutl/db";
-
-/* eslint-disable @typescript-eslint/no-unused-vars */
-async function isAllowed(
-  file: NonNullable<Awaited<ReturnType<typeof findFileForApi>>>,
-  userId: string | null,
-) {
-  // return userId === file.userId;
-  // todo
-  return true;
-}
+import { resolveContentAccess } from "@beutl/core";
+import { existsUserPaymentHistory, findFileForApi } from "@beutl/db";
 
 const app = new Hono().get("/:id", async (c) => {
   const id = c.req.param("id");
@@ -23,7 +14,19 @@ const app = new Hono().get("/:id", async (c) => {
   }
 
   const userId = await getUserId(c);
-  if (!(await isAllowed(file, userId))) {
+  const access = await resolveContentAccess({
+    file,
+    userId,
+    hasPurchasedPackage: async (packageId) =>
+      await existsUserPaymentHistory({
+        userId: userId ?? undefined,
+        packageId,
+      }),
+  });
+  if (access.outcome === "denied") {
+    return c.json(await apiErrorResponse("assetNotFound"), { status: 404 });
+  }
+  if (access.outcome === "payment-required") {
     return c.json(await apiErrorResponse("doNotHavePermissions"), {
       status: 403,
     });

--- a/packages/api/src/v3/files.ts
+++ b/packages/api/src/v3/files.ts
@@ -6,6 +6,9 @@ import { resolveContentAccess } from "@beutl/core";
 import { existsUserPaymentHistory, findFileForApi } from "@beutl/db";
 
 const app = new Hono().get("/:id", async (c) => {
+  c.header("Cache-Control", "no-store");
+  c.header("Vary", "Authorization");
+
   const id = c.req.param("id");
   const file = await findFileForApi({ id });
 

--- a/packages/core/src/content-access.ts
+++ b/packages/core/src/content-access.ts
@@ -15,13 +15,13 @@ export type ContentAccessFile = {
     published: boolean;
     package: OwnedPublication & {
       id: string;
-      packagePricing: readonly { id: string }[];
+      packagePricing: readonly { id: string; price: number }[];
     };
   }[];
 };
 
 export type ContentAccessResult =
-  | { outcome: "allowed"; isPublic: boolean }
+  | { outcome: "allowed"; canUsePublicCache: boolean }
   | { outcome: "denied" }
   | { outcome: "payment-required" };
 
@@ -34,12 +34,14 @@ export async function resolveContentAccess({
   userId: string | null;
   hasPurchasedPackage: (packageId: string) => Promise<boolean>;
 }): Promise<ContentAccessResult> {
+  const isReleasePayload = file.Release.length > 0;
+
   if (file.visibility === "PUBLIC") {
-    return { outcome: "allowed", isPublic: true };
+    return { outcome: "allowed", canUsePublicCache: !isReleasePayload };
   }
   if (file.visibility === "PRIVATE") {
     return file.userId === userId
-      ? { outcome: "allowed", isPublic: false }
+      ? { outcome: "allowed", canUsePublicCache: false }
       : { outcome: "denied" };
   }
 
@@ -61,29 +63,39 @@ export async function resolveContentAccess({
   const releaseIsOwned = visibleReleases.some(
     (release) => release.package.userId === userId,
   );
-  const freeReleaseIsPublic = visibleReleases.some(
+  const freeReleaseAllowsAnonymousAccess = visibleReleases.some(
     (release) =>
       release.published &&
       release.package.published &&
-      release.package.packagePricing.length === 0,
+      !release.package.packagePricing.some((pricing) => pricing.price > 0),
   );
 
-  const isPublic =
+  const allowsAnonymousAccess =
     packageIsPublic ||
     screenshotIsPublic ||
     profileIsPublic ||
-    freeReleaseIsPublic;
-  if (isPublic) {
-    return { outcome: "allowed", isPublic: true };
+    freeReleaseAllowsAnonymousAccess;
+  if (allowsAnonymousAccess) {
+    return {
+      outcome: "allowed",
+      canUsePublicCache: !isReleasePayload,
+    };
   }
-  if (packageIsOwned || screenshotIsOwned || releaseIsOwned) {
-    return { outcome: "allowed", isPublic: false };
+  if (
+    file.userId === userId ||
+    packageIsOwned ||
+    screenshotIsOwned ||
+    releaseIsOwned
+  ) {
+    return { outcome: "allowed", canUsePublicCache: false };
   }
 
   const paidPackageIds = [
     ...new Set(
       visibleReleases
-        .filter((release) => release.package.packagePricing.length > 0)
+        .filter((release) =>
+          release.package.packagePricing.some((pricing) => pricing.price > 0),
+        )
         .map((release) => release.package.id),
     ),
   ];
@@ -98,6 +110,6 @@ export async function resolveContentAccess({
     paidPackageIds.map((packageId) => hasPurchasedPackage(packageId)),
   );
   return paymentRecords.some(Boolean)
-    ? { outcome: "allowed", isPublic: false }
+    ? { outcome: "allowed", canUsePublicCache: false }
     : { outcome: "payment-required" };
 }

--- a/packages/core/src/content-access.ts
+++ b/packages/core/src/content-access.ts
@@ -35,8 +35,21 @@ export async function resolveContentAccess({
   hasPurchasedPackage: (packageId: string) => Promise<boolean>;
 }): Promise<ContentAccessResult> {
   const isReleasePayload = file.Release.length > 0;
+  const publishedPaidPackageIds = [
+    ...new Set(
+      file.Release.filter(
+        (release) =>
+          release.published &&
+          release.package.published &&
+          release.package.packagePricing.some((pricing) => pricing.price > 0),
+      ).map((release) => release.package.id),
+    ),
+  ];
 
-  if (file.visibility === "PUBLIC") {
+  if (
+    file.visibility === "PUBLIC" &&
+    publishedPaidPackageIds.length === 0
+  ) {
     return { outcome: "allowed", canUsePublicCache: !isReleasePayload };
   }
   if (file.visibility === "PRIVATE") {
@@ -75,7 +88,7 @@ export async function resolveContentAccess({
     screenshotIsPublic ||
     profileIsPublic ||
     freeReleaseAllowsAnonymousAccess;
-  if (allowsAnonymousAccess) {
+  if (allowsAnonymousAccess && publishedPaidPackageIds.length === 0) {
     return {
       outcome: "allowed",
       canUsePublicCache: !isReleasePayload,
@@ -90,16 +103,7 @@ export async function resolveContentAccess({
     return { outcome: "allowed", canUsePublicCache: false };
   }
 
-  const paidPackageIds = [
-    ...new Set(
-      visibleReleases
-        .filter((release) =>
-          release.package.packagePricing.some((pricing) => pricing.price > 0),
-        )
-        .map((release) => release.package.id),
-    ),
-  ];
-  if (paidPackageIds.length === 0) {
+  if (publishedPaidPackageIds.length === 0) {
     return { outcome: "denied" };
   }
   if (!userId) {
@@ -107,7 +111,9 @@ export async function resolveContentAccess({
   }
 
   const paymentRecords = await Promise.all(
-    paidPackageIds.map((packageId) => hasPurchasedPackage(packageId)),
+    publishedPaidPackageIds.map((packageId) =>
+      hasPurchasedPackage(packageId),
+    ),
   );
   return paymentRecords.some(Boolean)
     ? { outcome: "allowed", canUsePublicCache: false }

--- a/packages/core/src/content-access.ts
+++ b/packages/core/src/content-access.ts
@@ -1,0 +1,103 @@
+type OwnedPublication = {
+  userId: string;
+  published: boolean;
+};
+
+export type ContentAccessFile = {
+  visibility: "PUBLIC" | "PRIVATE" | "DEDICATED";
+  userId: string;
+  Package: readonly OwnedPublication[];
+  Profile: readonly unknown[];
+  PackageScreenshot: readonly {
+    package: OwnedPublication;
+  }[];
+  Release: readonly {
+    published: boolean;
+    package: OwnedPublication & {
+      id: string;
+      packagePricing: readonly { id: string }[];
+    };
+  }[];
+};
+
+export type ContentAccessResult =
+  | { outcome: "allowed"; isPublic: boolean }
+  | { outcome: "denied" }
+  | { outcome: "payment-required" };
+
+export async function resolveContentAccess({
+  file,
+  userId,
+  hasPurchasedPackage,
+}: {
+  file: ContentAccessFile;
+  userId: string | null;
+  hasPurchasedPackage: (packageId: string) => Promise<boolean>;
+}): Promise<ContentAccessResult> {
+  if (file.visibility === "PUBLIC") {
+    return { outcome: "allowed", isPublic: true };
+  }
+  if (file.visibility === "PRIVATE") {
+    return file.userId === userId
+      ? { outcome: "allowed", isPublic: false }
+      : { outcome: "denied" };
+  }
+
+  const packageIsPublic = file.Package.some((pkg) => pkg.published);
+  const packageIsOwned = file.Package.some((pkg) => pkg.userId === userId);
+  const screenshotIsPublic = file.PackageScreenshot.some(
+    (screenshot) => screenshot.package.published,
+  );
+  const screenshotIsOwned = file.PackageScreenshot.some(
+    (screenshot) => screenshot.package.userId === userId,
+  );
+  const profileIsPublic = file.Profile.length > 0;
+
+  const visibleReleases = file.Release.filter(
+    (release) =>
+      (release.published && release.package.published) ||
+      release.package.userId === userId,
+  );
+  const releaseIsOwned = visibleReleases.some(
+    (release) => release.package.userId === userId,
+  );
+  const freeReleaseIsPublic = visibleReleases.some(
+    (release) =>
+      release.published &&
+      release.package.published &&
+      release.package.packagePricing.length === 0,
+  );
+
+  const isPublic =
+    packageIsPublic ||
+    screenshotIsPublic ||
+    profileIsPublic ||
+    freeReleaseIsPublic;
+  if (isPublic) {
+    return { outcome: "allowed", isPublic: true };
+  }
+  if (packageIsOwned || screenshotIsOwned || releaseIsOwned) {
+    return { outcome: "allowed", isPublic: false };
+  }
+
+  const paidPackageIds = [
+    ...new Set(
+      visibleReleases
+        .filter((release) => release.package.packagePricing.length > 0)
+        .map((release) => release.package.id),
+    ),
+  ];
+  if (paidPackageIds.length === 0) {
+    return { outcome: "denied" };
+  }
+  if (!userId) {
+    return { outcome: "payment-required" };
+  }
+
+  const paymentRecords = await Promise.all(
+    paidPackageIds.map((packageId) => hasPurchasedPackage(packageId)),
+  );
+  return paymentRecords.some(Boolean)
+    ? { outcome: "allowed", isPublic: false }
+    : { outcome: "payment-required" };
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -9,3 +9,8 @@ export { cn, formatBytes } from "./utils";
 export type { ActionResult } from "./action-result";
 export { isAllowedContinueUrlHost } from "./native-auth";
 export { isAdmin } from "./admin-guard";
+export { resolveContentAccess } from "./content-access";
+export type {
+  ContentAccessFile,
+  ContentAccessResult,
+} from "./content-access";

--- a/packages/db/src/file.ts
+++ b/packages/db/src/file.ts
@@ -46,6 +46,7 @@ export async function findFileForContentAccess({
               packagePricing: {
                 select: {
                   id: true,
+                  price: true,
                 },
               },
             },
@@ -108,6 +109,7 @@ export async function findFileForApi({
               packagePricing: {
                 select: {
                   id: true,
+                  price: true,
                 },
               },
             },

--- a/packages/db/src/file.ts
+++ b/packages/db/src/file.ts
@@ -73,8 +73,47 @@ export async function findFileForApi({
       name: true,
       mimeType: true,
       userId: true,
+      visibility: true,
       size: true,
       sha256: true,
+      Package: {
+        select: {
+          userId: true,
+          published: true,
+        },
+      },
+      Profile: {
+        select: {
+          userId: true,
+        },
+      },
+      PackageScreenshot: {
+        select: {
+          package: {
+            select: {
+              userId: true,
+              published: true,
+            },
+          },
+        },
+      },
+      Release: {
+        select: {
+          published: true,
+          package: {
+            select: {
+              id: true,
+              userId: true,
+              published: true,
+              packagePricing: {
+                select: {
+                  id: true,
+                },
+              },
+            },
+          },
+        },
+      },
     },
   });
 }

--- a/tests/contract/content-route-security.test.ts
+++ b/tests/contract/content-route-security.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const dbMocks = vi.hoisted(() => ({
+  findFileForContentAccess: vi.fn(),
+  existsUserPaymentHistory: vi.fn(),
+}));
+const authMocks = vi.hoisted(() => ({
+  getSession: vi.fn(),
+  tryGetUserIdFromHeaders: vi.fn(),
+}));
+const bucketMocks = vi.hoisted(() => ({
+  get: vi.fn(),
+}));
+
+vi.mock("@beutl/db", () => dbMocks);
+vi.mock("@beutl/api", () => ({
+  tryGetUserIdFromHeaders: authMocks.tryGetUserIdFromHeaders,
+}));
+vi.mock("@/lib/better-auth", () => ({
+  auth: {
+    api: {
+      getSession: authMocks.getSession,
+    },
+  },
+}));
+vi.mock("@opennextjs/cloudflare", () => ({
+  getCloudflareContext: () => ({
+    env: {
+      BEUTL_R2_BUCKET: bucketMocks,
+    },
+  }),
+}));
+
+import { GET } from "../../apps/web/src/app/api/contents/[fileId]/route";
+
+describe("content route access failures", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    authMocks.getSession.mockResolvedValue(null);
+    authMocks.tryGetUserIdFromHeaders.mockResolvedValue(null);
+    dbMocks.existsUserPaymentHistory.mockResolvedValue(false);
+  });
+
+  it("hides denied file existence behind a no-store 404", async () => {
+    dbMocks.findFileForContentAccess.mockResolvedValue({
+      objectKey: "private/file-1",
+      visibility: "PRIVATE",
+      userId: "owner",
+      mimeType: "application/octet-stream",
+      Package: [],
+      Profile: [],
+      PackageScreenshot: [],
+      Release: [],
+    });
+
+    const response = await GET(
+      new Request("http://localhost/api/contents/file-1") as Parameters<typeof GET>[0],
+      { params: Promise.resolve({ fileId: "file-1" }) },
+    );
+
+    expect(response.status).toBe(404);
+    expect(await response.json()).toEqual({
+      message: "ファイルが見つかりません",
+    });
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
+    expect(response.headers.get("Vary")).toBe("Cookie, Authorization");
+    expect(bucketMocks.get).not.toHaveBeenCalled();
+  });
+});

--- a/tests/contract/file-access-security.test.ts
+++ b/tests/contract/file-access-security.test.ts
@@ -96,6 +96,8 @@ describe("v3 file metadata access", () => {
     const response = await requestFile(OWNER_ID);
 
     expect(response.status).toBe(200);
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
+    expect(response.headers.get("Vary")).toBe("Authorization");
     expect(await response.json()).toEqual({
       id: "file-1",
       name: "asset.beutl",

--- a/tests/contract/file-access-security.test.ts
+++ b/tests/contract/file-access-security.test.ts
@@ -1,0 +1,215 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Hono } from "hono";
+import { sign } from "hono/jwt";
+
+const dbMocks = vi.hoisted(() => ({
+  findFileForApi: vi.fn(),
+  existsUserPaymentHistory: vi.fn(),
+}));
+
+vi.mock("@beutl/db", () => dbMocks);
+
+import files from "../../packages/api/src/v3/files";
+
+const JWT_SECRET = "file-access-test-secret";
+const OWNER_ID = "file-owner";
+const OTHER_USER_ID = "other-user";
+
+type FileRecord = {
+  id: string;
+  name: string;
+  mimeType: string;
+  userId: string;
+  visibility: "PUBLIC" | "PRIVATE" | "DEDICATED";
+  size: bigint;
+  sha256: string;
+  Package: Array<{ userId: string; published: boolean }>;
+  Profile: Array<{ userId: string }>;
+  PackageScreenshot: Array<{
+    package: { userId: string; published: boolean };
+  }>;
+  Release: Array<{
+    published: boolean;
+    package: {
+      id: string;
+      userId: string;
+      published: boolean;
+      packagePricing: Array<{ id: string }>;
+    };
+  }>;
+};
+
+function fileRecord(overrides: Partial<FileRecord> = {}): FileRecord {
+  return {
+    id: "file-1",
+    name: "asset.beutl",
+    mimeType: "application/octet-stream",
+    userId: OWNER_ID,
+    visibility: "PRIVATE",
+    size: 42n,
+    sha256: "abc123",
+    Package: [],
+    Profile: [],
+    PackageScreenshot: [],
+    Release: [],
+    ...overrides,
+  };
+}
+
+function makeApp() {
+  return new Hono().route("/api/v3/files", files);
+}
+
+async function authorization(userId: string) {
+  const token = await sign(
+    {
+      "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier":
+        userId,
+      exp: Math.floor(Date.now() / 1000) + 300,
+    },
+    JWT_SECRET,
+    "HS256",
+  );
+  return { Authorization: `Bearer ${token}` };
+}
+
+async function requestFile(userId?: string) {
+  return await makeApp().request("/api/v3/files/file-1", {
+    headers: userId ? await authorization(userId) : undefined,
+  });
+}
+
+describe("v3 file metadata access", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.JWT_SECRET = JWT_SECRET;
+    dbMocks.existsUserPaymentHistory.mockResolvedValue(false);
+  });
+
+  afterEach(() => {
+    delete process.env.JWT_SECRET;
+  });
+
+  it("returns private metadata to its owner", async () => {
+    dbMocks.findFileForApi.mockResolvedValue(fileRecord());
+
+    const response = await requestFile(OWNER_ID);
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      id: "file-1",
+      name: "asset.beutl",
+      contentType: "application/octet-stream",
+      downloadUrl: "http://localhost/api/contents/file-1",
+      size: 42,
+      sha256: "abc123",
+    });
+  });
+
+  it("does not enumerate private metadata to other callers", async () => {
+    dbMocks.findFileForApi.mockResolvedValue(fileRecord());
+
+    const [otherResponse, anonymousResponse] = await Promise.all([
+      requestFile(OTHER_USER_ID),
+      requestFile(),
+    ]);
+
+    expect(otherResponse.status).toBe(404);
+    expect(anonymousResponse.status).toBe(404);
+    expect(await otherResponse.json()).toMatchObject({
+      error_code: "assetNotFound",
+    });
+    expect(await anonymousResponse.json()).toMatchObject({
+      error_code: "assetNotFound",
+    });
+  });
+
+  it("keeps explicitly public metadata available anonymously", async () => {
+    dbMocks.findFileForApi.mockResolvedValue(
+      fileRecord({ visibility: "PUBLIC" }),
+    );
+
+    expect((await requestFile()).status).toBe(200);
+  });
+
+  it("keeps published package and free release metadata available", async () => {
+    dbMocks.findFileForApi
+      .mockResolvedValueOnce(
+        fileRecord({
+          visibility: "DEDICATED",
+          Package: [{ userId: OWNER_ID, published: true }],
+        }),
+      )
+      .mockResolvedValueOnce(
+        fileRecord({
+          visibility: "DEDICATED",
+          Release: [
+            {
+              published: true,
+              package: {
+                id: "package-1",
+                userId: OWNER_ID,
+                published: true,
+                packagePricing: [],
+              },
+            },
+          ],
+        }),
+      );
+
+    expect((await requestFile()).status).toBe(200);
+    expect((await requestFile()).status).toBe(200);
+  });
+
+  it("requires payment for a paid release but allows its owner", async () => {
+    dbMocks.findFileForApi.mockResolvedValue(
+      fileRecord({
+        visibility: "DEDICATED",
+        Release: [
+          {
+            published: true,
+            package: {
+              id: "paid-package",
+              userId: OWNER_ID,
+              published: true,
+              packagePricing: [{ id: "price-1" }],
+            },
+          },
+        ],
+      }),
+    );
+
+    expect((await requestFile()).status).toBe(403);
+    expect((await requestFile(OTHER_USER_ID)).status).toBe(403);
+    expect((await requestFile(OWNER_ID)).status).toBe(200);
+
+    dbMocks.existsUserPaymentHistory.mockResolvedValue(true);
+    expect((await requestFile(OTHER_USER_ID)).status).toBe(200);
+    expect(dbMocks.existsUserPaymentHistory).toHaveBeenCalledWith({
+      userId: OTHER_USER_ID,
+      packageId: "paid-package",
+    });
+  });
+
+  it("hides unpublished dedicated metadata from non-owners", async () => {
+    dbMocks.findFileForApi.mockResolvedValue(
+      fileRecord({
+        visibility: "DEDICATED",
+        Release: [
+          {
+            published: false,
+            package: {
+              id: "draft-package",
+              userId: OWNER_ID,
+              published: false,
+              packagePricing: [],
+            },
+          },
+        ],
+      }),
+    );
+
+    expect((await requestFile(OTHER_USER_ID)).status).toBe(404);
+    expect((await requestFile(OWNER_ID)).status).toBe(200);
+  });
+});

--- a/tests/contract/file-access-security.test.ts
+++ b/tests/contract/file-access-security.test.ts
@@ -34,7 +34,7 @@ type FileRecord = {
       id: string;
       userId: string;
       published: boolean;
-      packagePricing: Array<{ id: string }>;
+      packagePricing: Array<{ id: string; price: number }>;
     };
   }>;
 };
@@ -161,6 +161,28 @@ describe("v3 file metadata access", () => {
     expect((await requestFile()).status).toBe(200);
   });
 
+  it("keeps an all-zero-priced release available anonymously", async () => {
+    dbMocks.findFileForApi.mockResolvedValue(
+      fileRecord({
+        visibility: "DEDICATED",
+        Release: [
+          {
+            published: true,
+            package: {
+              id: "zero-priced-package",
+              userId: OWNER_ID,
+              published: true,
+              packagePricing: [{ id: "zero-price", price: 0 }],
+            },
+          },
+        ],
+      }),
+    );
+
+    expect((await requestFile()).status).toBe(200);
+    expect(dbMocks.existsUserPaymentHistory).not.toHaveBeenCalled();
+  });
+
   it("requires payment for a paid release but allows its owner", async () => {
     dbMocks.findFileForApi.mockResolvedValue(
       fileRecord({
@@ -172,7 +194,7 @@ describe("v3 file metadata access", () => {
               id: "paid-package",
               userId: OWNER_ID,
               published: true,
-              packagePricing: [{ id: "price-1" }],
+              packagePricing: [{ id: "price-1", price: 100 }],
             },
           },
         ],

--- a/tests/contract/private-content-cache.test.ts
+++ b/tests/contract/private-content-cache.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+import { resolveContentAccess } from "@beutl/core";
+import { contentCacheHeaders } from "../../apps/web/src/lib/content-cache";
+
+describe("authenticated content caching", () => {
+  it("never stores private content in a reusable browser cache", () => {
+    expect(contentCacheHeaders(false)).toEqual({
+      "Cache-Control": "no-store",
+      Vary: "Cookie, Authorization",
+    });
+  });
+
+  it("keeps explicitly public content immutable", () => {
+    expect(contentCacheHeaders(true)).toEqual({
+      "Cache-Control": "public, max-age=31536000, immutable",
+    });
+  });
+
+  it("does not treat an empty Profile relation as public content", async () => {
+    await expect(
+      resolveContentAccess({
+        file: dedicatedFile(),
+        userId: "other-user",
+        hasPurchasedPackage: async () => false,
+      }),
+    ).resolves.toEqual({ outcome: "denied" });
+  });
+
+  it("keeps actual profile content public", async () => {
+    await expect(
+      resolveContentAccess({
+        file: dedicatedFile({ Profile: [{}] }),
+        userId: null,
+        hasPurchasedPackage: async () => false,
+      }),
+    ).resolves.toEqual({ outcome: "allowed", isPublic: true });
+  });
+
+  it("allows a paid release owner without a purchase record", async () => {
+    let paymentChecks = 0;
+    await expect(
+      resolveContentAccess({
+        file: paidReleaseFile(),
+        userId: "owner",
+        hasPurchasedPackage: async () => {
+          paymentChecks++;
+          return false;
+        },
+      }),
+    ).resolves.toEqual({ outcome: "allowed", isPublic: false });
+    expect(paymentChecks).toBe(0);
+  });
+
+  it("allows purchasers while keeping paid content private", async () => {
+    await expect(
+      resolveContentAccess({
+        file: paidReleaseFile(),
+        userId: "purchaser",
+        hasPurchasedPackage: async (packageId) => packageId === "package-1",
+      }),
+    ).resolves.toEqual({ outcome: "allowed", isPublic: false });
+  });
+
+  it("requires payment for an unpaid published release", async () => {
+    await expect(
+      resolveContentAccess({
+        file: paidReleaseFile(),
+        userId: "other-user",
+        hasPurchasedPackage: async () => false,
+      }),
+    ).resolves.toEqual({ outcome: "payment-required" });
+  });
+});
+
+function dedicatedFile(overrides: Record<string, unknown> = {}) {
+  return {
+    visibility: "DEDICATED" as const,
+    userId: "owner",
+    Package: [],
+    Profile: [],
+    PackageScreenshot: [],
+    Release: [],
+    ...overrides,
+  };
+}
+
+function paidReleaseFile() {
+  return dedicatedFile({
+    Release: [
+      {
+        published: true,
+        package: {
+          id: "package-1",
+          userId: "owner",
+          published: true,
+          packagePricing: [{ id: "price-1" }],
+        },
+      },
+    ],
+  });
+}

--- a/tests/contract/private-content-cache.test.ts
+++ b/tests/contract/private-content-cache.test.ts
@@ -26,6 +26,16 @@ describe("authenticated content caching", () => {
     ).resolves.toEqual({ outcome: "denied" });
   });
 
+  it("allows an orphaned dedicated file owner without public caching", async () => {
+    await expect(
+      resolveContentAccess({
+        file: dedicatedFile(),
+        userId: "owner",
+        hasPurchasedPackage: async () => false,
+      }),
+    ).resolves.toEqual({ outcome: "allowed", canUsePublicCache: false });
+  });
+
   it("keeps actual profile content public", async () => {
     await expect(
       resolveContentAccess({
@@ -33,7 +43,56 @@ describe("authenticated content caching", () => {
         userId: null,
         hasPurchasedPackage: async () => false,
       }),
-    ).resolves.toEqual({ outcome: "allowed", isPublic: true });
+    ).resolves.toEqual({ outcome: "allowed", canUsePublicCache: true });
+  });
+
+  it("allows a free release anonymously without public caching", async () => {
+    const access = await resolveContentAccess({
+      file: freeReleaseFile(),
+      userId: null,
+      hasPurchasedPackage: async () => false,
+    });
+
+    expect(access).toEqual({
+      outcome: "allowed",
+      canUsePublicCache: false,
+    });
+    expect(
+      contentCacheHeaders(
+        access.outcome === "allowed" && access.canUsePublicCache,
+      ),
+    ).toEqual({
+      "Cache-Control": "no-store",
+      Vary: "Cookie, Authorization",
+    });
+  });
+
+  it("allows an all-zero-priced release without a payment record", async () => {
+    let paymentChecks = 0;
+    await expect(
+      resolveContentAccess({
+        file: releaseFile([{ id: "zero-price", price: 0 }]),
+        userId: null,
+        hasPurchasedPackage: async () => {
+          paymentChecks++;
+          return false;
+        },
+      }),
+    ).resolves.toEqual({ outcome: "allowed", canUsePublicCache: false });
+    expect(paymentChecks).toBe(0);
+  });
+
+  it("does not publicly cache an explicitly public release payload", async () => {
+    await expect(
+      resolveContentAccess({
+        file: freeReleaseFile({ visibility: "PUBLIC" }),
+        userId: null,
+        hasPurchasedPackage: async () => false,
+      }),
+    ).resolves.toEqual({
+      outcome: "allowed",
+      canUsePublicCache: false,
+    });
   });
 
   it("allows a paid release owner without a purchase record", async () => {
@@ -47,7 +106,7 @@ describe("authenticated content caching", () => {
           return false;
         },
       }),
-    ).resolves.toEqual({ outcome: "allowed", isPublic: false });
+    ).resolves.toEqual({ outcome: "allowed", canUsePublicCache: false });
     expect(paymentChecks).toBe(0);
   });
 
@@ -58,7 +117,7 @@ describe("authenticated content caching", () => {
         userId: "purchaser",
         hasPurchasedPackage: async (packageId) => packageId === "package-1",
       }),
-    ).resolves.toEqual({ outcome: "allowed", isPublic: false });
+    ).resolves.toEqual({ outcome: "allowed", canUsePublicCache: false });
   });
 
   it("requires payment for an unpaid published release", async () => {
@@ -85,6 +144,17 @@ function dedicatedFile(overrides: Record<string, unknown> = {}) {
 }
 
 function paidReleaseFile() {
+  return releaseFile([{ id: "price-1", price: 100 }]);
+}
+
+function freeReleaseFile(overrides: Record<string, unknown> = {}) {
+  return releaseFile([], overrides);
+}
+
+function releaseFile(
+  packagePricing: Array<{ id: string; price: number }>,
+  overrides: Record<string, unknown> = {},
+) {
   return dedicatedFile({
     Release: [
       {
@@ -93,9 +163,10 @@ function paidReleaseFile() {
           id: "package-1",
           userId: "owner",
           published: true,
-          packagePricing: [{ id: "price-1" }],
+          packagePricing,
         },
       },
     ],
+    ...overrides,
   });
 }

--- a/tests/contract/private-content-cache.test.ts
+++ b/tests/contract/private-content-cache.test.ts
@@ -95,6 +95,28 @@ describe("authenticated content caching", () => {
     });
   });
 
+  it("requires payment for an explicitly public paid release", async () => {
+    await expect(
+      resolveContentAccess({
+        file: paidReleaseFile({ visibility: "PUBLIC" }),
+        userId: null,
+        hasPurchasedPackage: async () => false,
+      }),
+    ).resolves.toEqual({ outcome: "payment-required" });
+  });
+
+  it("requires payment when a paid release has a public package relation", async () => {
+    await expect(
+      resolveContentAccess({
+        file: paidReleaseFile({
+          Package: [{ userId: "owner", published: true }],
+        }),
+        userId: null,
+        hasPurchasedPackage: async () => false,
+      }),
+    ).resolves.toEqual({ outcome: "payment-required" });
+  });
+
   it("allows a paid release owner without a purchase record", async () => {
     let paymentChecks = 0;
     await expect(
@@ -143,8 +165,8 @@ function dedicatedFile(overrides: Record<string, unknown> = {}) {
   };
 }
 
-function paidReleaseFile() {
-  return releaseFile([{ id: "price-1", price: 100 }]);
+function paidReleaseFile(overrides: Record<string, unknown> = {}) {
+  return releaseFile([{ id: "price-1", price: 100 }], overrides);
 }
 
 function freeReleaseFile(overrides: Record<string, unknown> = {}) {


### PR DESCRIPTION
## Summary

- replace the permissive file-metadata check with a shared visibility and ownership policy
- distinguish empty Prisma relations from actual public profile content
- enforce purchase checks for paid release files in both metadata and content routes
- mark every non-public response as `no-store` and vary authenticated responses
- add regression coverage for private metadata, draft content, paid releases, and cache headers

## Root cause

The metadata endpoint used a placeholder authorization result, while the content route treated an empty relation array as truthy and allowed private responses to remain in a long-lived browser cache. The two routes also maintained separate authorization logic that could drift.

## Impact

Private and unpublished file metadata is no longer enumerable by unrelated callers, and authenticated content cannot survive account changes in a reusable browser cache. Explicitly public assets keep immutable caching.

## Checks

- `corepack pnpm test` (28 tests passed)
- `corepack pnpm --filter @beutl/api build`
- `corepack pnpm --filter @beutl/web exec tsc --noEmit`
- `corepack pnpm --filter @beutl/web lint`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added consistent access controls for private, public, dedicated, free, and paid content.
  * Paid content now requires a completed purchase, while owners and authorized viewers retain access.
  * Added appropriate caching behavior for public and private content.

* **Bug Fixes**
  * Prevented unauthorized users from discovering private file metadata.
  * Standardized responses for unavailable and payment-required content.

* **Tests**
  * Added coverage for file access, payment authorization, visibility rules, and cache behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->