### PR TITLE
fix: harden Stripe package payment integrity

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -11,6 +11,7 @@
     "lint": "next lint",
     "dev": "next dev --turbopack",
     "preview": "opennextjs-cloudflare build && opennextjs-cloudflare preview",
+    "reconcile:package-payments": "node --env-file-if-exists=.env scripts/reconcile-package-payments.mjs",
     "deploy": "opennextjs-cloudflare build && opennextjs-cloudflare deploy",
     "upload": "opennextjs-cloudflare build && opennextjs-cloudflare upload",
     "cf-typegen": "wrangler types --env-interface CloudflareEnv worker-configuration.d.ts",

--- a/apps/web/prisma/migrations/20260809171000_track_package_payment_state/migration.sql
+++ b/apps/web/prisma/migrations/20260809171000_track_package_payment_state/migration.sql
@@ -18,14 +18,6 @@ ADD COLUMN "paymentManaged" BOOL NOT NULL DEFAULT true;
 -- Existing paid entitlements and writes from the old Worker during cutover
 -- inherit the backward-compatible true default. The new Worker writes every
 -- fulfillment and reversal value explicitly.
-UPDATE "UserPackage" AS up
-SET "paymentManaged" = true
-WHERE EXISTS (
-  SELECT 1
-  FROM "UserPaymentHistory" AS history
-  WHERE history."userId" = up."userId"
-    AND history."packageId" = up."packageId"
-);
 
 -- Keep one deterministic owner for any legacy Stripe customer that was mapped
 -- to multiple users. Removed users receive a new owned customer on checkout.

--- a/apps/web/prisma/migrations/20260809171000_track_package_payment_state/migration.sql
+++ b/apps/web/prisma/migrations/20260809171000_track_package_payment_state/migration.sql
@@ -2,6 +2,8 @@
 ALTER TABLE "UserPaymentHistory"
 ADD COLUMN "revokedAt" TIMESTAMP(3);
 ALTER TABLE "UserPaymentHistory"
+ADD COLUMN "fulfillmentValidated" BOOL NOT NULL DEFAULT true;
+ALTER TABLE "UserPaymentHistory"
 ADD COLUMN "revocationReason" STRING;
 ALTER TABLE "UserPaymentHistory"
 ADD COLUMN "stripeStateEventId" STRING;
@@ -11,9 +13,11 @@ ALTER TABLE "UserPaymentHistory"
 ADD COLUMN "stripeStateEventRank" INT4 NOT NULL DEFAULT 0;
 
 ALTER TABLE "UserPackage"
-ADD COLUMN "paymentManaged" BOOL NOT NULL DEFAULT false;
+ADD COLUMN "paymentManaged" BOOL NOT NULL DEFAULT true;
 
--- Existing paid entitlements were created by the Stripe webhook.
+-- Existing paid entitlements and writes from the old Worker during cutover
+-- inherit the backward-compatible true default. The new Worker writes every
+-- fulfillment and reversal value explicitly.
 UPDATE "UserPackage" AS up
 SET "paymentManaged" = true
 WHERE EXISTS (

--- a/apps/web/prisma/migrations/20260809171000_track_package_payment_state/migration.sql
+++ b/apps/web/prisma/migrations/20260809171000_track_package_payment_state/migration.sql
@@ -1,0 +1,49 @@
+-- AlterTable
+ALTER TABLE "UserPaymentHistory"
+ADD COLUMN "revokedAt" TIMESTAMP(3);
+ALTER TABLE "UserPaymentHistory"
+ADD COLUMN "revocationReason" STRING;
+ALTER TABLE "UserPaymentHistory"
+ADD COLUMN "stripeStateEventId" STRING;
+ALTER TABLE "UserPaymentHistory"
+ADD COLUMN "stripeStateEventCreatedAt" TIMESTAMP(3);
+ALTER TABLE "UserPaymentHistory"
+ADD COLUMN "stripeStateEventRank" INT4 NOT NULL DEFAULT 0;
+
+ALTER TABLE "UserPackage"
+ADD COLUMN "paymentManaged" BOOL NOT NULL DEFAULT false;
+
+-- Existing paid entitlements were created by the Stripe webhook.
+UPDATE "UserPackage" AS up
+SET "paymentManaged" = true
+WHERE EXISTS (
+  SELECT 1
+  FROM "UserPaymentHistory" AS history
+  WHERE history."userId" = up."userId"
+    AND history."packageId" = up."packageId"
+);
+
+-- Keep one deterministic owner for any legacy Stripe customer that was mapped
+-- to multiple users. Removed users receive a new owned customer on checkout.
+WITH ranked_customer_owners AS (
+  SELECT
+    "userId",
+    row_number() OVER (
+      PARTITION BY "stripeId"
+      ORDER BY "createdAt", "userId"
+    ) AS owner_rank
+  FROM "Customer"
+)
+DELETE FROM "Customer"
+WHERE "userId" IN (
+  SELECT "userId"
+  FROM ranked_customer_owners
+  WHERE owner_rank > 1
+);
+
+-- CreateIndex
+CREATE INDEX "UserPaymentHistory_userId_packageId_revokedAt_idx"
+ON "UserPaymentHistory"("userId", "packageId", "revokedAt");
+
+CREATE UNIQUE INDEX "Customer_stripeId_key"
+ON "Customer"("stripeId");

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -182,20 +182,26 @@ model PackagePricing {
 }
 
 model UserPaymentHistory {
-  id        String   @id @default(uuid())
-  userId    String
-  paymentId String   @unique
-  packageId String
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
-  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  id                        String    @id @default(uuid())
+  userId                    String
+  paymentId                 String    @unique
+  packageId                 String
+  revokedAt                 DateTime?
+  revocationReason          String?
+  stripeStateEventId        String?
+  stripeStateEventCreatedAt DateTime?
+  stripeStateEventRank      Int       @default(0)
+  createdAt                 DateTime  @default(now())
+  updatedAt                 DateTime  @updatedAt
+  user                      User      @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@index([userId])
+  @@index([userId, packageId, revokedAt])
 }
 
 model Customer {
   userId    String   @id
-  stripeId  String
+  stripeId  String   @unique
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
   user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
@@ -214,11 +220,12 @@ model PackageScreenshot {
 }
 
 model UserPackage {
-  userId    String
-  packageId String
-  createdAt DateTime @default(now())
-  package   Package  @relation(fields: [packageId], references: [id], onDelete: Cascade)
-  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  userId         String
+  packageId      String
+  paymentManaged Boolean  @default(false)
+  createdAt      DateTime @default(now())
+  package        Package  @relation(fields: [packageId], references: [id], onDelete: Cascade)
+  user           User     @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@id([userId, packageId])
   @@index([packageId])

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -186,6 +186,7 @@ model UserPaymentHistory {
   userId                    String
   paymentId                 String    @unique
   packageId                 String
+  fulfillmentValidated      Boolean   @default(true)
   revokedAt                 DateTime?
   revocationReason          String?
   stripeStateEventId        String?
@@ -222,7 +223,7 @@ model PackageScreenshot {
 model UserPackage {
   userId         String
   packageId      String
-  paymentManaged Boolean  @default(false)
+  paymentManaged Boolean  @default(true)
   createdAt      DateTime @default(now())
   package        Package  @relation(fields: [packageId], references: [id], onDelete: Cascade)
   user           User     @relation(fields: [userId], references: [id], onDelete: Cascade)

--- a/apps/web/scripts/reconcile-package-payments.mjs
+++ b/apps/web/scripts/reconcile-package-payments.mjs
@@ -1,0 +1,198 @@
+import { pathToFileURL } from "node:url";
+import { PrismaPg } from "@prisma/adapter-pg";
+import { PrismaClient } from "@prisma/client";
+import Stripe from "stripe";
+
+const EVENT_RANK = {
+  disputeRestored: 20,
+  disputeRevoked: 30,
+  refundSucceeded: 40,
+};
+const REVOKED_DISPUTE_STATUSES = new Set([
+  "needs_response",
+  "under_review",
+  "lost",
+]);
+
+export function classifyHistoricalPackagePayment({
+  paymentIntent,
+  refunds,
+  disputes,
+}) {
+  const refund = refunds
+    .filter((item) => item.status === "succeeded")
+    .sort((left, right) => right.created - left.created)[0];
+  if (refund) {
+    return {
+      rank: EVENT_RANK.refundSucceeded,
+      reason: `historical refund succeeded: ${refund.id}`,
+      sourceId: refund.id,
+      sourceKind: "refund",
+    };
+  }
+
+  const dispute = disputes
+    .filter((item) => REVOKED_DISPUTE_STATUSES.has(item.status))
+    .sort((left, right) => {
+      const leftRank = left.status === "lost" ? 1 : 0;
+      const rightRank = right.status === "lost" ? 1 : 0;
+      return rightRank - leftRank || right.created - left.created;
+    })[0];
+  if (dispute) {
+    return {
+      rank: EVENT_RANK.disputeRevoked,
+      reason: `historical dispute ${dispute.status}: ${dispute.id}`,
+      sourceId: dispute.id,
+      sourceKind: "dispute",
+    };
+  }
+
+  if (paymentIntent.status !== "succeeded") {
+    return {
+      rank: EVENT_RANK.refundSucceeded,
+      reason: `historical PaymentIntent status: ${paymentIntent.status}`,
+      sourceId: paymentIntent.id,
+      sourceKind: "payment-intent",
+    };
+  }
+  return null;
+}
+
+async function main() {
+  const apply = process.argv.includes("--apply");
+  const connectionString = process.env.DATABASE_URL;
+  const stripeSecret = process.env.STRIPE_SECRET_KEY;
+  if (!connectionString || !stripeSecret) {
+    throw new Error("DATABASE_URL and STRIPE_SECRET_KEY are required");
+  }
+
+  const adapter = new PrismaPg({ connectionString });
+  const prisma = new PrismaClient({ adapter });
+  const stripe = new Stripe(stripeSecret, {
+    httpClient: Stripe.createFetchHttpClient(),
+  });
+  let cursor = "";
+  let inspected = 0;
+  let candidates = 0;
+  let revoked = 0;
+
+  try {
+    for (;;) {
+      const histories = await prisma.userPaymentHistory.findMany({
+        where: {
+          revokedAt: null,
+          ...(cursor ? { paymentId: { gt: cursor } } : {}),
+        },
+        orderBy: { paymentId: "asc" },
+        take: 100,
+        select: {
+          paymentId: true,
+          packageId: true,
+          userId: true,
+        },
+      });
+      if (histories.length === 0) {
+        break;
+      }
+
+      for (const history of histories) {
+        cursor = history.paymentId;
+        inspected++;
+        const [paymentIntent, refunds, disputes] = await Promise.all([
+          stripe.paymentIntents.retrieve(history.paymentId),
+          stripe.refunds.list({
+            payment_intent: history.paymentId,
+            limit: 100,
+          }).autoPagingToArray({ limit: 1_000 }),
+          stripe.disputes.list({
+            payment_intent: history.paymentId,
+            limit: 100,
+          }).autoPagingToArray({ limit: 1_000 }),
+        ]);
+        let candidate = classifyHistoricalPackagePayment({
+          paymentIntent,
+          refunds,
+          disputes,
+        });
+        if (!candidate) {
+          continue;
+        }
+        candidates++;
+        console.log(
+          `${apply ? "REVOKE" : "WOULD_REVOKE"} ${history.paymentId}: ${candidate.reason}`,
+        );
+        if (!apply) {
+          continue;
+        }
+
+        if (candidate.sourceKind === "dispute") {
+          const currentDispute = await stripe.disputes.retrieve(
+            candidate.sourceId,
+          );
+          candidate = classifyHistoricalPackagePayment({
+            paymentIntent,
+            refunds,
+            disputes: [currentDispute],
+          });
+          if (!candidate) {
+            continue;
+          }
+        }
+
+        const observedAt = new Date();
+        const changed = await prisma.$transaction(async (tx) => {
+          const current = await tx.userPaymentHistory.findUnique({
+            where: { paymentId: history.paymentId },
+            select: { revokedAt: true },
+          });
+          if (!current || current.revokedAt) {
+            return false;
+          }
+          await tx.userPaymentHistory.update({
+            where: { paymentId: history.paymentId },
+            data: {
+              revokedAt: observedAt,
+              revocationReason: candidate.reason,
+              stripeStateEventId: `reconcile:${candidate.sourceId}`,
+              stripeStateEventCreatedAt: observedAt,
+              stripeStateEventRank: candidate.rank,
+            },
+          });
+          const activePayments = await tx.userPaymentHistory.count({
+            where: {
+              userId: history.userId,
+              packageId: history.packageId,
+              revokedAt: null,
+            },
+          });
+          if (activePayments === 0) {
+            await tx.userPackage.deleteMany({
+              where: {
+                userId: history.userId,
+                packageId: history.packageId,
+                paymentManaged: true,
+              },
+            });
+          }
+          return true;
+        });
+        if (changed) {
+          revoked++;
+        }
+      }
+    }
+  } finally {
+    await prisma.$disconnect();
+  }
+
+  console.log(
+    JSON.stringify({ apply, inspected, candidates, revoked }, null, 2),
+  );
+}
+
+const entryPoint = process.argv[1]
+  ? pathToFileURL(process.argv[1]).href
+  : null;
+if (entryPoint === import.meta.url) {
+  await main();
+}

--- a/apps/web/scripts/reconcile-package-payments.mjs
+++ b/apps/web/scripts/reconcile-package-payments.mjs
@@ -4,8 +4,8 @@ import { PrismaClient } from "@prisma/client";
 import Stripe from "stripe";
 
 const EVENT_RANK = {
-  disputeRestored: 20,
-  disputeRevoked: 30,
+  disputeRevoked: 20,
+  disputeRestored: 30,
   refundSucceeded: 40,
 };
 const REVOKED_DISPUTE_STATUSES = new Set([
@@ -27,6 +27,7 @@ export function classifyHistoricalPackagePayment({
       rank: EVENT_RANK.refundSucceeded,
       reason: `historical refund succeeded: ${refund.id}`,
       sourceId: refund.id,
+      sourceCreated: refund.created,
       sourceKind: "refund",
     };
   }
@@ -43,6 +44,7 @@ export function classifyHistoricalPackagePayment({
       rank: EVENT_RANK.disputeRevoked,
       reason: `historical dispute ${dispute.status}: ${dispute.id}`,
       sourceId: dispute.id,
+      sourceCreated: dispute.created,
       sourceKind: "dispute",
     };
   }
@@ -52,10 +54,51 @@ export function classifyHistoricalPackagePayment({
       rank: EVENT_RANK.refundSucceeded,
       reason: `historical PaymentIntent status: ${paymentIntent.status}`,
       sourceId: paymentIntent.id,
+      sourceCreated: paymentIntent.created,
       sourceKind: "payment-intent",
     };
   }
   return null;
+}
+
+export function historicalStateEvent(candidate, observedAt = new Date()) {
+  const createdAt =
+    candidate.sourceKind === "refund"
+      ? observedAt
+      : new Date(candidate.sourceCreated * 1_000);
+  if (
+    (candidate.sourceKind !== "refund" &&
+      !Number.isSafeInteger(candidate.sourceCreated)) ||
+    Number.isNaN(createdAt.getTime())
+  ) {
+    throw new TypeError("Historical Stripe state timestamp is invalid");
+  }
+  return {
+    id: `reconcile:${candidate.sourceId}`,
+    createdAt,
+    rank: candidate.rank,
+  };
+}
+
+export function isHistoricalStateEventNewer(current, incoming) {
+  if (
+    current.stripeStateEventRank === EVENT_RANK.refundSucceeded &&
+    incoming.rank < EVENT_RANK.refundSucceeded
+  ) {
+    return false;
+  }
+  if (!current.stripeStateEventCreatedAt) {
+    return true;
+  }
+  const currentTime = current.stripeStateEventCreatedAt.getTime();
+  const incomingTime = incoming.createdAt.getTime();
+  if (incomingTime !== currentTime) {
+    return incomingTime > currentTime;
+  }
+  if (incoming.rank !== current.stripeStateEventRank) {
+    return incoming.rank > current.stripeStateEventRank;
+  }
+  return incoming.id > (current.stripeStateEventId ?? "");
 }
 
 async function main() {
@@ -80,6 +123,7 @@ async function main() {
     for (;;) {
       const histories = await prisma.userPaymentHistory.findMany({
         where: {
+          fulfillmentValidated: true,
           revokedAt: null,
           ...(cursor ? { paymentId: { gt: cursor } } : {}),
         },
@@ -139,29 +183,39 @@ async function main() {
           }
         }
 
-        const observedAt = new Date();
+        const stateEvent = historicalStateEvent(candidate);
         const changed = await prisma.$transaction(async (tx) => {
           const current = await tx.userPaymentHistory.findUnique({
             where: { paymentId: history.paymentId },
-            select: { revokedAt: true },
+            select: {
+              revokedAt: true,
+              stripeStateEventId: true,
+              stripeStateEventCreatedAt: true,
+              stripeStateEventRank: true,
+            },
           });
-          if (!current || current.revokedAt) {
+          if (
+            !current ||
+            current.revokedAt ||
+            !isHistoricalStateEventNewer(current, stateEvent)
+          ) {
             return false;
           }
           await tx.userPaymentHistory.update({
             where: { paymentId: history.paymentId },
             data: {
-              revokedAt: observedAt,
+              revokedAt: stateEvent.createdAt,
               revocationReason: candidate.reason,
-              stripeStateEventId: `reconcile:${candidate.sourceId}`,
-              stripeStateEventCreatedAt: observedAt,
-              stripeStateEventRank: candidate.rank,
+              stripeStateEventId: stateEvent.id,
+              stripeStateEventCreatedAt: stateEvent.createdAt,
+              stripeStateEventRank: stateEvent.rank,
             },
           });
           const activePayments = await tx.userPaymentHistory.count({
             where: {
               userId: history.userId,
               packageId: history.packageId,
+              fulfillmentValidated: true,
               revokedAt: null,
             },
           });

--- a/apps/web/src/app/[lang]/(manage-account)/account/manage/email/actions.ts
+++ b/apps/web/src/app/[lang]/(manage-account)/account/manage/email/actions.ts
@@ -13,7 +13,7 @@ import {
   existsUserById,
   updateUserEmail,
 } from "@beutl/db";
-import { updateCustomerEmailIfExist } from "@/lib/customer";
+import { synchronizeMappedStripeCustomer } from "@/lib/customer";
 import { startTransaction } from "@beutl/db";
 import { addAuditLog, auditLogActions } from "@/lib/audit-log";
 import {
@@ -128,7 +128,7 @@ export async function updateEmail(token: string, identifier: string) {
       prisma: p,
     });
 
-    await updateCustomerEmailIfExist({
+    await synchronizeMappedStripeCustomer({
       userId: tokenData.userId,
       email: tokenData.identifier,
       prisma: p,

--- a/apps/web/src/app/[lang]/(store)/store/[name]/actions.tsx
+++ b/apps/web/src/app/[lang]/(store)/store/[name]/actions.tsx
@@ -42,10 +42,14 @@ export async function addToLibrary(packageId: string) {
       packageId: pkg.id,
     }))
   ) {
-    await createUserPackage({
+    const userPackage = await createUserPackage({
       userId: session.user.id,
       packageId: pkg.id,
+      requireActivePayment: pkg.packagePricing.length > 0,
     });
+    if (!userPackage) {
+      redirect(`/${lang}/store/${pkg.name}/checkout`);
+    }
     await addAuditLog({
       userId: session.user.id,
       action: auditLogActions.store.addToLibrary,

--- a/apps/web/src/app/[lang]/(store)/store/[name]/checkout/complete/components.tsx
+++ b/apps/web/src/app/[lang]/(store)/store/[name]/checkout/complete/components.tsx
@@ -26,6 +26,11 @@ async function getStatusContent(
       text: t("store:orderRefunded"),
       icon: () => <Info className="min-w-9 min-h-9 text-gray-500" />,
     },
+    revoked: {
+      title: t("store:paymentRevoked"),
+      text: t("store:orderRevoked"),
+      icon: () => <Info className="min-w-9 min-h-9 text-gray-500" />,
+    },
     requires_payment_method: {
       title: t("error"),
       text: t("store:paymentFailed"),

--- a/apps/web/src/app/[lang]/(store)/store/[name]/checkout/complete/components.tsx
+++ b/apps/web/src/app/[lang]/(store)/store/[name]/checkout/complete/components.tsx
@@ -2,10 +2,11 @@ import { getTranslation } from "@beutl/i18n";
 import { Button } from "@/components/ui/button";
 import { CheckCircle, CircleSlash, Info } from "lucide-react";
 import Link from "next/link";
-import Stripe from "stripe";
+import type { PackageCheckoutCompletionStatus } from "./status";
+import { CompletionStatusPoller } from "./status-poller";
 
 async function getStatusContent(
-  status: Stripe.PaymentIntent["status"],
+  status: PackageCheckoutCompletionStatus,
   t: Awaited<ReturnType<typeof getTranslation>>["t"],
 ) {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -20,6 +21,11 @@ async function getStatusContent(
       text: t("store:orderProcessing"),
       icon: () => <Info className="min-w-9 min-h-9 text-gray-500" />,
     },
+    refunded: {
+      title: t("store:paymentRefunded"),
+      text: t("store:orderRefunded"),
+      icon: () => <Info className="min-w-9 min-h-9 text-gray-500" />,
+    },
     requires_payment_method: {
       title: t("error"),
       text: t("store:paymentFailed"),
@@ -32,7 +38,7 @@ async function getStatusContent(
     },
   };
 
-  return STATUS_CONTENT_MAP[status];
+  return STATUS_CONTENT_MAP[status] ?? STATUS_CONTENT_MAP.default;
 }
 
 export async function ClientPage({
@@ -42,12 +48,13 @@ export async function ClientPage({
 }: {
   lang: string;
   name: string;
-  status: Stripe.PaymentIntent["status"];
+  status: PackageCheckoutCompletionStatus;
 }) {
   const { t } = await getTranslation(lang);
   const statusContent = await getStatusContent(status, t);
   return (
     <div className="h-full flex flex-col justify-between gap-6">
+      <CompletionStatusPoller status={status} />
       <div>
         <div className="flex gap-2 items-center">
           {statusContent.icon()}

--- a/apps/web/src/app/[lang]/(store)/store/[name]/checkout/complete/page.tsx
+++ b/apps/web/src/app/[lang]/(store)/store/[name]/checkout/complete/page.tsx
@@ -1,8 +1,11 @@
+import { authOrSignIn } from "@/lib/auth-guard";
 import { createStripe } from "@/lib/stripe/config";
+import { isOwnedPackagePaymentIntent } from "@/lib/stripe/store-checkout";
 import { ClientPage } from "./components";
 import { notFound } from "next/navigation";
 import { PackageDetails } from "../components";
 import { retrievePackage } from "@/lib/store-utils";
+import { findCustomerByUserId } from "@beutl/db";
 
 export default async function Page(
   props: {
@@ -23,6 +26,7 @@ export default async function Page(
     lang
   } = params;
 
+  const session = await authOrSignIn();
   const pkg = await retrievePackage(name);
   if (!pkg) {
     notFound();
@@ -30,6 +34,17 @@ export default async function Page(
 
   const stripe = createStripe();
   const intent = await stripe.paymentIntents.retrieve(payment_intent);
+  const customer = await findCustomerByUserId({ userId: session.user.id });
+  if (
+    !customer ||
+    !isOwnedPackagePaymentIntent(intent, {
+      customerId: customer.stripeId,
+      userId: session.user.id,
+      packageId: pkg.id,
+    })
+  ) {
+    notFound();
+  }
 
   return (
     <div className="max-w-5xl mx-auto py-10 lg:py-6 px-2 bg-card lg:rounded-lg border text-card-foreground lg:my-4">

--- a/apps/web/src/app/[lang]/(store)/store/[name]/checkout/complete/page.tsx
+++ b/apps/web/src/app/[lang]/(store)/store/[name]/checkout/complete/page.tsx
@@ -5,7 +5,11 @@ import { ClientPage } from "./components";
 import { notFound } from "next/navigation";
 import { PackageDetails } from "../components";
 import { retrievePackage } from "@/lib/store-utils";
-import { findCustomerByUserId } from "@beutl/db";
+import {
+  findCustomerByUserId,
+  findPackagePaymentReference,
+} from "@beutl/db";
+import { resolvePackageCheckoutCompletionStatus } from "./status";
 
 export default async function Page(
   props: {
@@ -45,6 +49,13 @@ export default async function Page(
   ) {
     notFound();
   }
+  const payment = await findPackagePaymentReference({
+    paymentId: intent.id,
+  });
+  const status = resolvePackageCheckoutCompletionStatus(
+    intent.status,
+    payment,
+  );
 
   return (
     <div className="max-w-5xl mx-auto py-10 lg:py-6 px-2 bg-card lg:rounded-lg border text-card-foreground lg:my-4">
@@ -59,7 +70,7 @@ export default async function Page(
         </div>
         <div className="border max-md:h-[1px] md:w-[1px]" />
         <div className="md:flex-1 mx-2 max-md:mt-4">
-          <ClientPage status={intent.status} name={name} lang={lang} />
+          <ClientPage status={status} name={name} lang={lang} />
         </div>
       </div>
     </div>

--- a/apps/web/src/app/[lang]/(store)/store/[name]/checkout/complete/page.tsx
+++ b/apps/web/src/app/[lang]/(store)/store/[name]/checkout/complete/page.tsx
@@ -14,7 +14,9 @@ import { resolvePackageCheckoutCompletionStatus } from "./status";
 export default async function Page(
   props: {
     params: Promise<{ name: string; lang: string }>;
-    searchParams: Promise<{ payment_intent: string }>;
+    searchParams: Promise<{
+      payment_intent?: string | string[];
+    }>;
   }
 ) {
   const searchParams = await props.searchParams;
@@ -32,7 +34,7 @@ export default async function Page(
 
   const session = await authOrSignIn();
   const pkg = await retrievePackage(name);
-  if (!pkg) {
+  if (!pkg || typeof payment_intent !== "string" || !payment_intent) {
     notFound();
   }
 

--- a/apps/web/src/app/[lang]/(store)/store/[name]/checkout/complete/polling.ts
+++ b/apps/web/src/app/[lang]/(store)/store/[name]/checkout/complete/polling.ts
@@ -1,7 +1,12 @@
 import type { PackageCheckoutCompletionStatus } from "./status";
 
-export const PACKAGE_CHECKOUT_POLL_INTERVAL_MS = 2_000;
+export const PACKAGE_CHECKOUT_POLL_INITIAL_INTERVAL_MS = 1_000;
+export const PACKAGE_CHECKOUT_POLL_MAX_INTERVAL_MS = 8_000;
 export const PACKAGE_CHECKOUT_POLL_TIMEOUT_MS = 30_000;
+
+export function nextPackageCheckoutPollInterval(interval: number): number {
+  return Math.min(interval * 2, PACKAGE_CHECKOUT_POLL_MAX_INTERVAL_MS);
+}
 
 export function shouldPollPackageCheckoutCompletionStatus(
   status: PackageCheckoutCompletionStatus,

--- a/apps/web/src/app/[lang]/(store)/store/[name]/checkout/complete/polling.ts
+++ b/apps/web/src/app/[lang]/(store)/store/[name]/checkout/complete/polling.ts
@@ -1,0 +1,10 @@
+import type { PackageCheckoutCompletionStatus } from "./status";
+
+export const PACKAGE_CHECKOUT_POLL_INTERVAL_MS = 2_000;
+export const PACKAGE_CHECKOUT_POLL_TIMEOUT_MS = 30_000;
+
+export function shouldPollPackageCheckoutCompletionStatus(
+  status: PackageCheckoutCompletionStatus,
+): boolean {
+  return status === "processing";
+}

--- a/apps/web/src/app/[lang]/(store)/store/[name]/checkout/complete/status-poller.tsx
+++ b/apps/web/src/app/[lang]/(store)/store/[name]/checkout/complete/status-poller.tsx
@@ -3,7 +3,8 @@
 import { useEffect, useRef } from "react";
 import { useRouter } from "next/navigation";
 import {
-  PACKAGE_CHECKOUT_POLL_INTERVAL_MS,
+  nextPackageCheckoutPollInterval,
+  PACKAGE_CHECKOUT_POLL_INITIAL_INTERVAL_MS,
   PACKAGE_CHECKOUT_POLL_TIMEOUT_MS,
   shouldPollPackageCheckoutCompletionStatus,
 } from "./polling";
@@ -25,16 +26,18 @@ export function CompletionStatusPoller({
 
     const startedAt = startedAtRef.current ?? Date.now();
     startedAtRef.current = startedAt;
+    let interval = PACKAGE_CHECKOUT_POLL_INITIAL_INTERVAL_MS;
     let timeoutId: number;
     const poll = () => {
       if (Date.now() - startedAt >= PACKAGE_CHECKOUT_POLL_TIMEOUT_MS) {
         return;
       }
       router.refresh();
-      timeoutId = window.setTimeout(poll, PACKAGE_CHECKOUT_POLL_INTERVAL_MS);
+      interval = nextPackageCheckoutPollInterval(interval);
+      timeoutId = window.setTimeout(poll, interval);
     };
 
-    timeoutId = window.setTimeout(poll, PACKAGE_CHECKOUT_POLL_INTERVAL_MS);
+    timeoutId = window.setTimeout(poll, interval);
     return () => window.clearTimeout(timeoutId);
   }, [router, status]);
 

--- a/apps/web/src/app/[lang]/(store)/store/[name]/checkout/complete/status-poller.tsx
+++ b/apps/web/src/app/[lang]/(store)/store/[name]/checkout/complete/status-poller.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { useRouter } from "next/navigation";
+import {
+  PACKAGE_CHECKOUT_POLL_INTERVAL_MS,
+  PACKAGE_CHECKOUT_POLL_TIMEOUT_MS,
+  shouldPollPackageCheckoutCompletionStatus,
+} from "./polling";
+import type { PackageCheckoutCompletionStatus } from "./status";
+
+export function CompletionStatusPoller({
+  status,
+}: {
+  status: PackageCheckoutCompletionStatus;
+}) {
+  const router = useRouter();
+  const startedAtRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    if (!shouldPollPackageCheckoutCompletionStatus(status)) {
+      startedAtRef.current = null;
+      return;
+    }
+
+    const startedAt = startedAtRef.current ?? Date.now();
+    startedAtRef.current = startedAt;
+    let timeoutId: number;
+    const poll = () => {
+      if (Date.now() - startedAt >= PACKAGE_CHECKOUT_POLL_TIMEOUT_MS) {
+        return;
+      }
+      router.refresh();
+      timeoutId = window.setTimeout(poll, PACKAGE_CHECKOUT_POLL_INTERVAL_MS);
+    };
+
+    timeoutId = window.setTimeout(poll, PACKAGE_CHECKOUT_POLL_INTERVAL_MS);
+    return () => window.clearTimeout(timeoutId);
+  }, [router, status]);
+
+  return null;
+}

--- a/apps/web/src/app/[lang]/(store)/store/[name]/checkout/complete/status.ts
+++ b/apps/web/src/app/[lang]/(store)/store/[name]/checkout/complete/status.ts
@@ -1,0 +1,28 @@
+import {
+  PACKAGE_PAYMENT_EVENT_RANK,
+  type PackagePaymentRecord,
+} from "@beutl/db";
+import type Stripe from "stripe";
+
+export type PackageCheckoutCompletionStatus =
+  | Stripe.PaymentIntent.Status
+  | "refunded";
+
+export function resolvePackageCheckoutCompletionStatus(
+  paymentIntentStatus: Stripe.PaymentIntent.Status,
+  payment: PackagePaymentRecord | null,
+): PackageCheckoutCompletionStatus {
+  if (paymentIntentStatus !== "succeeded") {
+    return paymentIntentStatus;
+  }
+  if (payment?.fulfillmentValidated && !payment.revokedAt) {
+    return "succeeded";
+  }
+  if (
+    payment?.revokedAt &&
+    payment.stripeStateEventRank === PACKAGE_PAYMENT_EVENT_RANK.refundSucceeded
+  ) {
+    return "refunded";
+  }
+  return "processing";
+}

--- a/apps/web/src/app/[lang]/(store)/store/[name]/checkout/complete/status.ts
+++ b/apps/web/src/app/[lang]/(store)/store/[name]/checkout/complete/status.ts
@@ -6,7 +6,8 @@ import type Stripe from "stripe";
 
 export type PackageCheckoutCompletionStatus =
   | Stripe.PaymentIntent.Status
-  | "refunded";
+  | "refunded"
+  | "revoked";
 
 export function resolvePackageCheckoutCompletionStatus(
   paymentIntentStatus: Stripe.PaymentIntent.Status,
@@ -18,11 +19,11 @@ export function resolvePackageCheckoutCompletionStatus(
   if (payment?.fulfillmentValidated && !payment.revokedAt) {
     return "succeeded";
   }
-  if (
-    payment?.revokedAt &&
-    payment.stripeStateEventRank === PACKAGE_PAYMENT_EVENT_RANK.refundSucceeded
-  ) {
-    return "refunded";
+  if (payment?.revokedAt) {
+    return payment.stripeStateEventRank ===
+      PACKAGE_PAYMENT_EVENT_RANK.refundSucceeded
+      ? "refunded"
+      : "revoked";
   }
   return "processing";
 }

--- a/apps/web/src/app/[lang]/(store)/store/[name]/checkout/page.tsx
+++ b/apps/web/src/app/[lang]/(store)/store/[name]/checkout/page.tsx
@@ -1,6 +1,11 @@
 import { authOrSignIn } from "@/lib/auth-guard";
 import { createOrRetrieveCustomerId } from "@/lib/customer";
 import { createStripe } from "@/lib/stripe/config";
+import {
+  isOwnedPackagePaymentIntent,
+  packagePaymentIntentMetadata,
+  packagePaymentIntentSearchQuery,
+} from "@/lib/stripe/store-checkout";
 import { ClientPage, PackageDetails } from "./components";
 import { notFound, redirect } from "next/navigation";
 import { guessCurrency } from "@/lib/currency";
@@ -45,20 +50,32 @@ export default async function Page(
   });
   const stripe = createStripe();
   const intents = await stripe.paymentIntents.search({
-    query: `customer:"${customerId}" AND metadata["packageId"]:"${pkg.id}" AND amount:${price.price} AND currency:"${price.currency}" AND status:"requires_payment_method"`,
+    query: packagePaymentIntentSearchQuery({
+      customerId,
+      userId: session.user.id,
+      packageId: pkg.id,
+      amount: price.price,
+      currency: price.currency,
+    }),
     limit: 1,
   });
 
   const paymentIntent =
-    intents.data[0] ||
+    intents.data.find((intent) =>
+      isOwnedPackagePaymentIntent(intent, {
+        customerId,
+        userId: session.user.id,
+        packageId: pkg.id,
+        amount: price.price,
+        currency: price.currency,
+      }),
+    ) ||
     (await stripe.paymentIntents.create({
       customer: customerId,
       setup_future_usage: "off_session",
       amount: price.price,
       currency: price.currency,
-      metadata: {
-        packageId: pkg.id,
-      },
+      metadata: packagePaymentIntentMetadata(session.user.id, pkg.id),
       // In the latest version of the API, specifying the `automatic_payment_methods` parameter is optional because Stripe enables its functionality by default.
       automatic_payment_methods: {
         enabled: true,

--- a/apps/web/src/app/api/stripe/webhook/route.ts
+++ b/apps/web/src/app/api/stripe/webhook/route.ts
@@ -32,6 +32,14 @@ const RESTORED_DISPUTE_STATUSES = new Set<Stripe.Dispute.Status>([
   "won",
 ]);
 
+const REFUND_INTERVENTION_STATUSES = new Set([
+  "failed",
+  "canceled",
+  "requires_action",
+]);
+const PACKAGE_PAYMENT_VALIDATION_REFUND =
+  "package-payment-validation-failed";
+
 function stripeStateEvent(
   event: Stripe.Event,
   rank: number,
@@ -66,21 +74,37 @@ async function resolveReversalReference({
   paymentIntent,
   stripe,
   requireValidPayment,
+  event,
 }: {
   paymentIntent: Stripe.PaymentIntent;
   stripe: StripeClient;
   requireValidPayment: boolean;
+  event: Stripe.Event;
 }): Promise<PackagePaymentReference | null> {
   const existing = await findPackagePaymentReference({
     paymentId: paymentIntent.id,
   });
-  if (existing) {
+  if (existing && (!requireValidPayment || existing.fulfillmentValidated)) {
     return existing;
   }
 
   if (requireValidPayment) {
     const payment = await resolvePackagePayment({ paymentIntent, stripe });
-    return payment.status === "fulfill" ? payment.reference : null;
+    if (payment.status !== "fulfill") {
+      return null;
+    }
+    const result = await recordPackagePaymentSucceeded({
+      reference: payment.reference,
+      billing: {
+        amount: paymentIntent.amount,
+        currency: paymentIntent.currency,
+      },
+      event: stripeStateEvent(
+        event,
+        PACKAGE_PAYMENT_EVENT_RANK.paymentSucceeded,
+      ),
+    });
+    return result ? payment.reference : null;
   }
   const owner = await resolvePackagePaymentOwner({ paymentIntent, stripe });
   return owner.status === "owned" ? owner.reference : null;
@@ -91,7 +115,10 @@ async function handlePaymentSucceeded(
   paymentIntent: Stripe.PaymentIntent,
   event: Stripe.Event,
 ): Promise<void> {
-  if (await findPackagePaymentReference({ paymentId: paymentIntent.id })) {
+  const existing = await findPackagePaymentReference({
+    paymentId: paymentIntent.id,
+  });
+  if (existing?.fulfillmentValidated) {
     return;
   }
   const payment = await resolvePackagePayment({ paymentIntent, stripe });
@@ -142,15 +169,125 @@ async function handleRefundedCharge(
   if (charge.amount_refunded <= 0) {
     return;
   }
+  const refund = await findSucceededRefund(stripe, charge.id);
+  if (!refund) {
+    return;
+  }
   const paymentIntentId = getExpandableId(charge.payment_intent);
   if (!paymentIntentId) {
     return;
   }
+  await revokeRefundedPayment({
+    stripe,
+    event,
+    paymentIntentId,
+    chargeId: charge.id,
+    refundId: refund.id,
+  });
+}
+
+async function findSucceededRefund(
+  stripe: StripeClient,
+  chargeId: string,
+): Promise<Stripe.Refund | null> {
+  let startingAfter: string | undefined;
+  while (true) {
+    const refunds = await stripe.refunds.list({
+      charge: chargeId,
+      limit: 100,
+      ...(startingAfter ? { starting_after: startingAfter } : {}),
+    });
+    const succeeded = refunds.data.find(
+      (refund) => refund.status === "succeeded",
+    );
+    if (succeeded) {
+      return succeeded;
+    }
+    if (!refunds.has_more) {
+      return null;
+    }
+    const lastRefund = refunds.data.at(-1);
+    if (!lastRefund) {
+      throw new Error("Stripe returned an empty refund page with has_more");
+    }
+    startingAfter = lastRefund.id;
+  }
+}
+
+async function handleRefund(
+  stripe: StripeClient,
+  eventRefund: Stripe.Refund,
+  event: Stripe.Event,
+): Promise<void> {
+  const refund = await stripe.refunds.retrieve(eventRefund.id);
+  if (refund.status !== "succeeded") {
+    await recordAutomaticRefundFailure(refund);
+    return;
+  }
+  let paymentIntentId = getExpandableId(refund.payment_intent);
+  const chargeId = getExpandableId(refund.charge);
+  if (!paymentIntentId && chargeId) {
+    const charge = await stripe.charges.retrieve(chargeId);
+    paymentIntentId = getExpandableId(charge.payment_intent);
+  }
+  if (!paymentIntentId) {
+    return;
+  }
+  await revokeRefundedPayment({
+    stripe,
+    event,
+    paymentIntentId,
+    chargeId,
+    refundId: refund.id,
+  });
+}
+
+async function recordAutomaticRefundFailure(
+  refund: Stripe.Refund,
+): Promise<void> {
+  if (
+    !refund.status ||
+    !REFUND_INTERVENTION_STATUSES.has(refund.status) ||
+    refund.metadata?.beutlDisposition !== PACKAGE_PAYMENT_VALIDATION_REFUND
+  ) {
+    return;
+  }
+  await addAuditLog({
+    userId: null,
+    action:
+      refund.status === "requires_action"
+        ? auditLogActions.store.paymentRefundRequiresAction
+        : auditLogActions.store.paymentRefundFailed,
+    details: [
+      `refundId: ${refund.id}`,
+      `refundStatus: ${refund.status}`,
+      `paymentIntentId: ${getExpandableId(refund.payment_intent) ?? "unknown"}`,
+      `chargeId: ${getExpandableId(refund.charge) ?? "unknown"}`,
+      `failureReason: ${refund.failure_reason ?? "unknown"}`,
+      `dispositionReason: ${refund.metadata.beutlDispositionReason ?? "unknown"}`,
+    ].join(", "),
+  });
+}
+
+async function revokeRefundedPayment({
+  stripe,
+  event,
+  paymentIntentId,
+  chargeId,
+  refundId,
+}: {
+  stripe: StripeClient;
+  event: Stripe.Event;
+  paymentIntentId: string;
+  chargeId: string | null;
+  refundId: string;
+}): Promise<void> {
   const paymentIntent = await stripe.paymentIntents.retrieve(paymentIntentId);
   const reference = await resolveReversalReference({
     paymentIntent,
     stripe,
     requireValidPayment: false,
+    event,
   });
   const result = await revokePackagePayment({
     paymentId: paymentIntent.id,
@@ -161,12 +298,12 @@ async function handleRefundedCharge(
       event,
       PACKAGE_PAYMENT_EVENT_RANK.refundSucceeded,
     ),
-    reason: `charge refunded: ${charge.id}`,
+    reason: `refund succeeded: ${refundId}`,
   });
   await addPaymentAuditLog(
     result,
     auditLogActions.store.paymentRevoked,
-    `state: revoked, chargeId: ${charge.id}`,
+    `state: revoked, chargeId: ${chargeId ?? "unknown"}, refundId: ${refundId}`,
   );
 }
 
@@ -186,10 +323,23 @@ async function handleDispute(
   if (!shouldRevoke && !shouldRestore) {
     return;
   }
+  if (shouldRestore) {
+    const chargeId = getExpandableId(dispute.charge);
+    if (chargeId) {
+      const charge = await stripe.charges.retrieve(chargeId);
+      if (
+        charge.amount_refunded > 0 &&
+        (await findSucceededRefund(stripe, charge.id))
+      ) {
+        return;
+      }
+    }
+  }
   const reference = await resolveReversalReference({
     paymentIntent,
     stripe,
     requireValidPayment: !shouldRevoke,
+    event,
   });
 
   if (shouldRevoke) {
@@ -212,18 +362,12 @@ async function handleDispute(
     return;
   }
 
-  const chargeId = getExpandableId(dispute.charge);
-  if (chargeId) {
-    const charge = await stripe.charges.retrieve(chargeId);
-    if (charge.amount_refunded > 0) {
-      return;
-    }
+  if (!reference) {
+    return;
   }
   const result = await restorePackagePayment({
     paymentId: paymentIntent.id,
-    reference: reference
-      ? { userId: reference.userId, packageId: reference.packageId }
-      : undefined,
+    reference: { userId: reference.userId, packageId: reference.packageId },
     event: stripeStateEvent(
       event,
       PACKAGE_PAYMENT_EVENT_RANK.disputeRestored,
@@ -269,6 +413,15 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
         await handleRefundedCharge(
           stripe,
           event.data.object as Stripe.Charge,
+          event,
+        );
+        break;
+      case "refund.created":
+      case "refund.updated":
+      case "refund.failed":
+        await handleRefund(
+          stripe,
+          event.data.object as Stripe.Refund,
           event,
         );
         break;

--- a/apps/web/src/app/api/stripe/webhook/route.ts
+++ b/apps/web/src/app/api/stripe/webhook/route.ts
@@ -1,93 +1,291 @@
 import { addAuditLog, auditLogActions } from "@/lib/audit-log";
-import { findCustomerByStripeId } from "@beutl/db";
-import { findPackageIdById } from "@beutl/db";
-import {
-  createUserPaymentHistory,
-  existsUserPaymentHistoryByPaymentId,
-} from "@beutl/db";
-import { createUserPackage } from "@beutl/db";
 import { createStripe } from "@/lib/stripe/config";
+import {
+  refundPackagePayment,
+  resolvePackagePayment,
+  resolvePackagePaymentOwner,
+} from "@/lib/stripe/package-payment";
+import { getExpandableId } from "@/lib/stripe/ownership";
+import {
+  findPackagePaymentReference,
+  PACKAGE_PAYMENT_EVENT_RANK,
+  recordPackagePaymentSucceeded,
+  restorePackagePayment,
+  revokePackagePayment,
+  type PackagePaymentReference,
+  type PackagePaymentStateResult,
+} from "@beutl/db";
 import { type NextRequest, NextResponse } from "next/server";
 import type Stripe from "stripe";
 
+type StripeClient = ReturnType<typeof createStripe>;
+
+const REVOKED_DISPUTE_STATUSES = new Set<Stripe.Dispute.Status>([
+  "needs_response",
+  "under_review",
+  "lost",
+]);
+
+const RESTORED_DISPUTE_STATUSES = new Set<Stripe.Dispute.Status>([
+  "prevented",
+  "warning_closed",
+  "won",
+]);
+
+function stripeStateEvent(
+  event: Stripe.Event,
+  rank: number,
+): { id: string; createdAt: Date; rank: number } {
+  const createdAt = new Date(event.created * 1_000);
+  if (!Number.isSafeInteger(event.created) || Number.isNaN(createdAt.getTime())) {
+    throw new TypeError("Stripe event timestamp is invalid");
+  }
+  return { id: event.id, createdAt, rank };
+}
+
+async function addPaymentAuditLog(
+  result: PackagePaymentStateResult | null,
+  action: string,
+  details: string,
+): Promise<void> {
+  if (!result?.changed) {
+    return;
+  }
+  try {
+    await addAuditLog({
+      userId: result.userId,
+      action,
+      details: `packageId: ${result.packageId}, paymentIntentId: ${result.paymentId}, ${details}`,
+    });
+  } catch (error) {
+    console.error("Failed to record package-payment audit log", error);
+  }
+}
+
+async function resolveReversalReference({
+  paymentIntent,
+  stripe,
+  requireValidPayment,
+}: {
+  paymentIntent: Stripe.PaymentIntent;
+  stripe: StripeClient;
+  requireValidPayment: boolean;
+}): Promise<PackagePaymentReference | null> {
+  const existing = await findPackagePaymentReference({
+    paymentId: paymentIntent.id,
+  });
+  if (existing) {
+    return existing;
+  }
+
+  if (requireValidPayment) {
+    const payment = await resolvePackagePayment({ paymentIntent, stripe });
+    return payment.status === "fulfill" ? payment.reference : null;
+  }
+  const owner = await resolvePackagePaymentOwner({ paymentIntent, stripe });
+  return owner.status === "owned" ? owner.reference : null;
+}
+
+async function handlePaymentSucceeded(
+  stripe: StripeClient,
+  paymentIntent: Stripe.PaymentIntent,
+  event: Stripe.Event,
+): Promise<void> {
+  if (await findPackagePaymentReference({ paymentId: paymentIntent.id })) {
+    return;
+  }
+  const payment = await resolvePackagePayment({ paymentIntent, stripe });
+  if (payment.status === "unrecognized") {
+    return;
+  }
+  if (payment.status === "refund") {
+    await refundPackagePayment({
+      paymentIntentId: paymentIntent.id,
+      reason: payment.reason,
+      stripe,
+    });
+    return;
+  }
+
+  const result = await recordPackagePaymentSucceeded({
+    reference: payment.reference,
+    billing: {
+      amount: paymentIntent.amount,
+      currency: paymentIntent.currency,
+    },
+    event: stripeStateEvent(
+      event,
+      PACKAGE_PAYMENT_EVENT_RANK.paymentSucceeded,
+    ),
+  });
+  if (!result) {
+    await refundPackagePayment({
+      paymentIntentId: paymentIntent.id,
+      reason: "package price changed before fulfillment",
+      stripe,
+    });
+    return;
+  }
+  await addPaymentAuditLog(
+    result,
+    auditLogActions.store.paymentSucceeded,
+    "state: active",
+  );
+}
+
+async function handleRefundedCharge(
+  stripe: StripeClient,
+  eventCharge: Stripe.Charge,
+  event: Stripe.Event,
+): Promise<void> {
+  const charge = await stripe.charges.retrieve(eventCharge.id);
+  if (charge.amount_refunded <= 0) {
+    return;
+  }
+  const paymentIntentId = getExpandableId(charge.payment_intent);
+  if (!paymentIntentId) {
+    return;
+  }
+  const paymentIntent = await stripe.paymentIntents.retrieve(paymentIntentId);
+  const reference = await resolveReversalReference({
+    paymentIntent,
+    stripe,
+    requireValidPayment: false,
+  });
+  const result = await revokePackagePayment({
+    paymentId: paymentIntent.id,
+    reference: reference
+      ? { userId: reference.userId, packageId: reference.packageId }
+      : undefined,
+    event: stripeStateEvent(
+      event,
+      PACKAGE_PAYMENT_EVENT_RANK.refundSucceeded,
+    ),
+    reason: `charge refunded: ${charge.id}`,
+  });
+  await addPaymentAuditLog(
+    result,
+    auditLogActions.store.paymentRevoked,
+    `state: revoked, chargeId: ${charge.id}`,
+  );
+}
+
+async function handleDispute(
+  stripe: StripeClient,
+  eventDispute: Stripe.Dispute,
+  event: Stripe.Event,
+): Promise<void> {
+  const dispute = await stripe.disputes.retrieve(eventDispute.id);
+  const paymentIntentId = getExpandableId(dispute.payment_intent);
+  if (!paymentIntentId) {
+    return;
+  }
+  const paymentIntent = await stripe.paymentIntents.retrieve(paymentIntentId);
+  const shouldRevoke = REVOKED_DISPUTE_STATUSES.has(dispute.status);
+  const shouldRestore = RESTORED_DISPUTE_STATUSES.has(dispute.status);
+  if (!shouldRevoke && !shouldRestore) {
+    return;
+  }
+  const reference = await resolveReversalReference({
+    paymentIntent,
+    stripe,
+    requireValidPayment: !shouldRevoke,
+  });
+
+  if (shouldRevoke) {
+    const result = await revokePackagePayment({
+      paymentId: paymentIntent.id,
+      reference: reference
+        ? { userId: reference.userId, packageId: reference.packageId }
+        : undefined,
+      event: stripeStateEvent(
+        event,
+        PACKAGE_PAYMENT_EVENT_RANK.disputeRevoked,
+      ),
+      reason: `dispute ${dispute.status}: ${dispute.id}`,
+    });
+    await addPaymentAuditLog(
+      result,
+      auditLogActions.store.paymentRevoked,
+      `state: revoked, disputeId: ${dispute.id}, disputeStatus: ${dispute.status}`,
+    );
+    return;
+  }
+
+  const chargeId = getExpandableId(dispute.charge);
+  if (chargeId) {
+    const charge = await stripe.charges.retrieve(chargeId);
+    if (charge.amount_refunded > 0) {
+      return;
+    }
+  }
+  const result = await restorePackagePayment({
+    paymentId: paymentIntent.id,
+    reference: reference
+      ? { userId: reference.userId, packageId: reference.packageId }
+      : undefined,
+    event: stripeStateEvent(
+      event,
+      PACKAGE_PAYMENT_EVENT_RANK.disputeRestored,
+    ),
+  });
+  await addPaymentAuditLog(
+    result,
+    auditLogActions.store.paymentRestored,
+    `state: active, disputeId: ${dispute.id}, disputeStatus: ${dispute.status}`,
+  );
+}
+
 export async function POST(request: NextRequest): Promise<NextResponse> {
   const stripe = createStripe();
-  const sig = request.headers.get("stripe-signature");
-  if (!sig) {
+  const signature = request.headers.get("stripe-signature");
+  if (!signature) {
     return NextResponse.json({ message: "No signature" }, { status: 400 });
   }
 
-  // 署名を確認する
   const body = await request.text();
   let event: Stripe.Event;
   try {
     event = stripe.webhooks.constructEvent(
       body,
-      sig,
+      signature,
       process.env.STRIPE_ENDPOINT_SECRET as string,
     );
-  } catch (err) {
-    console.error("Stripe webhook signature verification failed", err);
+  } catch (error) {
+    console.error("Stripe webhook signature verification failed", error);
     return NextResponse.json({ message: "Invalid signature" }, { status: 400 });
   }
 
   try {
     switch (event.type) {
-      case "payment_intent.succeeded": {
-        const paymentIntent = event.data.object as Stripe.PaymentIntent;
-        if (typeof paymentIntent.customer !== "string") {
-          return NextResponse.json(
-            { message: "paymentIntent.customer is not string" },
-            { status: 400 },
-          );
-        }
-
-        // 冪等化: 同じ payment_intent が再送されても二重付与しない
-        if (
-          await existsUserPaymentHistoryByPaymentId({
-            paymentId: paymentIntent.id,
-          })
-        ) {
-          return NextResponse.json({ received: true });
-        }
-
-        const customer = await findCustomerByStripeId({
-          stripeId: paymentIntent.customer,
-        });
-        if (!customer) {
-          return NextResponse.json(
-            { message: "User not found" },
-            { status: 404 },
-          );
-        }
-        const pkg = await findPackageIdById({
-          id: paymentIntent.metadata.packageId,
-        });
-        if (!pkg) {
-          return NextResponse.json(
-            { message: "Package not found" },
-            { status: 404 },
-          );
-        }
-        await createUserPackage({
-          userId: customer.userId,
-          packageId: pkg.id,
-        });
-        await createUserPaymentHistory({
-          userId: customer.userId,
-          packageId: pkg.id,
-          paymentIntentId: paymentIntent.id,
-        });
-        await addAuditLog({
-          userId: customer.userId,
-          action: auditLogActions.store.paymentSucceeded,
-          details: `packageId: ${pkg.id}`,
-        });
+      case "payment_intent.succeeded":
+        await handlePaymentSucceeded(
+          stripe,
+          event.data.object as Stripe.PaymentIntent,
+          event,
+        );
         break;
-      }
+      case "charge.refunded":
+        await handleRefundedCharge(
+          stripe,
+          event.data.object as Stripe.Charge,
+          event,
+        );
+        break;
+      case "charge.dispute.created":
+      case "charge.dispute.updated":
+      case "charge.dispute.closed":
+      case "charge.dispute.funds_withdrawn":
+      case "charge.dispute.funds_reinstated":
+        await handleDispute(
+          stripe,
+          event.data.object as Stripe.Dispute,
+          event,
+        );
+        break;
     }
-  } catch (err) {
-    console.error("Stripe webhook handler failed", err);
+  } catch (error) {
+    console.error("Stripe webhook handler failed", error);
     return NextResponse.json({ message: "Internal error" }, { status: 500 });
   }
 

--- a/apps/web/src/lib/audit-log.ts
+++ b/apps/web/src/lib/audit-log.ts
@@ -34,6 +34,8 @@ export const auditLogActions = {
     paymentSucceeded: "store.paymentSucceeded",
     paymentRevoked: "store.paymentRevoked",
     paymentRestored: "store.paymentRestored",
+    paymentRefundFailed: "store.paymentRefundFailed",
+    paymentRefundRequiresAction: "store.paymentRefundRequiresAction",
   },
   admin: {
     updatePackagePricing: "admin.updatePackagePricing",

--- a/apps/web/src/lib/audit-log.ts
+++ b/apps/web/src/lib/audit-log.ts
@@ -32,6 +32,8 @@ export const auditLogActions = {
     addToLibrary: "store.addToLibrary",
     removeFromLibrary: "store.removeFromLibrary",
     paymentSucceeded: "store.paymentSucceeded",
+    paymentRevoked: "store.paymentRevoked",
+    paymentRestored: "store.paymentRestored",
   },
   admin: {
     updatePackagePricing: "admin.updatePackagePricing",

--- a/apps/web/src/lib/customer.ts
+++ b/apps/web/src/lib/customer.ts
@@ -1,27 +1,58 @@
 import {
-  createCustomer,
-  deleteCustomerByUserId,
   findCustomerByUserId,
+  findCustomerOwnersByStripeId,
+  type PrismaTransaction,
+  upsertCustomerMapping,
 } from "@beutl/db";
 import { createStripe } from "@/lib/stripe/config";
-import type { PrismaTransaction } from "@beutl/db";
+import { isStripeResourceMissingError } from "@/lib/stripe/errors";
+import {
+  hasConflictingStripeOwnerMetadata,
+  hasStripeOwnerMetadata,
+  isDeletedCustomer,
+  stripeOwnerMetadata,
+} from "@/lib/stripe/ownership";
+import type Stripe from "stripe";
 
-export async function updateCustomerEmailIfExist({
-  userId,
-  email,
-  prisma,
-}: {
-  userId: string;
-  email: string;
-  prisma?: PrismaTransaction;
-}) {
-  const customer = await findCustomerByUserId({ userId, prisma });
-  if (customer) {
-    const stripe = createStripe();
-    await stripe.customers.update(customer.stripeId, {
-      email: email,
-    });
+type StripeClient = ReturnType<typeof createStripe>;
+
+async function retrieveCustomerIfPresent(
+  stripe: StripeClient,
+  customerId: string,
+): Promise<Stripe.Customer | null> {
+  try {
+    const customer = await stripe.customers.retrieve(customerId);
+    return isDeletedCustomer(customer) ? null : customer;
+  } catch (error) {
+    if (isStripeResourceMissingError(error)) {
+      return null;
+    }
+    throw error;
   }
+}
+
+async function createOwnedCustomer({
+  stripe,
+  email,
+  userId,
+  replacesCustomerId,
+}: {
+  stripe: StripeClient;
+  email: string;
+  userId: string;
+  replacesCustomerId?: string;
+}): Promise<Stripe.Customer> {
+  return await stripe.customers.create(
+    {
+      email,
+      metadata: stripeOwnerMetadata(userId),
+    },
+    {
+      idempotencyKey: replacesCustomerId
+        ? `beutl:customer:${userId}:replace:${replacesCustomerId}`
+        : `beutl:customer:${userId}`,
+    },
+  );
 }
 
 export async function createOrRetrieveCustomerId({
@@ -33,28 +64,59 @@ export async function createOrRetrieveCustomerId({
   userId: string;
   prisma?: PrismaTransaction;
 }) {
-  const customer = await findCustomerByUserId({ userId, prisma });
+  const mapping = await findCustomerByUserId({ userId, prisma });
   const stripe = createStripe();
-  let customerId = customer?.stripeId;
-  if (customerId) {
-    const c = await stripe.customers.retrieve(customerId);
-    if (c?.deleted) {
-      await deleteCustomerByUserId({ userId, prisma });
-      customerId = undefined;
+
+  if (mapping) {
+    const customer = await retrieveCustomerIfPresent(stripe, mapping.stripeId);
+    const owners = await findCustomerOwnersByStripeId({
+      stripeId: mapping.stripeId,
+      prisma,
+    });
+    const mappingIsUnique =
+      owners.length === 1 && owners[0]?.userId === userId;
+    if (
+      customer &&
+      mappingIsUnique &&
+      !hasConflictingStripeOwnerMetadata(customer.metadata, userId)
+    ) {
+      if (!hasStripeOwnerMetadata(customer.metadata, userId)) {
+        await stripe.customers.update(customer.id, {
+          email,
+          metadata: stripeOwnerMetadata(userId),
+        });
+      } else if (customer.email !== email) {
+        await stripe.customers.update(customer.id, { email });
+      }
+      return customer.id;
     }
   }
 
-  if (!customerId) {
-    customerId = (await stripe.customers.list({ email: email })).data[0]?.id;
-    if (!customerId) {
-      const customer = await stripe.customers.create({ email: email });
-      customerId = customer.id;
-      await createCustomer({
-        userId: userId,
-        stripeId: customerId,
-        prisma,
-      });
-    }
+  const customer = await createOwnedCustomer({
+    stripe,
+    email,
+    userId,
+    replacesCustomerId: mapping?.stripeId,
+  });
+  await upsertCustomerMapping({
+    userId,
+    stripeId: customer.id,
+    prisma,
+  });
+  return customer.id;
+}
+
+export async function updateCustomerEmailIfExist({
+  userId,
+  email,
+  prisma,
+}: {
+  userId: string;
+  email: string;
+  prisma?: PrismaTransaction;
+}) {
+  const mapping = await findCustomerByUserId({ userId, prisma });
+  if (mapping) {
+    await createOrRetrieveCustomerId({ userId, email, prisma });
   }
-  return customerId;
 }

--- a/apps/web/src/lib/customer.ts
+++ b/apps/web/src/lib/customer.ts
@@ -12,6 +12,7 @@ import {
   isDeletedCustomer,
   stripeOwnerMetadata,
 } from "@/lib/stripe/ownership";
+import { createHash } from "@beutl/core";
 import type Stripe from "stripe";
 
 type StripeClient = ReturnType<typeof createStripe>;
@@ -42,6 +43,7 @@ async function createOwnedCustomer({
   userId: string;
   replacesCustomerId?: string;
 }): Promise<Stripe.Customer> {
+  const emailDigest = (await createHash(email)).slice(0, 16);
   return await stripe.customers.create(
     {
       email,
@@ -49,8 +51,8 @@ async function createOwnedCustomer({
     },
     {
       idempotencyKey: replacesCustomerId
-        ? `beutl:customer:${userId}:replace:${replacesCustomerId}`
-        : `beutl:customer:${userId}`,
+        ? `beutl:customer:${userId}:replace:${replacesCustomerId}:${emailDigest}`
+        : `beutl:customer:${userId}:${emailDigest}`,
     },
   );
 }
@@ -68,11 +70,13 @@ export async function createOrRetrieveCustomerId({
   const stripe = createStripe();
 
   if (mapping) {
-    const customer = await retrieveCustomerIfPresent(stripe, mapping.stripeId);
-    const owners = await findCustomerOwnersByStripeId({
-      stripeId: mapping.stripeId,
-      prisma,
-    });
+    const [customer, owners] = await Promise.all([
+      retrieveCustomerIfPresent(stripe, mapping.stripeId),
+      findCustomerOwnersByStripeId({
+        stripeId: mapping.stripeId,
+        prisma,
+      }),
+    ]);
     const mappingIsUnique =
       owners.length === 1 && owners[0]?.userId === userId;
     if (
@@ -106,7 +110,7 @@ export async function createOrRetrieveCustomerId({
   return customer.id;
 }
 
-export async function updateCustomerEmailIfExist({
+export async function synchronizeMappedStripeCustomer({
   userId,
   email,
   prisma,

--- a/apps/web/src/lib/stripe/errors.ts
+++ b/apps/web/src/lib/stripe/errors.ts
@@ -1,0 +1,19 @@
+export function isStripeResourceMissingError(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "statusCode" in error &&
+    error.statusCode === 404 &&
+    "code" in error &&
+    error.code === "resource_missing"
+  );
+}
+
+export function isStripeChargeAlreadyRefundedError(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    error.code === "charge_already_refunded"
+  );
+}

--- a/apps/web/src/lib/stripe/ownership.ts
+++ b/apps/web/src/lib/stripe/ownership.ts
@@ -1,0 +1,44 @@
+import type Stripe from "stripe";
+
+export const STRIPE_APPLICATION_METADATA_VALUE = "beutl-web";
+
+export type StripeOwnershipMetadata = Record<string, string | undefined>;
+
+export function stripeOwnerMetadata(userId: string): Record<string, string> {
+  return {
+    beutlApplication: STRIPE_APPLICATION_METADATA_VALUE,
+    beutlUserId: userId,
+  };
+}
+
+export function hasStripeOwnerMetadata(
+  metadata: StripeOwnershipMetadata | null | undefined,
+  userId: string,
+): boolean {
+  return (
+    metadata?.beutlApplication === STRIPE_APPLICATION_METADATA_VALUE &&
+    metadata.beutlUserId === userId
+  );
+}
+
+export function hasConflictingStripeOwnerMetadata(
+  metadata: StripeOwnershipMetadata | null | undefined,
+  userId: string,
+): boolean {
+  const hasAnyOwnershipMetadata =
+    metadata?.beutlApplication !== undefined ||
+    metadata?.beutlUserId !== undefined;
+  return hasAnyOwnershipMetadata && !hasStripeOwnerMetadata(metadata, userId);
+}
+
+export function getExpandableId(
+  value: string | { id: string } | null | undefined,
+): string | null {
+  return typeof value === "string" ? value : value?.id ?? null;
+}
+
+export function isDeletedCustomer(
+  customer: Stripe.Customer | Stripe.DeletedCustomer,
+): customer is Stripe.DeletedCustomer {
+  return "deleted" in customer && customer.deleted === true;
+}

--- a/apps/web/src/lib/stripe/package-payment.ts
+++ b/apps/web/src/lib/stripe/package-payment.ts
@@ -1,0 +1,191 @@
+import {
+  findCustomerOwnersByStripeId,
+  getDb,
+  type PackagePaymentReference,
+} from "@beutl/db";
+import {
+  isStripeChargeAlreadyRefundedError,
+  isStripeResourceMissingError,
+} from "./errors";
+import {
+  getExpandableId,
+  hasStripeOwnerMetadata,
+  isDeletedCustomer,
+} from "./ownership";
+import { PACKAGE_PURCHASE_METADATA_VALUE } from "./store-checkout";
+import type Stripe from "stripe";
+
+type PackagePaymentStripeClient = {
+  customers: Pick<Stripe.CustomersResource, "retrieve">;
+  refunds: Pick<Stripe.RefundsResource, "create">;
+};
+
+export type PackagePaymentOwnerResolution =
+  | { status: "owned"; reference: PackagePaymentReference }
+  | { status: "invalid"; reason: string }
+  | { status: "unrecognized" };
+
+export type PackagePaymentResolution =
+  | { status: "fulfill"; reference: PackagePaymentReference }
+  | { status: "refund"; reason: string }
+  | { status: "unrecognized" };
+
+async function retrieveCustomer(
+  stripe: PackagePaymentStripeClient,
+  customerId: string,
+): Promise<Stripe.Customer | null> {
+  try {
+    const customer = await stripe.customers.retrieve(customerId);
+    return isDeletedCustomer(customer) ? null : customer;
+  } catch (error) {
+    if (isStripeResourceMissingError(error)) {
+      return null;
+    }
+    throw error;
+  }
+}
+
+export async function resolvePackagePaymentOwner({
+  paymentIntent,
+  stripe,
+}: {
+  paymentIntent: Stripe.PaymentIntent;
+  stripe: PackagePaymentStripeClient;
+}): Promise<PackagePaymentOwnerResolution> {
+  const packageId = paymentIntent.metadata.packageId?.trim();
+  if (!packageId) {
+    return { status: "unrecognized" };
+  }
+  const purchaseKind = paymentIntent.metadata.beutlPurchaseKind;
+  if (
+    purchaseKind !== undefined &&
+    purchaseKind !== PACKAGE_PURCHASE_METADATA_VALUE
+  ) {
+    return { status: "unrecognized" };
+  }
+  if (purchaseKind !== PACKAGE_PURCHASE_METADATA_VALUE) {
+    return { status: "invalid", reason: "missing package ownership binding" };
+  }
+
+  const userId = paymentIntent.metadata.beutlUserId?.trim();
+  const customerId = getExpandableId(paymentIntent.customer);
+  if (!userId || !customerId) {
+    return { status: "invalid", reason: "missing payment owner" };
+  }
+  if (!hasStripeOwnerMetadata(paymentIntent.metadata, userId)) {
+    return { status: "invalid", reason: "payment owner metadata mismatch" };
+  }
+
+  const owners = await findCustomerOwnersByStripeId({ stripeId: customerId });
+  if (owners.length !== 1 || owners[0]?.userId !== userId) {
+    return { status: "invalid", reason: "customer mapping mismatch" };
+  }
+
+  const customer = await retrieveCustomer(stripe, customerId);
+  if (!customer) {
+    return { status: "invalid", reason: "Stripe customer is closed" };
+  }
+  if (!hasStripeOwnerMetadata(customer.metadata, userId)) {
+    return { status: "invalid", reason: "Stripe customer owner mismatch" };
+  }
+
+  return {
+    status: "owned",
+    reference: {
+      paymentId: paymentIntent.id,
+      userId,
+      packageId,
+    },
+  };
+}
+
+async function matchesCurrentPackagePrice(
+  paymentIntent: Stripe.PaymentIntent,
+  packageId: string,
+): Promise<boolean> {
+  if (
+    paymentIntent.status !== "succeeded" ||
+    !Number.isSafeInteger(paymentIntent.amount) ||
+    paymentIntent.amount <= 0 ||
+    paymentIntent.amount_received !== paymentIntent.amount ||
+    paymentIntent.currency.trim().length === 0
+  ) {
+    return false;
+  }
+
+  const db = await getDb();
+  return !!(await db.package.findFirst({
+    where: {
+      id: packageId,
+      published: true,
+      packagePricing: {
+        some: {
+          price: paymentIntent.amount,
+          currency: {
+            equals: paymentIntent.currency,
+            mode: "insensitive",
+          },
+        },
+      },
+    },
+    select: { id: true },
+  }));
+}
+
+export async function resolvePackagePayment({
+  paymentIntent,
+  stripe,
+}: {
+  paymentIntent: Stripe.PaymentIntent;
+  stripe: PackagePaymentStripeClient;
+}): Promise<PackagePaymentResolution> {
+  const owner = await resolvePackagePaymentOwner({ paymentIntent, stripe });
+  if (owner.status === "unrecognized") {
+    return owner;
+  }
+  if (owner.status === "invalid") {
+    return { status: "refund", reason: owner.reason };
+  }
+  if (
+    !(await matchesCurrentPackagePrice(
+      paymentIntent,
+      owner.reference.packageId,
+    ))
+  ) {
+    return {
+      status: "refund",
+      reason: "package, amount, or currency mismatch",
+    };
+  }
+  return { status: "fulfill", reference: owner.reference };
+}
+
+export async function refundPackagePayment({
+  paymentIntentId,
+  reason,
+  stripe,
+}: {
+  paymentIntentId: string;
+  reason: string;
+  stripe: PackagePaymentStripeClient;
+}): Promise<void> {
+  try {
+    await stripe.refunds.create(
+      {
+        payment_intent: paymentIntentId,
+        reason: "requested_by_customer",
+        metadata: {
+          beutlDisposition: "package-payment-validation-failed",
+          beutlDispositionReason: reason.slice(0, 500),
+        },
+      },
+      {
+        idempotencyKey: `beutl:package-payment:${paymentIntentId}:refund`,
+      },
+    );
+  } catch (error) {
+    if (!isStripeChargeAlreadyRefundedError(error)) {
+      throw error;
+    }
+  }
+}

--- a/apps/web/src/lib/stripe/package-payment.ts
+++ b/apps/web/src/lib/stripe/package-payment.ts
@@ -53,15 +53,17 @@ export async function resolvePackagePaymentOwner({
   stripe: PackagePaymentStripeClient;
 }): Promise<PackagePaymentOwnerResolution> {
   const packageId = paymentIntent.metadata.packageId?.trim();
-  if (!packageId) {
-    return { status: "unrecognized" };
-  }
   const purchaseKind = paymentIntent.metadata.beutlPurchaseKind;
   if (
     purchaseKind !== undefined &&
     purchaseKind !== PACKAGE_PURCHASE_METADATA_VALUE
   ) {
     return { status: "unrecognized" };
+  }
+  if (!packageId) {
+    return purchaseKind === PACKAGE_PURCHASE_METADATA_VALUE
+      ? { status: "invalid", reason: "missing package id" }
+      : { status: "unrecognized" };
   }
   if (purchaseKind !== PACKAGE_PURCHASE_METADATA_VALUE) {
     return { status: "invalid", reason: "missing package ownership binding" };

--- a/apps/web/src/lib/stripe/package-payment.ts
+++ b/apps/web/src/lib/stripe/package-payment.ts
@@ -101,10 +101,14 @@ export async function resolvePackagePaymentOwner({
   };
 }
 
-async function matchesCurrentPackagePrice(
+type PackagePriceValidation =
+  | { valid: true }
+  | { valid: false; reason: string };
+
+async function validateCurrentPackagePrice(
   paymentIntent: Stripe.PaymentIntent,
   packageId: string,
-): Promise<boolean> {
+): Promise<PackagePriceValidation> {
   if (
     paymentIntent.status !== "succeeded" ||
     !Number.isSafeInteger(paymentIntent.amount) ||
@@ -112,11 +116,14 @@ async function matchesCurrentPackagePrice(
     paymentIntent.amount_received !== paymentIntent.amount ||
     paymentIntent.currency.trim().length === 0
   ) {
-    return false;
+    return {
+      valid: false,
+      reason: "payment status, amount, or currency is invalid",
+    };
   }
 
   const db = await getDb();
-  return !!(await db.package.findFirst({
+  const pkg = await db.package.findFirst({
     where: {
       id: packageId,
       published: true,
@@ -131,7 +138,10 @@ async function matchesCurrentPackagePrice(
       },
     },
     select: { id: true },
-  }));
+  });
+  return pkg
+    ? { valid: true }
+    : { valid: false, reason: "package is unpublished or price changed" };
 }
 
 export async function resolvePackagePayment({
@@ -148,15 +158,14 @@ export async function resolvePackagePayment({
   if (owner.status === "invalid") {
     return { status: "refund", reason: owner.reason };
   }
-  if (
-    !(await matchesCurrentPackagePrice(
-      paymentIntent,
-      owner.reference.packageId,
-    ))
-  ) {
+  const price = await validateCurrentPackagePrice(
+    paymentIntent,
+    owner.reference.packageId,
+  );
+  if (!price.valid) {
     return {
       status: "refund",
-      reason: "package, amount, or currency mismatch",
+      reason: price.reason,
     };
   }
   return { status: "fulfill", reference: owner.reference };

--- a/apps/web/src/lib/stripe/store-checkout.ts
+++ b/apps/web/src/lib/stripe/store-checkout.ts
@@ -1,0 +1,70 @@
+import {
+  hasStripeOwnerMetadata,
+  stripeOwnerMetadata,
+  STRIPE_APPLICATION_METADATA_VALUE,
+} from "./ownership";
+import type Stripe from "stripe";
+
+export const PACKAGE_PURCHASE_METADATA_VALUE = "package";
+
+export function packagePaymentIntentMetadata(
+  userId: string,
+  packageId: string,
+): Record<string, string> {
+  return {
+    ...stripeOwnerMetadata(userId),
+    beutlPurchaseKind: PACKAGE_PURCHASE_METADATA_VALUE,
+    packageId,
+  };
+}
+
+export function packagePaymentIntentSearchQuery({
+  customerId,
+  userId,
+  packageId,
+  amount,
+  currency,
+}: {
+  customerId: string;
+  userId: string;
+  packageId: string;
+  amount: number;
+  currency: string;
+}): string {
+  return `customer:"${customerId}" AND metadata["beutlApplication"]:"${STRIPE_APPLICATION_METADATA_VALUE}" AND metadata["beutlPurchaseKind"]:"${PACKAGE_PURCHASE_METADATA_VALUE}" AND metadata["beutlUserId"]:"${userId}" AND metadata["packageId"]:"${packageId}" AND amount:${amount} AND currency:"${currency.toLowerCase()}" AND status:"requires_payment_method"`;
+}
+
+export function isOwnedPackagePaymentIntent(
+  paymentIntent: Pick<
+    Stripe.PaymentIntent,
+    "amount" | "currency" | "customer" | "metadata"
+  >,
+  {
+    customerId,
+    userId,
+    packageId,
+    amount,
+    currency,
+  }: {
+    customerId: string;
+    userId: string;
+    packageId: string;
+    amount?: number;
+    currency?: string;
+  },
+): boolean {
+  const paymentCustomerId =
+    typeof paymentIntent.customer === "string"
+      ? paymentIntent.customer
+      : paymentIntent.customer?.id;
+  return (
+    paymentCustomerId === customerId &&
+    paymentIntent.metadata.beutlPurchaseKind ===
+      PACKAGE_PURCHASE_METADATA_VALUE &&
+    paymentIntent.metadata.packageId === packageId &&
+    hasStripeOwnerMetadata(paymentIntent.metadata, userId) &&
+    (amount === undefined || paymentIntent.amount === amount) &&
+    (currency === undefined ||
+      paymentIntent.currency.toLowerCase() === currency.toLowerCase())
+  );
+}

--- a/packages/api/src/v3/library.ts
+++ b/packages/api/src/v3/library.ts
@@ -130,10 +130,16 @@ const app = new Hono()
         packageId: pkg.package.id,
       }))
     ) {
-      await createUserPackage({
+      const userPackage = await createUserPackage({
         userId: user.id,
         packageId: pkg.package.id,
+        requireActivePayment: paymentRequired,
       });
+      if (!userPackage) {
+        return c.json(await apiErrorResponse("packageIsPrivate"), {
+          status: 402,
+        });
+      }
     }
 
     return c.json(pkg);

--- a/packages/db/src/customer.ts
+++ b/packages/db/src/customer.ts
@@ -19,6 +19,22 @@ export async function findCustomerByStripeId({
   });
 }
 
+export async function findCustomerOwnersByStripeId({
+  stripeId,
+  prisma,
+}: {
+  stripeId: string;
+  prisma?: PrismaTransaction;
+}) {
+  const db = prisma ?? await getDb();
+  return await db.customer.findMany({
+    where: { stripeId },
+    select: { userId: true },
+    orderBy: { userId: "asc" },
+    take: 2,
+  });
+}
+
 export async function findCustomerByUserId({
   userId,
   prisma,
@@ -64,5 +80,22 @@ export async function createCustomer({
       userId: userId,
       stripeId: stripeId,
     },
+  });
+}
+
+export async function upsertCustomerMapping({
+  userId,
+  stripeId,
+  prisma,
+}: {
+  userId: string;
+  stripeId: string;
+  prisma?: PrismaTransaction;
+}) {
+  const db = prisma ?? await getDb();
+  return await db.customer.upsert({
+    where: { userId },
+    create: { userId, stripeId },
+    update: { stripeId },
   });
 }

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -9,6 +9,7 @@ export * from "./feedback";
 export * from "./file";
 export * from "./native-app-auth";
 export * from "./package";
+export * from "./package-payment";
 export * from "./passkey";
 export * from "./profile";
 export * from "./release";

--- a/packages/db/src/package-payment.ts
+++ b/packages/db/src/package-payment.ts
@@ -8,6 +8,9 @@ export const PACKAGE_PAYMENT_EVENT_RANK = {
   refundSucceeded: 40,
 } as const;
 
+const PACKAGE_PAYMENT_TRANSACTION_MAX_ATTEMPTS = 3;
+const PACKAGE_PAYMENT_TRANSACTION_RETRY_CODES = new Set(["P2002", "P2034"]);
+
 export type PackagePaymentReference = {
   paymentId: string;
   userId: string;
@@ -54,6 +57,33 @@ const paymentStateSelect = {
   stripeStateEventCreatedAt: true,
   stripeStateEventRank: true,
 } as const;
+
+function isRetryablePackagePaymentTransactionError(error: unknown): boolean {
+  return Boolean(
+    error &&
+      typeof error === "object" &&
+      "code" in error &&
+      typeof error.code === "string" &&
+      PACKAGE_PAYMENT_TRANSACTION_RETRY_CODES.has(error.code),
+  );
+}
+
+async function startPackagePaymentTransaction<T>(
+  callback: (tx: PrismaTransaction) => Promise<T>,
+): Promise<T> {
+  for (let attempt = 1; ; attempt++) {
+    try {
+      return await startTransaction(callback);
+    } catch (error) {
+      if (
+        attempt >= PACKAGE_PAYMENT_TRANSACTION_MAX_ATTEMPTS ||
+        !isRetryablePackagePaymentTransactionError(error)
+      ) {
+        throw error;
+      }
+    }
+  }
+}
 
 function validateEvent(event: PackagePaymentStateEvent): void {
   if (!event.id || Number.isNaN(event.createdAt.getTime())) {
@@ -316,7 +346,9 @@ export async function recordPackagePaymentSucceeded({
       tx,
     });
   };
-  return prisma ? await record(prisma) : await startTransaction(record);
+  return prisma
+    ? await record(prisma)
+    : await startPackagePaymentTransaction(record);
 }
 
 export async function revokePackagePayment({
@@ -349,7 +381,9 @@ export async function revokePackagePayment({
       tx,
     });
   };
-  return prisma ? await revoke(prisma) : await startTransaction(revoke);
+  return prisma
+    ? await revoke(prisma)
+    : await startPackagePaymentTransaction(revoke);
 }
 
 export async function restorePackagePayment({
@@ -383,5 +417,7 @@ export async function restorePackagePayment({
       tx,
     });
   };
-  return prisma ? await restore(prisma) : await startTransaction(restore);
+  return prisma
+    ? await restore(prisma)
+    : await startPackagePaymentTransaction(restore);
 }

--- a/packages/db/src/package-payment.ts
+++ b/packages/db/src/package-payment.ts
@@ -3,8 +3,8 @@ import { startTransaction, type PrismaTransaction } from "./transaction";
 
 export const PACKAGE_PAYMENT_EVENT_RANK = {
   paymentSucceeded: 10,
-  disputeRestored: 20,
-  disputeRevoked: 30,
+  disputeRevoked: 20,
+  disputeRestored: 30,
   refundSucceeded: 40,
 } as const;
 
@@ -30,7 +30,14 @@ export type PackagePaymentStateResult = PackagePaymentReference & {
   changed: boolean;
 };
 
+export type PackagePaymentRecord = PackagePaymentReference & {
+  fulfillmentValidated: boolean;
+  revokedAt: Date | null;
+  stripeStateEventRank: number;
+};
+
 type PaymentHistoryState = PackagePaymentReference & {
+  fulfillmentValidated: boolean;
   revokedAt: Date | null;
   stripeStateEventId: string | null;
   stripeStateEventCreatedAt: Date | null;
@@ -41,6 +48,7 @@ const paymentStateSelect = {
   paymentId: true,
   userId: true,
   packageId: true,
+  fulfillmentValidated: true,
   revokedAt: true,
   stripeStateEventId: true,
   stripeStateEventCreatedAt: true,
@@ -60,6 +68,13 @@ function isNewerEvent(
   current: PaymentHistoryState,
   incoming: PackagePaymentStateEvent,
 ): boolean {
+  if (
+    current.stripeStateEventRank ===
+      PACKAGE_PAYMENT_EVENT_RANK.refundSucceeded &&
+    incoming.rank < PACKAGE_PAYMENT_EVENT_RANK.refundSucceeded
+  ) {
+    return false;
+  }
   if (!current.stripeStateEventCreatedAt) {
     return true;
   }
@@ -75,7 +90,7 @@ function isNewerEvent(
 }
 
 function assertSameReference(
-  current: PaymentHistoryState,
+  current: PackagePaymentReference,
   reference: PackagePaymentReference,
 ): void {
   if (
@@ -91,7 +106,7 @@ async function reconcileLibraryEntitlement(
   tx: PrismaTransaction,
   state: PaymentHistoryState,
 ): Promise<void> {
-  if (!state.revokedAt) {
+  if (state.fulfillmentValidated && !state.revokedAt) {
     const pkg = await tx.package.findFirst({
       where: { id: state.packageId },
       select: { id: true },
@@ -120,6 +135,7 @@ async function reconcileLibraryEntitlement(
     where: {
       userId: state.userId,
       packageId: state.packageId,
+      fulfillmentValidated: true,
       revokedAt: null,
     },
   });
@@ -140,6 +156,7 @@ async function applyPackagePaymentState({
   event,
   reason,
   reference,
+  validateFulfillment,
   tx,
 }: {
   active: boolean;
@@ -147,6 +164,7 @@ async function applyPackagePaymentState({
   event: PackagePaymentStateEvent;
   reason?: string;
   reference?: PackagePaymentReference;
+  validateFulfillment: boolean;
   tx: PrismaTransaction;
 }): Promise<PackagePaymentStateResult | null> {
   validateEvent(event);
@@ -168,6 +186,7 @@ async function applyPackagePaymentState({
         paymentId: reference.paymentId,
         userId: reference.userId,
         packageId: reference.packageId,
+        fulfillmentValidated: validateFulfillment,
         revokedAt: active ? null : event.createdAt,
         revocationReason: active ? null : reason ?? "payment reversed",
         stripeStateEventId: event.id,
@@ -180,17 +199,29 @@ async function applyPackagePaymentState({
   } else {
     assertSameReference(existing, reference);
     state = existing;
+    const shouldValidateFulfillment =
+      validateFulfillment && !existing.fulfillmentValidated;
     const mayReactivate = !active || !existing.revokedAt || allowReactivation;
-    if (mayReactivate && isNewerEvent(existing, event)) {
-      changed = Boolean(existing.revokedAt) === active;
+    const shouldApplyEvent = mayReactivate && isNewerEvent(existing, event);
+    if (shouldValidateFulfillment || shouldApplyEvent) {
+      changed = shouldApplyEvent && Boolean(existing.revokedAt) === active;
       state = await tx.userPaymentHistory.update({
         where: { paymentId },
         data: {
-          revokedAt: active ? null : event.createdAt,
-          revocationReason: active ? null : reason ?? "payment reversed",
-          stripeStateEventId: event.id,
-          stripeStateEventCreatedAt: event.createdAt,
-          stripeStateEventRank: event.rank,
+          ...(shouldValidateFulfillment
+            ? { fulfillmentValidated: true }
+            : {}),
+          ...(shouldApplyEvent
+            ? {
+                revokedAt: active ? null : event.createdAt,
+                revocationReason: active
+                  ? null
+                  : reason ?? "payment reversed",
+                stripeStateEventId: event.id,
+                stripeStateEventCreatedAt: event.createdAt,
+                stripeStateEventRank: event.rank,
+              }
+            : {}),
         },
         select: paymentStateSelect,
       });
@@ -213,7 +244,7 @@ export async function findPackagePaymentReference({
 }: {
   paymentId: string;
   prisma?: PrismaTransaction;
-}): Promise<PackagePaymentReference | null> {
+}): Promise<PackagePaymentRecord | null> {
   const db = prisma ?? await getDb();
   return await db.userPaymentHistory.findUnique({
     where: { paymentId },
@@ -221,6 +252,9 @@ export async function findPackagePaymentReference({
       paymentId: true,
       userId: true,
       packageId: true,
+      fulfillmentValidated: true,
+      revokedAt: true,
+      stripeStateEventRank: true,
     },
   });
 }
@@ -249,7 +283,10 @@ export async function recordPackagePaymentSucceeded({
       paymentId: reference.paymentId,
       prisma: tx,
     });
-    if (!existing) {
+    if (existing) {
+      assertSameReference(existing, reference);
+    }
+    if (!existing?.fulfillmentValidated) {
       const pkg = await tx.package.findFirst({
         where: {
           id: reference.packageId,
@@ -275,6 +312,7 @@ export async function recordPackagePaymentSucceeded({
       allowReactivation: false,
       event,
       reference,
+      validateFulfillment: true,
       tx,
     });
   };
@@ -307,6 +345,7 @@ export async function revokePackagePayment({
       event,
       reason,
       reference: resolvedReference,
+      validateFulfillment: false,
       tx,
     });
   };
@@ -329,13 +368,18 @@ export async function restorePackagePayment({
       paymentId,
       prisma: tx,
     });
-    const resolvedReference =
-      existing ?? (reference ? { paymentId, ...reference } : undefined);
+    if (!existing?.fulfillmentValidated) {
+      return null;
+    }
+    if (reference) {
+      assertSameReference(existing, { paymentId, ...reference });
+    }
     return await applyPackagePaymentState({
       active: true,
       allowReactivation: true,
       event,
-      reference: resolvedReference,
+      reference: existing,
+      validateFulfillment: false,
       tx,
     });
   };

--- a/packages/db/src/package-payment.ts
+++ b/packages/db/src/package-payment.ts
@@ -9,6 +9,7 @@ export const PACKAGE_PAYMENT_EVENT_RANK = {
 } as const;
 
 const PACKAGE_PAYMENT_TRANSACTION_MAX_ATTEMPTS = 3;
+const PACKAGE_PAYMENT_TRANSACTION_RETRY_BASE_DELAY_MS = 10;
 const PACKAGE_PAYMENT_TRANSACTION_RETRY_CODES = new Set(["P2002", "P2034"]);
 
 export type PackagePaymentReference = {
@@ -81,6 +82,12 @@ async function startPackagePaymentTransaction<T>(
       ) {
         throw error;
       }
+      await new Promise((resolve) =>
+        setTimeout(
+          resolve,
+          PACKAGE_PAYMENT_TRANSACTION_RETRY_BASE_DELAY_MS * attempt,
+        ),
+      );
     }
   }
 }
@@ -209,6 +216,7 @@ async function applyPackagePaymentState({
   });
   let state: PaymentHistoryState;
   let changed = false;
+  let shouldReconcileEntitlement = false;
 
   if (!existing) {
     state = await tx.userPaymentHistory.create({
@@ -226,6 +234,7 @@ async function applyPackagePaymentState({
       select: paymentStateSelect,
     });
     changed = true;
+    shouldReconcileEntitlement = true;
   } else {
     assertSameReference(existing, reference);
     state = existing;
@@ -255,10 +264,15 @@ async function applyPackagePaymentState({
         },
         select: paymentStateSelect,
       });
+      shouldReconcileEntitlement = active
+        ? changed || (shouldValidateFulfillment && !state.revokedAt)
+        : shouldApplyEvent || shouldValidateFulfillment;
     }
   }
 
-  await reconcileLibraryEntitlement(tx, state);
+  if (shouldReconcileEntitlement) {
+    await reconcileLibraryEntitlement(tx, state);
+  }
   return {
     paymentId: state.paymentId,
     userId: state.userId,

--- a/packages/db/src/package-payment.ts
+++ b/packages/db/src/package-payment.ts
@@ -1,0 +1,343 @@
+import { getDb } from "./provider";
+import { startTransaction, type PrismaTransaction } from "./transaction";
+
+export const PACKAGE_PAYMENT_EVENT_RANK = {
+  paymentSucceeded: 10,
+  disputeRestored: 20,
+  disputeRevoked: 30,
+  refundSucceeded: 40,
+} as const;
+
+export type PackagePaymentReference = {
+  paymentId: string;
+  userId: string;
+  packageId: string;
+};
+
+export type PackagePaymentBilling = {
+  amount: number;
+  currency: string;
+};
+
+export type PackagePaymentStateEvent = {
+  id: string;
+  createdAt: Date;
+  rank: number;
+};
+
+export type PackagePaymentStateResult = PackagePaymentReference & {
+  active: boolean;
+  changed: boolean;
+};
+
+type PaymentHistoryState = PackagePaymentReference & {
+  revokedAt: Date | null;
+  stripeStateEventId: string | null;
+  stripeStateEventCreatedAt: Date | null;
+  stripeStateEventRank: number;
+};
+
+const paymentStateSelect = {
+  paymentId: true,
+  userId: true,
+  packageId: true,
+  revokedAt: true,
+  stripeStateEventId: true,
+  stripeStateEventCreatedAt: true,
+  stripeStateEventRank: true,
+} as const;
+
+function validateEvent(event: PackagePaymentStateEvent): void {
+  if (!event.id || Number.isNaN(event.createdAt.getTime())) {
+    throw new TypeError("Stripe package-payment event is invalid");
+  }
+  if (!Number.isSafeInteger(event.rank) || event.rank < 0) {
+    throw new RangeError("Stripe package-payment event rank is invalid");
+  }
+}
+
+function isNewerEvent(
+  current: PaymentHistoryState,
+  incoming: PackagePaymentStateEvent,
+): boolean {
+  if (!current.stripeStateEventCreatedAt) {
+    return true;
+  }
+  const currentTime = current.stripeStateEventCreatedAt.getTime();
+  const incomingTime = incoming.createdAt.getTime();
+  if (incomingTime !== currentTime) {
+    return incomingTime > currentTime;
+  }
+  if (incoming.rank !== current.stripeStateEventRank) {
+    return incoming.rank > current.stripeStateEventRank;
+  }
+  return incoming.id > (current.stripeStateEventId ?? "");
+}
+
+function assertSameReference(
+  current: PaymentHistoryState,
+  reference: PackagePaymentReference,
+): void {
+  if (
+    current.paymentId !== reference.paymentId ||
+    current.userId !== reference.userId ||
+    current.packageId !== reference.packageId
+  ) {
+    throw new Error("Package payment identity cannot be rebound");
+  }
+}
+
+async function reconcileLibraryEntitlement(
+  tx: PrismaTransaction,
+  state: PaymentHistoryState,
+): Promise<void> {
+  if (!state.revokedAt) {
+    const pkg = await tx.package.findFirst({
+      where: { id: state.packageId },
+      select: { id: true },
+    });
+    if (!pkg) {
+      return;
+    }
+    await tx.userPackage.upsert({
+      where: {
+        userId_packageId: {
+          userId: state.userId,
+          packageId: state.packageId,
+        },
+      },
+      create: {
+        userId: state.userId,
+        packageId: state.packageId,
+        paymentManaged: true,
+      },
+      update: {},
+    });
+    return;
+  }
+
+  const activePayments = await tx.userPaymentHistory.count({
+    where: {
+      userId: state.userId,
+      packageId: state.packageId,
+      revokedAt: null,
+    },
+  });
+  if (activePayments === 0) {
+    await tx.userPackage.deleteMany({
+      where: {
+        userId: state.userId,
+        packageId: state.packageId,
+        paymentManaged: true,
+      },
+    });
+  }
+}
+
+async function applyPackagePaymentState({
+  active,
+  allowReactivation,
+  event,
+  reason,
+  reference,
+  tx,
+}: {
+  active: boolean;
+  allowReactivation: boolean;
+  event: PackagePaymentStateEvent;
+  reason?: string;
+  reference?: PackagePaymentReference;
+  tx: PrismaTransaction;
+}): Promise<PackagePaymentStateResult | null> {
+  validateEvent(event);
+  const paymentId = reference?.paymentId;
+  if (!paymentId) {
+    return null;
+  }
+
+  const existing = await tx.userPaymentHistory.findUnique({
+    where: { paymentId },
+    select: paymentStateSelect,
+  });
+  let state: PaymentHistoryState;
+  let changed = false;
+
+  if (!existing) {
+    state = await tx.userPaymentHistory.create({
+      data: {
+        paymentId: reference.paymentId,
+        userId: reference.userId,
+        packageId: reference.packageId,
+        revokedAt: active ? null : event.createdAt,
+        revocationReason: active ? null : reason ?? "payment reversed",
+        stripeStateEventId: event.id,
+        stripeStateEventCreatedAt: event.createdAt,
+        stripeStateEventRank: event.rank,
+      },
+      select: paymentStateSelect,
+    });
+    changed = true;
+  } else {
+    assertSameReference(existing, reference);
+    state = existing;
+    const mayReactivate = !active || !existing.revokedAt || allowReactivation;
+    if (mayReactivate && isNewerEvent(existing, event)) {
+      changed = Boolean(existing.revokedAt) === active;
+      state = await tx.userPaymentHistory.update({
+        where: { paymentId },
+        data: {
+          revokedAt: active ? null : event.createdAt,
+          revocationReason: active ? null : reason ?? "payment reversed",
+          stripeStateEventId: event.id,
+          stripeStateEventCreatedAt: event.createdAt,
+          stripeStateEventRank: event.rank,
+        },
+        select: paymentStateSelect,
+      });
+    }
+  }
+
+  await reconcileLibraryEntitlement(tx, state);
+  return {
+    paymentId: state.paymentId,
+    userId: state.userId,
+    packageId: state.packageId,
+    active: state.revokedAt === null,
+    changed,
+  };
+}
+
+export async function findPackagePaymentReference({
+  paymentId,
+  prisma,
+}: {
+  paymentId: string;
+  prisma?: PrismaTransaction;
+}): Promise<PackagePaymentReference | null> {
+  const db = prisma ?? await getDb();
+  return await db.userPaymentHistory.findUnique({
+    where: { paymentId },
+    select: {
+      paymentId: true,
+      userId: true,
+      packageId: true,
+    },
+  });
+}
+
+export async function recordPackagePaymentSucceeded({
+  reference,
+  billing,
+  event,
+  prisma,
+}: {
+  reference: PackagePaymentReference;
+  billing: PackagePaymentBilling;
+  event: PackagePaymentStateEvent;
+  prisma?: PrismaTransaction;
+}): Promise<PackagePaymentStateResult | null> {
+  if (
+    !Number.isSafeInteger(billing.amount) ||
+    billing.amount <= 0 ||
+    billing.currency.trim().length === 0
+  ) {
+    throw new TypeError("Package payment billing data is invalid");
+  }
+
+  const record = async (tx: PrismaTransaction) => {
+    const existing = await findPackagePaymentReference({
+      paymentId: reference.paymentId,
+      prisma: tx,
+    });
+    if (!existing) {
+      const pkg = await tx.package.findFirst({
+        where: {
+          id: reference.packageId,
+          published: true,
+          packagePricing: {
+            some: {
+              price: billing.amount,
+              currency: {
+                equals: billing.currency,
+                mode: "insensitive",
+              },
+            },
+          },
+        },
+        select: { id: true },
+      });
+      if (!pkg) {
+        return null;
+      }
+    }
+    return await applyPackagePaymentState({
+      active: true,
+      allowReactivation: false,
+      event,
+      reference,
+      tx,
+    });
+  };
+  return prisma ? await record(prisma) : await startTransaction(record);
+}
+
+export async function revokePackagePayment({
+  paymentId,
+  reference,
+  event,
+  reason,
+  prisma,
+}: {
+  paymentId: string;
+  reference?: Omit<PackagePaymentReference, "paymentId">;
+  event: PackagePaymentStateEvent;
+  reason: string;
+  prisma?: PrismaTransaction;
+}): Promise<PackagePaymentStateResult | null> {
+  const revoke = async (tx: PrismaTransaction) => {
+    const existing = await findPackagePaymentReference({
+      paymentId,
+      prisma: tx,
+    });
+    const resolvedReference =
+      existing ?? (reference ? { paymentId, ...reference } : undefined);
+    return await applyPackagePaymentState({
+      active: false,
+      allowReactivation: false,
+      event,
+      reason,
+      reference: resolvedReference,
+      tx,
+    });
+  };
+  return prisma ? await revoke(prisma) : await startTransaction(revoke);
+}
+
+export async function restorePackagePayment({
+  paymentId,
+  reference,
+  event,
+  prisma,
+}: {
+  paymentId: string;
+  reference?: Omit<PackagePaymentReference, "paymentId">;
+  event: PackagePaymentStateEvent;
+  prisma?: PrismaTransaction;
+}): Promise<PackagePaymentStateResult | null> {
+  const restore = async (tx: PrismaTransaction) => {
+    const existing = await findPackagePaymentReference({
+      paymentId,
+      prisma: tx,
+    });
+    const resolvedReference =
+      existing ?? (reference ? { paymentId, ...reference } : undefined);
+    return await applyPackagePaymentState({
+      active: true,
+      allowReactivation: true,
+      event,
+      reference: resolvedReference,
+      tx,
+    });
+  };
+  return prisma ? await restore(prisma) : await startTransaction(restore);
+}

--- a/packages/db/src/user-package.ts
+++ b/packages/db/src/user-package.ts
@@ -59,9 +59,11 @@ export async function createUserPackage(
   {
     userId,
     packageId,
+    requireActivePayment = false,
   }: {
     userId: string;
     packageId: string;
+    requireActivePayment?: boolean;
   },
   prisma?: PrismaTransaction,
 ) {
@@ -77,6 +79,9 @@ export async function createUserPackage(
         select: { paymentId: true },
       }),
     );
+    if (requireActivePayment && !paymentManaged) {
+      return null;
+    }
     return await tx.userPackage.upsert({
       where: { userId_packageId: { userId, packageId } },
       create: { userId, packageId, paymentManaged },

--- a/packages/db/src/user-package.ts
+++ b/packages/db/src/user-package.ts
@@ -1,5 +1,5 @@
 import { getDb } from "./provider";
-import type { PrismaTransaction } from "./transaction";
+import { startTransaction, type PrismaTransaction } from "./transaction";
 
 export async function findUserPackageIdsByUserId({
   userId,
@@ -65,12 +65,25 @@ export async function createUserPackage(
   },
   prisma?: PrismaTransaction,
 ) {
-  const db = prisma || await getDb();
-  return await db.userPackage.upsert({
-    where: { userId_packageId: { userId, packageId } },
-    create: { userId, packageId },
-    update: {},
-  });
+  const create = async (tx: PrismaTransaction) => {
+    const paymentManaged = Boolean(
+      await tx.userPaymentHistory.findFirst({
+        where: {
+          userId,
+          packageId,
+          fulfillmentValidated: true,
+          revokedAt: null,
+        },
+        select: { paymentId: true },
+      }),
+    );
+    return await tx.userPackage.upsert({
+      where: { userId_packageId: { userId, packageId } },
+      create: { userId, packageId, paymentManaged },
+      update: paymentManaged ? { paymentManaged: true } : {},
+    });
+  };
+  return prisma ? await create(prisma) : await startTransaction(create);
 }
 
 export async function deleteUserPackage(

--- a/packages/db/src/user-payment-history.ts
+++ b/packages/db/src/user-payment-history.ts
@@ -34,6 +34,7 @@ export async function existsUserPaymentHistory({
     where: {
       userId: userId,
       packageId: packageId,
+      fulfillmentValidated: true,
       revokedAt: null,
     },
     select: {
@@ -78,6 +79,7 @@ export async function createUserPaymentHistory({
       userId: userId,
       packageId: packageId,
       paymentId: paymentIntentId,
+      fulfillmentValidated: false,
     },
     update: {},
   });

--- a/packages/db/src/user-payment-history.ts
+++ b/packages/db/src/user-payment-history.ts
@@ -34,6 +34,7 @@ export async function existsUserPaymentHistory({
     where: {
       userId: userId,
       packageId: packageId,
+      revokedAt: null,
     },
     select: {
       id: true,

--- a/packages/i18n/src/locales/en/store.json
+++ b/packages/i18n/src/locales/en/store.json
@@ -8,6 +8,8 @@
   "orderProcessing": "Thank you for your order. Payment is being processed.",
   "paymentRefunded": "Payment refunded",
   "orderRefunded": "This payment was refunded, so the package was not added to your library.",
+  "paymentRevoked": "Package access unavailable",
+  "orderRevoked": "Access to this package is unavailable while the payment is under review.",
   "paymentFailed": "Payment was unsuccessful. Please try again.",
   "somethingWentWrong": "Something went wrong. Please try again.",
   "returnToProductPage": "Return to product page",

--- a/packages/i18n/src/locales/en/store.json
+++ b/packages/i18n/src/locales/en/store.json
@@ -6,6 +6,8 @@
   "orderThankYou": "Thank you for your order. Payment has been successfully completed. Please open the desktop app to install.",
   "processing": "Processing",
   "orderProcessing": "Thank you for your order. Payment is being processed.",
+  "paymentRefunded": "Payment refunded",
+  "orderRefunded": "This payment was refunded, so the package was not added to your library.",
   "paymentFailed": "Payment was unsuccessful. Please try again.",
   "somethingWentWrong": "Something went wrong. Please try again.",
   "returnToProductPage": "Return to product page",

--- a/packages/i18n/src/locales/ja/store.json
+++ b/packages/i18n/src/locales/ja/store.json
@@ -6,6 +6,8 @@
   "orderThankYou": "ご注文ありがとうございます。決済が正常に完了しました。インストールするにはデスクトップアプリを開いてください。",
   "processing": "処理中",
   "orderProcessing": "ご注文ありがとうございます。支払い処理中です。",
+  "paymentRefunded": "返金済み",
+  "orderRefunded": "この決済は返金されたため、パッケージはライブラリに追加されていません。",
   "paymentFailed": "支払いが成功しませんでした。もう一度お試しください。",
   "somethingWentWrong": "何かがうまくいきませんでした。もう一度お試しください。",
   "returnToProductPage": "商品ページに戻る",

--- a/packages/i18n/src/locales/ja/store.json
+++ b/packages/i18n/src/locales/ja/store.json
@@ -8,6 +8,8 @@
   "orderProcessing": "ご注文ありがとうございます。支払い処理中です。",
   "paymentRefunded": "返金済み",
   "orderRefunded": "この決済は返金されたため、パッケージはライブラリに追加されていません。",
+  "paymentRevoked": "パッケージを利用できません",
+  "orderRevoked": "支払いの確認中は、このパッケージを利用できません。",
   "paymentFailed": "支払いが成功しませんでした。もう一度お試しください。",
   "somethingWentWrong": "何かがうまくいきませんでした。もう一度お試しください。",
   "returnToProductPage": "商品ページに戻る",

--- a/tests/contract/customer-ownership.test.ts
+++ b/tests/contract/customer-ownership.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createHash } from "@beutl/core";
 
 const mocks = vi.hoisted(() => ({
   createCustomer: vi.fn(),
@@ -27,6 +28,10 @@ vi.mock("@/lib/stripe/config", () => ({
 import { createOrRetrieveCustomerId } from "../../apps/web/src/lib/customer";
 
 describe("Stripe customer ownership", () => {
+  async function idempotencyKey(email: string, prefix: string) {
+    return `${prefix}:${(await createHash(email)).slice(0, 16)}`;
+  }
+
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.findCustomerByUserId.mockResolvedValue(null);
@@ -54,7 +59,12 @@ describe("Stripe customer ownership", () => {
           beutlUserId: "user-1",
         },
       },
-      { idempotencyKey: "beutl:customer:user-1" },
+      {
+        idempotencyKey: await idempotencyKey(
+          "user@example.com",
+          "beutl:customer:user-1",
+        ),
+      },
     );
     expect(mocks.upsertCustomerMapping).toHaveBeenCalledWith({
       userId: "user-1",
@@ -126,7 +136,10 @@ describe("Stripe customer ownership", () => {
         },
       }),
       {
-        idempotencyKey: "beutl:customer:user-1:replace:cus_shared",
+        idempotencyKey: await idempotencyKey(
+          "user@example.com",
+          "beutl:customer:user-1:replace:cus_shared",
+        ),
       },
     );
     expect(mocks.upsertCustomerMapping).toHaveBeenCalledWith({
@@ -161,5 +174,85 @@ describe("Stripe customer ownership", () => {
       }),
     ).resolves.toBe("cus_new");
     expect(mocks.updateCustomer).not.toHaveBeenCalled();
+    expect(mocks.upsertCustomerMapping).toHaveBeenCalledWith({
+      userId: "user-1",
+      stripeId: "cus_new",
+      prisma: undefined,
+    });
+  });
+
+  it("replaces a mapping whose Stripe customer is deleted", async () => {
+    mocks.findCustomerByUserId.mockResolvedValue({
+      userId: "user-1",
+      stripeId: "cus_deleted",
+    });
+    mocks.findCustomerOwnersByStripeId.mockResolvedValue([
+      { userId: "user-1" },
+    ]);
+    mocks.retrieveCustomer.mockResolvedValue({
+      id: "cus_deleted",
+      deleted: true,
+    });
+
+    await expect(
+      createOrRetrieveCustomerId({
+        email: "user@example.com",
+        userId: "user-1",
+      }),
+    ).resolves.toBe("cus_new");
+    expect(mocks.upsertCustomerMapping).toHaveBeenCalledWith({
+      userId: "user-1",
+      stripeId: "cus_new",
+      prisma: undefined,
+    });
+  });
+
+  it("replaces a mapping whose Stripe customer is missing", async () => {
+    mocks.findCustomerByUserId.mockResolvedValue({
+      userId: "user-1",
+      stripeId: "cus_missing",
+    });
+    mocks.findCustomerOwnersByStripeId.mockResolvedValue([
+      { userId: "user-1" },
+    ]);
+    mocks.retrieveCustomer.mockRejectedValue(
+      Object.assign(new Error("No such customer"), {
+        statusCode: 404,
+        code: "resource_missing",
+      }),
+    );
+
+    await expect(
+      createOrRetrieveCustomerId({
+        email: "user@example.com",
+        userId: "user-1",
+      }),
+    ).resolves.toBe("cus_new");
+    expect(mocks.upsertCustomerMapping).toHaveBeenCalledWith({
+      userId: "user-1",
+      stripeId: "cus_new",
+      prisma: undefined,
+    });
+  });
+
+  it("binds customer idempotency to the email request body", async () => {
+    await createOrRetrieveCustomerId({
+      email: "user@example.com",
+      userId: "user-1",
+    });
+    await createOrRetrieveCustomerId({
+      email: "user@example.com",
+      userId: "user-1",
+    });
+    await createOrRetrieveCustomerId({
+      email: "changed@example.com",
+      userId: "user-1",
+    });
+
+    const keys = mocks.createCustomer.mock.calls.map(
+      ([, options]) => options.idempotencyKey,
+    );
+    expect(keys[0]).toBe(keys[1]);
+    expect(keys[2]).not.toBe(keys[0]);
   });
 });

--- a/tests/contract/customer-ownership.test.ts
+++ b/tests/contract/customer-ownership.test.ts
@@ -1,0 +1,165 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  createCustomer: vi.fn(),
+  findCustomerByUserId: vi.fn(),
+  findCustomerOwnersByStripeId: vi.fn(),
+  retrieveCustomer: vi.fn(),
+  updateCustomer: vi.fn(),
+  upsertCustomerMapping: vi.fn(),
+}));
+
+vi.mock("@beutl/db", () => ({
+  findCustomerByUserId: mocks.findCustomerByUserId,
+  findCustomerOwnersByStripeId: mocks.findCustomerOwnersByStripeId,
+  upsertCustomerMapping: mocks.upsertCustomerMapping,
+}));
+vi.mock("@/lib/stripe/config", () => ({
+  createStripe: () => ({
+    customers: {
+      create: mocks.createCustomer,
+      retrieve: mocks.retrieveCustomer,
+      update: mocks.updateCustomer,
+    },
+  }),
+}));
+
+import { createOrRetrieveCustomerId } from "../../apps/web/src/lib/customer";
+
+describe("Stripe customer ownership", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.findCustomerByUserId.mockResolvedValue(null);
+    mocks.findCustomerOwnersByStripeId.mockResolvedValue([]);
+    mocks.createCustomer.mockResolvedValue({ id: "cus_new" });
+    mocks.upsertCustomerMapping.mockResolvedValue({
+      userId: "user-1",
+      stripeId: "cus_new",
+    });
+  });
+
+  it("creates a new owned customer instead of adopting one by email", async () => {
+    await expect(
+      createOrRetrieveCustomerId({
+        email: "user@example.com",
+        userId: "user-1",
+      }),
+    ).resolves.toBe("cus_new");
+
+    expect(mocks.createCustomer).toHaveBeenCalledWith(
+      {
+        email: "user@example.com",
+        metadata: {
+          beutlApplication: "beutl-web",
+          beutlUserId: "user-1",
+        },
+      },
+      { idempotencyKey: "beutl:customer:user-1" },
+    );
+    expect(mocks.upsertCustomerMapping).toHaveBeenCalledWith({
+      userId: "user-1",
+      stripeId: "cus_new",
+      prisma: undefined,
+    });
+  });
+
+  it("adopts a uniquely mapped legacy customer by stamping ownership", async () => {
+    mocks.findCustomerByUserId.mockResolvedValue({
+      userId: "user-1",
+      stripeId: "cus_legacy",
+    });
+    mocks.findCustomerOwnersByStripeId.mockResolvedValue([
+      { userId: "user-1" },
+    ]);
+    mocks.retrieveCustomer.mockResolvedValue({
+      id: "cus_legacy",
+      deleted: false,
+      email: "old@example.com",
+      metadata: {},
+    });
+
+    await expect(
+      createOrRetrieveCustomerId({
+        email: "user@example.com",
+        userId: "user-1",
+      }),
+    ).resolves.toBe("cus_legacy");
+
+    expect(mocks.updateCustomer).toHaveBeenCalledWith("cus_legacy", {
+      email: "user@example.com",
+      metadata: {
+        beutlApplication: "beutl-web",
+        beutlUserId: "user-1",
+      },
+    });
+    expect(mocks.createCustomer).not.toHaveBeenCalled();
+  });
+
+  it("replaces a customer shared by multiple local users", async () => {
+    mocks.findCustomerByUserId.mockResolvedValue({
+      userId: "user-1",
+      stripeId: "cus_shared",
+    });
+    mocks.findCustomerOwnersByStripeId.mockResolvedValue([
+      { userId: "user-1" },
+      { userId: "user-2" },
+    ]);
+    mocks.retrieveCustomer.mockResolvedValue({
+      id: "cus_shared",
+      deleted: false,
+      email: "user@example.com",
+      metadata: {},
+    });
+
+    await expect(
+      createOrRetrieveCustomerId({
+        email: "user@example.com",
+        userId: "user-1",
+      }),
+    ).resolves.toBe("cus_new");
+
+    expect(mocks.createCustomer).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metadata: {
+          beutlApplication: "beutl-web",
+          beutlUserId: "user-1",
+        },
+      }),
+      {
+        idempotencyKey: "beutl:customer:user-1:replace:cus_shared",
+      },
+    );
+    expect(mocks.upsertCustomerMapping).toHaveBeenCalledWith({
+      userId: "user-1",
+      stripeId: "cus_new",
+      prisma: undefined,
+    });
+  });
+
+  it("replaces a mapping with conflicting Stripe owner metadata", async () => {
+    mocks.findCustomerByUserId.mockResolvedValue({
+      userId: "user-1",
+      stripeId: "cus_conflict",
+    });
+    mocks.findCustomerOwnersByStripeId.mockResolvedValue([
+      { userId: "user-1" },
+    ]);
+    mocks.retrieveCustomer.mockResolvedValue({
+      id: "cus_conflict",
+      deleted: false,
+      email: "user@example.com",
+      metadata: {
+        beutlApplication: "beutl-web",
+        beutlUserId: "user-2",
+      },
+    });
+
+    await expect(
+      createOrRetrieveCustomerId({
+        email: "user@example.com",
+        userId: "user-1",
+      }),
+    ).resolves.toBe("cus_new");
+    expect(mocks.updateCustomer).not.toHaveBeenCalled();
+  });
+});

--- a/tests/contract/package-checkout-completion.test.ts
+++ b/tests/contract/package-checkout-completion.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import {
+  resolvePackageCheckoutCompletionStatus,
+} from "../../apps/web/src/app/[lang]/(store)/store/[name]/checkout/complete/status";
+import { shouldPollPackageCheckoutCompletionStatus } from "../../apps/web/src/app/[lang]/(store)/store/[name]/checkout/complete/polling";
+
+const activePayment = {
+  paymentId: "pi_1",
+  userId: "user-1",
+  packageId: "package-1",
+  fulfillmentValidated: true,
+  revokedAt: null,
+  stripeStateEventRank: 10,
+};
+
+describe("package checkout completion status", () => {
+  it("shows success only for validated active fulfillment", () => {
+    expect(
+      resolvePackageCheckoutCompletionStatus("succeeded", activePayment),
+    ).toBe("succeeded");
+    expect(resolvePackageCheckoutCompletionStatus("succeeded", null)).toBe(
+      "processing",
+    );
+  });
+
+  it("shows a completed refund instead of payment success", () => {
+    expect(
+      resolvePackageCheckoutCompletionStatus("succeeded", {
+        ...activePayment,
+        fulfillmentValidated: false,
+        revokedAt: new Date("2026-08-09T00:01:00.000Z"),
+        stripeStateEventRank: 40,
+      }),
+    ).toBe("refunded");
+  });
+
+  it("polls only while webhook fulfillment is still processing", () => {
+    expect(shouldPollPackageCheckoutCompletionStatus("processing")).toBe(true);
+    expect(shouldPollPackageCheckoutCompletionStatus("succeeded")).toBe(false);
+    expect(shouldPollPackageCheckoutCompletionStatus("refunded")).toBe(false);
+  });
+
+  it("keeps other Stripe statuses unchanged", () => {
+    expect(
+      resolvePackageCheckoutCompletionStatus("requires_payment_method", null),
+    ).toBe("requires_payment_method");
+  });
+});

--- a/tests/contract/package-checkout-completion.test.ts
+++ b/tests/contract/package-checkout-completion.test.ts
@@ -1,8 +1,12 @@
 import { describe, expect, it } from "vitest";
+import { PACKAGE_PAYMENT_EVENT_RANK } from "@beutl/db";
 import {
   resolvePackageCheckoutCompletionStatus,
 } from "../../apps/web/src/app/[lang]/(store)/store/[name]/checkout/complete/status";
-import { shouldPollPackageCheckoutCompletionStatus } from "../../apps/web/src/app/[lang]/(store)/store/[name]/checkout/complete/polling";
+import {
+  nextPackageCheckoutPollInterval,
+  shouldPollPackageCheckoutCompletionStatus,
+} from "../../apps/web/src/app/[lang]/(store)/store/[name]/checkout/complete/polling";
 
 const activePayment = {
   paymentId: "pi_1",
@@ -10,7 +14,7 @@ const activePayment = {
   packageId: "package-1",
   fulfillmentValidated: true,
   revokedAt: null,
-  stripeStateEventRank: 10,
+  stripeStateEventRank: PACKAGE_PAYMENT_EVENT_RANK.paymentSucceeded,
 };
 
 describe("package checkout completion status", () => {
@@ -29,9 +33,20 @@ describe("package checkout completion status", () => {
         ...activePayment,
         fulfillmentValidated: false,
         revokedAt: new Date("2026-08-09T00:01:00.000Z"),
-        stripeStateEventRank: 40,
+        stripeStateEventRank: PACKAGE_PAYMENT_EVENT_RANK.refundSucceeded,
       }),
     ).toBe("refunded");
+  });
+
+  it("shows a dispute revocation as a terminal unavailable state", () => {
+    expect(
+      resolvePackageCheckoutCompletionStatus("succeeded", {
+        ...activePayment,
+        revokedAt: new Date("2026-08-09T00:01:00.000Z"),
+        stripeStateEventRank: PACKAGE_PAYMENT_EVENT_RANK.disputeRevoked,
+      }),
+    ).toBe("revoked");
+    expect(shouldPollPackageCheckoutCompletionStatus("revoked")).toBe(false);
   });
 
   it("polls only while webhook fulfillment is still processing", () => {
@@ -44,5 +59,11 @@ describe("package checkout completion status", () => {
     expect(
       resolvePackageCheckoutCompletionStatus("requires_payment_method", null),
     ).toBe("requires_payment_method");
+  });
+
+  it("backs polling off to the configured maximum", () => {
+    expect(nextPackageCheckoutPollInterval(1_000)).toBe(2_000);
+    expect(nextPackageCheckoutPollInterval(4_000)).toBe(8_000);
+    expect(nextPackageCheckoutPollInterval(8_000)).toBe(8_000);
   });
 });

--- a/tests/contract/package-payment-reconciliation.test.ts
+++ b/tests/contract/package-payment-reconciliation.test.ts
@@ -1,9 +1,13 @@
 import { describe, expect, it } from "vitest";
-import { classifyHistoricalPackagePayment } from "../../apps/web/scripts/reconcile-package-payments.mjs";
+import {
+  classifyHistoricalPackagePayment,
+  historicalStateEvent,
+  isHistoricalStateEventNewer,
+} from "../../apps/web/scripts/reconcile-package-payments.mjs";
 
 function classify(overrides: Record<string, unknown> = {}) {
   return classifyHistoricalPackagePayment({
-    paymentIntent: { id: "pi_1", status: "succeeded" },
+    paymentIntent: { id: "pi_1", status: "succeeded", created: 5 },
     refunds: [],
     disputes: [],
     ...overrides,
@@ -22,6 +26,7 @@ describe("historical package payment reconciliation", () => {
     ).toMatchObject({
       rank: 40,
       sourceId: "re_success",
+      sourceCreated: 10,
       sourceKind: "refund",
     });
   });
@@ -33,12 +38,12 @@ describe("historical package payment reconciliation", () => {
           { id: "dp_open", status: "under_review", created: 10 },
         ],
       }),
-    ).toMatchObject({ rank: 30, sourceId: "dp_open" });
+    ).toMatchObject({ rank: 20, sourceId: "dp_open" });
     expect(
       classify({
         disputes: [{ id: "dp_lost", status: "lost", created: 10 }],
       }),
-    ).toMatchObject({ rank: 30, sourceId: "dp_lost" });
+    ).toMatchObject({ rank: 20, sourceId: "dp_lost" });
     expect(
       classify({
         disputes: [{ id: "dp_won", status: "won", created: 10 }],
@@ -49,12 +54,71 @@ describe("historical package payment reconciliation", () => {
   it("revokes a historical payment that is no longer succeeded", () => {
     expect(
       classify({
-        paymentIntent: { id: "pi_1", status: "canceled" },
+        paymentIntent: { id: "pi_1", status: "canceled", created: 5 },
       }),
     ).toMatchObject({
       rank: 40,
       sourceId: "pi_1",
+      sourceCreated: 5,
       sourceKind: "payment-intent",
+    });
+  });
+
+  it("does not let a stale dispute dominate a concurrent restoration", () => {
+    const candidate = classify({
+      disputes: [{ id: "dp_open", status: "under_review", created: 10 }],
+    });
+    const incoming = historicalStateEvent(candidate);
+
+    expect(
+      isHistoricalStateEventNewer(
+        {
+          stripeStateEventId: "evt_dispute_won",
+          stripeStateEventCreatedAt: new Date(11_000),
+          stripeStateEventRank: 30,
+        },
+        incoming,
+      ),
+    ).toBe(false);
+    expect(
+      isHistoricalStateEventNewer(
+        {
+          stripeStateEventId: "evt_dispute_won",
+          stripeStateEventCreatedAt: new Date(10_000),
+          stripeStateEventRank: 30,
+        },
+        incoming,
+      ),
+    ).toBe(false);
+  });
+
+  it("does not overwrite a terminal refund with later dispute bookkeeping", () => {
+    expect(
+      isHistoricalStateEventNewer(
+        {
+          stripeStateEventId: "reconcile:re_success",
+          stripeStateEventCreatedAt: new Date(10_000),
+          stripeStateEventRank: 40,
+        },
+        {
+          id: "reconcile:dp_open",
+          createdAt: new Date(20_000),
+          rank: 20,
+        },
+      ),
+    ).toBe(false);
+  });
+
+  it("uses observation time for a terminal succeeded refund", () => {
+    const candidate = classify({
+      refunds: [{ id: "re_success", status: "succeeded", created: 10 }],
+    });
+    const observedAt = new Date("2026-08-09T00:03:00.000Z");
+
+    expect(historicalStateEvent(candidate, observedAt)).toMatchObject({
+      id: "reconcile:re_success",
+      createdAt: observedAt,
+      rank: 40,
     });
   });
 });

--- a/tests/contract/package-payment-reconciliation.test.ts
+++ b/tests/contract/package-payment-reconciliation.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { classifyHistoricalPackagePayment } from "../../apps/web/scripts/reconcile-package-payments.mjs";
+
+function classify(overrides: Record<string, unknown> = {}) {
+  return classifyHistoricalPackagePayment({
+    paymentIntent: { id: "pi_1", status: "succeeded" },
+    refunds: [],
+    disputes: [],
+    ...overrides,
+  });
+}
+
+describe("historical package payment reconciliation", () => {
+  it("revokes any successfully refunded payment", () => {
+    expect(
+      classify({
+        refunds: [
+          { id: "re_failed", status: "failed", created: 20 },
+          { id: "re_success", status: "succeeded", created: 10 },
+        ],
+      }),
+    ).toMatchObject({
+      rank: 40,
+      sourceId: "re_success",
+      sourceKind: "refund",
+    });
+  });
+
+  it("revokes open and lost disputes but not won disputes", () => {
+    expect(
+      classify({
+        disputes: [
+          { id: "dp_open", status: "under_review", created: 10 },
+        ],
+      }),
+    ).toMatchObject({ rank: 30, sourceId: "dp_open" });
+    expect(
+      classify({
+        disputes: [{ id: "dp_lost", status: "lost", created: 10 }],
+      }),
+    ).toMatchObject({ rank: 30, sourceId: "dp_lost" });
+    expect(
+      classify({
+        disputes: [{ id: "dp_won", status: "won", created: 10 }],
+      }),
+    ).toBeNull();
+  });
+
+  it("revokes a historical payment that is no longer succeeded", () => {
+    expect(
+      classify({
+        paymentIntent: { id: "pi_1", status: "canceled" },
+      }),
+    ).toMatchObject({
+      rank: 40,
+      sourceId: "pi_1",
+      sourceKind: "payment-intent",
+    });
+  });
+});

--- a/tests/contract/package-payment-state.test.ts
+++ b/tests/contract/package-payment-state.test.ts
@@ -1,5 +1,7 @@
+import { readFileSync } from "node:fs";
 import { beforeEach, describe, expect, it } from "vitest";
 import {
+  createUserPackage,
   PACKAGE_PAYMENT_EVENT_RANK,
   recordPackagePaymentSucceeded,
   restorePackagePayment,
@@ -11,6 +13,7 @@ type History = {
   paymentId: string;
   userId: string;
   packageId: string;
+  fulfillmentValidated: boolean;
   revokedAt: Date | null;
   revocationReason: string | null;
   stripeStateEventId: string | null;
@@ -36,6 +39,23 @@ function createPaymentStatePrisma() {
       const history = histories.get(where.paymentId);
       return history ? clone(history) : null;
     },
+    findFirst: async ({
+      where,
+    }: {
+      where: {
+        userId: string;
+        packageId: string;
+        fulfillmentValidated: true;
+        revokedAt: null;
+      };
+    }) =>
+      [...histories.values()].find(
+        (history) =>
+          history.userId === where.userId &&
+          history.packageId === where.packageId &&
+          history.fulfillmentValidated === where.fulfillmentValidated &&
+          history.revokedAt === null,
+      ) ?? null,
     create: async ({ data }: { data: History }) => {
       if (histories.has(data.paymentId)) {
         throw new Error("duplicate payment");
@@ -62,12 +82,18 @@ function createPaymentStatePrisma() {
     count: async ({
       where,
     }: {
-      where: { userId: string; packageId: string; revokedAt: null };
+      where: {
+        userId: string;
+        packageId: string;
+        fulfillmentValidated: true;
+        revokedAt: null;
+      };
     }) =>
       [...histories.values()].filter(
         (history) =>
           history.userId === where.userId &&
           history.packageId === where.packageId &&
+          history.fulfillmentValidated === where.fulfillmentValidated &&
           history.revokedAt === null,
       ).length,
   };
@@ -75,9 +101,11 @@ function createPaymentStatePrisma() {
     upsert: async ({
       where,
       create,
+      update,
     }: {
       where: { userId_packageId: { userId: string; packageId: string } };
       create: { userId: string; packageId: string; paymentManaged: boolean };
+      update: { paymentManaged?: boolean };
     }) => {
       const key = packageKey(
         where.userId_packageId.userId,
@@ -85,6 +113,8 @@ function createPaymentStatePrisma() {
       );
       if (!packages.has(key)) {
         packages.set(key, { paymentManaged: create.paymentManaged });
+      } else if (update.paymentManaged !== undefined) {
+        packages.set(key, { paymentManaged: update.paymentManaged });
       }
       return packages.get(key);
     },
@@ -140,6 +170,9 @@ function createPaymentStatePrisma() {
     seedPackage(userId: string, packageId: string, paymentManaged: boolean) {
       packages.set(packageKey(userId, packageId), { paymentManaged });
     },
+    removePackage(userId: string, packageId: string) {
+      packages.delete(packageKey(userId, packageId));
+    },
     setPackageAvailable(value: boolean) {
       packageAvailable = value;
     },
@@ -149,6 +182,22 @@ function createPaymentStatePrisma() {
 const SUCCEEDED_AT = new Date("2026-08-09T00:00:00.000Z");
 const REFUNDED_AT = new Date("2026-08-09T00:01:00.000Z");
 const RESTORED_AT = new Date("2026-08-09T00:02:00.000Z");
+
+describe("package payment migration cutover", () => {
+  it("marks old-Worker library writes as payment-managed by default", () => {
+    const migration = readFileSync(
+      new URL(
+        "../../apps/web/prisma/migrations/20260809171000_track_package_payment_state/migration.sql",
+        import.meta.url,
+      ),
+      "utf8",
+    );
+
+    expect(migration).toContain(
+      'ADD COLUMN "paymentManaged" BOOL NOT NULL DEFAULT true;',
+    );
+  });
+});
 
 describe("package payment entitlement state", () => {
   let store: ReturnType<typeof createPaymentStatePrisma>;
@@ -173,7 +222,10 @@ describe("package payment entitlement state", () => {
       },
     });
 
-    expect(store.history("pi_1")?.revokedAt).toBeNull();
+    expect(store.history("pi_1")).toMatchObject({
+      fulfillmentValidated: true,
+      revokedAt: null,
+    });
     expect(store.package("user-1", "package-1")).toEqual({
       paymentManaged: true,
     });
@@ -221,6 +273,81 @@ describe("package payment entitlement state", () => {
     expect(store.package("user-1", "package-1")).toBeNull();
   });
 
+  it("keeps a succeeded refund terminal across later dispute events", async () => {
+    await recordSuccess("pi_refunded_then_disputed");
+    await revokePackagePayment({
+      paymentId: "pi_refunded_then_disputed",
+      event: {
+        id: "evt_refunded",
+        createdAt: REFUNDED_AT,
+        rank: PACKAGE_PAYMENT_EVENT_RANK.refundSucceeded,
+      },
+      reason: "refunded",
+    });
+    await revokePackagePayment({
+      paymentId: "pi_refunded_then_disputed",
+      event: {
+        id: "evt_dispute_opened_after_refund",
+        createdAt: RESTORED_AT,
+        rank: PACKAGE_PAYMENT_EVENT_RANK.disputeRevoked,
+      },
+      reason: "disputed",
+    });
+
+    expect(store.history("pi_refunded_then_disputed")).toMatchObject({
+      revokedAt: REFUNDED_AT,
+      revocationReason: "refunded",
+      stripeStateEventId: "evt_refunded",
+      stripeStateEventRank: PACKAGE_PAYMENT_EVENT_RANK.refundSucceeded,
+    });
+    expect(store.package("user-1", "package-1")).toBeNull();
+  });
+
+  it("does not restore an unvalidated reversal tombstone", async () => {
+    await recordReversal("pi_tombstone");
+
+    expect(store.history("pi_tombstone")).toMatchObject({
+      fulfillmentValidated: false,
+      revokedAt: REFUNDED_AT,
+    });
+    await expect(
+      restorePackagePayment({
+        paymentId: "pi_tombstone",
+        event: {
+          id: "evt_dispute_won",
+          createdAt: RESTORED_AT,
+          rank: PACKAGE_PAYMENT_EVENT_RANK.disputeRestored,
+        },
+      }),
+    ).resolves.toBeNull();
+    expect(store.history("pi_tombstone")?.revokedAt).toEqual(REFUNDED_AT);
+    expect(store.package("user-1", "package-1")).toBeNull();
+  });
+
+  it("validates a tombstone without overriding its newer reversal", async () => {
+    await recordReversal("pi_tombstone");
+
+    await recordSuccess("pi_tombstone");
+    expect(store.history("pi_tombstone")).toMatchObject({
+      fulfillmentValidated: true,
+      revokedAt: REFUNDED_AT,
+      stripeStateEventId: "evt_dispute_opened_pi_tombstone",
+    });
+
+    await restorePackagePayment({
+      paymentId: "pi_tombstone",
+      event: {
+        id: "evt_dispute_won",
+        createdAt: RESTORED_AT,
+        rank: PACKAGE_PAYMENT_EVENT_RANK.disputeRestored,
+      },
+    });
+    expect(store.history("pi_tombstone")?.revokedAt).toBeNull();
+    expect(store.package("user-1", "package-1")).toEqual({
+      paymentManaged: true,
+    });
+  });
+
   it("restores access after a later dispute resolution", async () => {
     await recordSuccess("pi_1");
     await revokePackagePayment({
@@ -248,6 +375,37 @@ describe("package payment entitlement state", () => {
     });
   });
 
+  it("lets a terminal dispute resolution win a same-second tie", async () => {
+    await recordSuccess("pi_same_second");
+    await revokePackagePayment({
+      paymentId: "pi_same_second",
+      event: {
+        id: "evt_dispute_opened",
+        createdAt: REFUNDED_AT,
+        rank: PACKAGE_PAYMENT_EVENT_RANK.disputeRevoked,
+      },
+      reason: "disputed",
+    });
+
+    await restorePackagePayment({
+      paymentId: "pi_same_second",
+      event: {
+        id: "evt_dispute_won",
+        createdAt: REFUNDED_AT,
+        rank: PACKAGE_PAYMENT_EVENT_RANK.disputeRestored,
+      },
+    });
+
+    expect(store.history("pi_same_second")).toMatchObject({
+      revokedAt: null,
+      stripeStateEventId: "evt_dispute_won",
+      stripeStateEventRank: PACKAGE_PAYMENT_EVENT_RANK.disputeRestored,
+    });
+    expect(store.package("user-1", "package-1")).toEqual({
+      paymentManaged: true,
+    });
+  });
+
   it("keeps access while another active payment exists", async () => {
     await recordSuccess("pi_1");
     await recordSuccess("pi_2");
@@ -263,6 +421,30 @@ describe("package payment entitlement state", () => {
     });
 
     expect(store.package("user-1", "package-1")).not.toBeNull();
+  });
+
+  it("re-adds a paid package as payment-managed", async () => {
+    await recordSuccess("pi_reacquired");
+    store.removePackage("user-1", "package-1");
+
+    await createUserPackage({
+      userId: "user-1",
+      packageId: "package-1",
+    });
+    expect(store.package("user-1", "package-1")).toEqual({
+      paymentManaged: true,
+    });
+
+    await revokePackagePayment({
+      paymentId: "pi_reacquired",
+      event: {
+        id: "evt_refunded_reacquired",
+        createdAt: REFUNDED_AT,
+        rank: PACKAGE_PAYMENT_EVENT_RANK.refundSucceeded,
+      },
+      reason: "refunded",
+    });
+    expect(store.package("user-1", "package-1")).toBeNull();
   });
 
   it("does not remove a manually managed library entry", async () => {
@@ -316,6 +498,22 @@ describe("package payment entitlement state", () => {
         createdAt: SUCCEEDED_AT,
         rank: PACKAGE_PAYMENT_EVENT_RANK.paymentSucceeded,
       },
+    });
+  }
+
+  async function recordReversal(paymentId: string) {
+    await revokePackagePayment({
+      paymentId,
+      reference: {
+        userId: "user-1",
+        packageId: "package-1",
+      },
+      event: {
+        id: `evt_dispute_opened_${paymentId}`,
+        createdAt: REFUNDED_AT,
+        rank: PACKAGE_PAYMENT_EVENT_RANK.disputeRevoked,
+      },
+      reason: "disputed",
     });
   }
 });

--- a/tests/contract/package-payment-state.test.ts
+++ b/tests/contract/package-payment-state.test.ts
@@ -1,0 +1,321 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  PACKAGE_PAYMENT_EVENT_RANK,
+  recordPackagePaymentSucceeded,
+  restorePackagePayment,
+  revokePackagePayment,
+  setDbProvider,
+} from "@beutl/db";
+
+type History = {
+  paymentId: string;
+  userId: string;
+  packageId: string;
+  revokedAt: Date | null;
+  revocationReason: string | null;
+  stripeStateEventId: string | null;
+  stripeStateEventCreatedAt: Date | null;
+  stripeStateEventRank: number;
+};
+
+function createPaymentStatePrisma() {
+  const histories = new Map<string, History>();
+  const packages = new Map<string, { paymentManaged: boolean }>();
+  const packageKey = (userId: string, packageId: string) =>
+    `${userId}:${packageId}`;
+  const clone = (history: History): History => ({
+    ...history,
+    revokedAt: history.revokedAt ? new Date(history.revokedAt) : null,
+    stripeStateEventCreatedAt: history.stripeStateEventCreatedAt
+      ? new Date(history.stripeStateEventCreatedAt)
+      : null,
+  });
+
+  const userPaymentHistory = {
+    findUnique: async ({ where }: { where: { paymentId: string } }) => {
+      const history = histories.get(where.paymentId);
+      return history ? clone(history) : null;
+    },
+    create: async ({ data }: { data: History }) => {
+      if (histories.has(data.paymentId)) {
+        throw new Error("duplicate payment");
+      }
+      const history = clone(data);
+      histories.set(history.paymentId, history);
+      return clone(history);
+    },
+    update: async ({
+      where,
+      data,
+    }: {
+      where: { paymentId: string };
+      data: Partial<History>;
+    }) => {
+      const history = histories.get(where.paymentId);
+      if (!history) {
+        throw new Error("missing payment");
+      }
+      const updated = clone({ ...history, ...data });
+      histories.set(updated.paymentId, updated);
+      return clone(updated);
+    },
+    count: async ({
+      where,
+    }: {
+      where: { userId: string; packageId: string; revokedAt: null };
+    }) =>
+      [...histories.values()].filter(
+        (history) =>
+          history.userId === where.userId &&
+          history.packageId === where.packageId &&
+          history.revokedAt === null,
+      ).length,
+  };
+  const userPackage = {
+    upsert: async ({
+      where,
+      create,
+    }: {
+      where: { userId_packageId: { userId: string; packageId: string } };
+      create: { userId: string; packageId: string; paymentManaged: boolean };
+    }) => {
+      const key = packageKey(
+        where.userId_packageId.userId,
+        where.userId_packageId.packageId,
+      );
+      if (!packages.has(key)) {
+        packages.set(key, { paymentManaged: create.paymentManaged });
+      }
+      return packages.get(key);
+    },
+    deleteMany: async ({
+      where,
+    }: {
+      where: {
+        userId: string;
+        packageId: string;
+        paymentManaged: boolean;
+      };
+    }) => {
+      const key = packageKey(where.userId, where.packageId);
+      const current = packages.get(key);
+      if (current?.paymentManaged === where.paymentManaged) {
+        packages.delete(key);
+        return { count: 1 };
+      }
+      return { count: 0 };
+    },
+  };
+  let packageAvailable = true;
+  const packageDelegate = {
+    findFirst: async () => (packageAvailable ? { id: "package-1" } : null),
+  };
+  const prisma = {
+    package: packageDelegate,
+    userPaymentHistory,
+    userPackage,
+    $transaction: async <T>(
+      callback: (tx: {
+        userPaymentHistory: typeof userPaymentHistory;
+        userPackage: typeof userPackage;
+        package: typeof packageDelegate;
+      }) => Promise<T>,
+    ) =>
+      await callback({
+        package: packageDelegate,
+        userPaymentHistory,
+        userPackage,
+      }),
+  };
+
+  return {
+    prisma,
+    history(paymentId: string) {
+      const history = histories.get(paymentId);
+      return history ? clone(history) : null;
+    },
+    package(userId: string, packageId: string) {
+      return packages.get(packageKey(userId, packageId)) ?? null;
+    },
+    seedPackage(userId: string, packageId: string, paymentManaged: boolean) {
+      packages.set(packageKey(userId, packageId), { paymentManaged });
+    },
+    setPackageAvailable(value: boolean) {
+      packageAvailable = value;
+    },
+  };
+}
+
+const SUCCEEDED_AT = new Date("2026-08-09T00:00:00.000Z");
+const REFUNDED_AT = new Date("2026-08-09T00:01:00.000Z");
+const RESTORED_AT = new Date("2026-08-09T00:02:00.000Z");
+
+describe("package payment entitlement state", () => {
+  let store: ReturnType<typeof createPaymentStatePrisma>;
+
+  beforeEach(() => {
+    store = createPaymentStatePrisma();
+    setDbProvider(async () => store.prisma as never);
+  });
+
+  it("creates an active payment-managed library entitlement", async () => {
+    await recordPackagePaymentSucceeded({
+      reference: {
+        paymentId: "pi_1",
+        userId: "user-1",
+        packageId: "package-1",
+      },
+      billing: { amount: 1_000, currency: "usd" },
+      event: {
+        id: "evt_succeeded",
+        createdAt: SUCCEEDED_AT,
+        rank: PACKAGE_PAYMENT_EVENT_RANK.paymentSucceeded,
+      },
+    });
+
+    expect(store.history("pi_1")?.revokedAt).toBeNull();
+    expect(store.package("user-1", "package-1")).toEqual({
+      paymentManaged: true,
+    });
+  });
+
+  it("does not fulfill after the package price changes", async () => {
+    store.setPackageAvailable(false);
+
+    await expect(
+      recordPackagePaymentSucceeded({
+        reference: {
+          paymentId: "pi_stale",
+          userId: "user-1",
+          packageId: "package-1",
+        },
+        billing: { amount: 1_000, currency: "usd" },
+        event: {
+          id: "evt_stale_price",
+          createdAt: SUCCEEDED_AT,
+          rank: PACKAGE_PAYMENT_EVENT_RANK.paymentSucceeded,
+        },
+      }),
+    ).resolves.toBeNull();
+    expect(store.history("pi_stale")).toBeNull();
+    expect(store.package("user-1", "package-1")).toBeNull();
+  });
+
+  it("revokes refunded access and ignores a delayed success delivery", async () => {
+    await recordSuccess("pi_1");
+    await revokePackagePayment({
+      paymentId: "pi_1",
+      event: {
+        id: "evt_refunded",
+        createdAt: REFUNDED_AT,
+        rank: PACKAGE_PAYMENT_EVENT_RANK.refundSucceeded,
+      },
+      reason: "refunded",
+    });
+
+    expect(store.history("pi_1")?.revokedAt).toEqual(REFUNDED_AT);
+    expect(store.package("user-1", "package-1")).toBeNull();
+
+    await recordSuccess("pi_1");
+    expect(store.history("pi_1")?.revokedAt).toEqual(REFUNDED_AT);
+    expect(store.package("user-1", "package-1")).toBeNull();
+  });
+
+  it("restores access after a later dispute resolution", async () => {
+    await recordSuccess("pi_1");
+    await revokePackagePayment({
+      paymentId: "pi_1",
+      event: {
+        id: "evt_dispute_opened",
+        createdAt: REFUNDED_AT,
+        rank: PACKAGE_PAYMENT_EVENT_RANK.disputeRevoked,
+      },
+      reason: "disputed",
+    });
+
+    await restorePackagePayment({
+      paymentId: "pi_1",
+      event: {
+        id: "evt_dispute_won",
+        createdAt: RESTORED_AT,
+        rank: PACKAGE_PAYMENT_EVENT_RANK.disputeRestored,
+      },
+    });
+
+    expect(store.history("pi_1")?.revokedAt).toBeNull();
+    expect(store.package("user-1", "package-1")).toEqual({
+      paymentManaged: true,
+    });
+  });
+
+  it("keeps access while another active payment exists", async () => {
+    await recordSuccess("pi_1");
+    await recordSuccess("pi_2");
+
+    await revokePackagePayment({
+      paymentId: "pi_1",
+      event: {
+        id: "evt_refunded",
+        createdAt: REFUNDED_AT,
+        rank: PACKAGE_PAYMENT_EVENT_RANK.refundSucceeded,
+      },
+      reason: "refunded",
+    });
+
+    expect(store.package("user-1", "package-1")).not.toBeNull();
+  });
+
+  it("does not remove a manually managed library entry", async () => {
+    store.seedPackage("user-1", "package-1", false);
+    await recordSuccess("pi_1");
+    await revokePackagePayment({
+      paymentId: "pi_1",
+      event: {
+        id: "evt_refunded",
+        createdAt: REFUNDED_AT,
+        rank: PACKAGE_PAYMENT_EVENT_RANK.refundSucceeded,
+      },
+      reason: "refunded",
+    });
+
+    expect(store.package("user-1", "package-1")).toEqual({
+      paymentManaged: false,
+    });
+  });
+
+  it("never rebinds a Stripe payment to another user", async () => {
+    await recordSuccess("pi_1");
+
+    await expect(
+      recordPackagePaymentSucceeded({
+        reference: {
+          paymentId: "pi_1",
+          userId: "attacker",
+          packageId: "package-1",
+        },
+        billing: { amount: 1_000, currency: "usd" },
+        event: {
+          id: "evt_rebound",
+          createdAt: RESTORED_AT,
+          rank: PACKAGE_PAYMENT_EVENT_RANK.paymentSucceeded,
+        },
+      }),
+    ).rejects.toThrow("Package payment identity cannot be rebound");
+  });
+
+  async function recordSuccess(paymentId: string) {
+    await recordPackagePaymentSucceeded({
+      reference: {
+        paymentId,
+        userId: "user-1",
+        packageId: "package-1",
+      },
+      billing: { amount: 1_000, currency: "usd" },
+      event: {
+        id: `evt_succeeded_${paymentId}`,
+        createdAt: SUCCEEDED_AT,
+        rank: PACKAGE_PAYMENT_EVENT_RANK.paymentSucceeded,
+      },
+    });
+  }
+});

--- a/tests/contract/package-payment-state.test.ts
+++ b/tests/contract/package-payment-state.test.ts
@@ -24,6 +24,8 @@ type History = {
 function createPaymentStatePrisma() {
   const histories = new Map<string, History>();
   const packages = new Map<string, { paymentManaged: boolean }>();
+  let raceNextHistoryCreate = false;
+  let transactionAttempts = 0;
   const packageKey = (userId: string, packageId: string) =>
     `${userId}:${packageId}`;
   const clone = (history: History): History => ({
@@ -62,6 +64,12 @@ function createPaymentStatePrisma() {
       }
       const history = clone(data);
       histories.set(history.paymentId, history);
+      if (raceNextHistoryCreate) {
+        raceNextHistoryCreate = false;
+        throw Object.assign(new Error("concurrent payment insert"), {
+          code: "P2002",
+        });
+      }
       return clone(history);
     },
     update: async ({
@@ -150,12 +158,14 @@ function createPaymentStatePrisma() {
         userPackage: typeof userPackage;
         package: typeof packageDelegate;
       }) => Promise<T>,
-    ) =>
-      await callback({
+    ) => {
+      transactionAttempts++;
+      return await callback({
         package: packageDelegate,
         userPaymentHistory,
         userPackage,
-      }),
+      });
+    },
   };
 
   return {
@@ -172,6 +182,12 @@ function createPaymentStatePrisma() {
     },
     removePackage(userId: string, packageId: string) {
       packages.delete(packageKey(userId, packageId));
+    },
+    raceNextPaymentHistoryCreate() {
+      raceNextHistoryCreate = true;
+    },
+    transactionAttempts() {
+      return transactionAttempts;
     },
     setPackageAvailable(value: boolean) {
       packageAvailable = value;
@@ -223,6 +239,21 @@ describe("package payment entitlement state", () => {
     });
 
     expect(store.history("pi_1")).toMatchObject({
+      fulfillmentValidated: true,
+      revokedAt: null,
+    });
+    expect(store.package("user-1", "package-1")).toEqual({
+      paymentManaged: true,
+    });
+  });
+
+  it("retries a concurrent payment-history insert", async () => {
+    store.raceNextPaymentHistoryCreate();
+
+    await recordSuccess("pi_concurrent");
+
+    expect(store.transactionAttempts()).toBe(2);
+    expect(store.history("pi_concurrent")).toMatchObject({
       fulfillmentValidated: true,
       revokedAt: null,
     });

--- a/tests/contract/package-payment-state.test.ts
+++ b/tests/contract/package-payment-state.test.ts
@@ -24,6 +24,7 @@ type History = {
 function createPaymentStatePrisma() {
   const histories = new Map<string, History>();
   const packages = new Map<string, { paymentManaged: boolean }>();
+  let concurrentHistoryAfterRollback: History | null = null;
   let raceNextHistoryCreate = false;
   let transactionAttempts = 0;
   const packageKey = (userId: string, packageId: string) =>
@@ -63,13 +64,14 @@ function createPaymentStatePrisma() {
         throw new Error("duplicate payment");
       }
       const history = clone(data);
-      histories.set(history.paymentId, history);
       if (raceNextHistoryCreate) {
         raceNextHistoryCreate = false;
+        concurrentHistoryAfterRollback = history;
         throw Object.assign(new Error("concurrent payment insert"), {
           code: "P2002",
         });
       }
+      histories.set(history.paymentId, history);
       return clone(history);
     },
     update: async ({
@@ -160,11 +162,39 @@ function createPaymentStatePrisma() {
       }) => Promise<T>,
     ) => {
       transactionAttempts++;
-      return await callback({
-        package: packageDelegate,
-        userPaymentHistory,
-        userPackage,
-      });
+      const historiesSnapshot = new Map(
+        [...histories].map(([key, value]) => [key, clone(value)]),
+      );
+      const packagesSnapshot = new Map(
+        [...packages].map(([key, value]) => [key, { ...value }]),
+      );
+      try {
+        return await callback({
+          package: packageDelegate,
+          userPaymentHistory,
+          userPackage,
+        });
+      } catch (error) {
+        histories.clear();
+        for (const [key, value] of historiesSnapshot) {
+          histories.set(key, value);
+        }
+        packages.clear();
+        for (const [key, value] of packagesSnapshot) {
+          packages.set(key, value);
+        }
+        if (concurrentHistoryAfterRollback) {
+          const history = concurrentHistoryAfterRollback;
+          concurrentHistoryAfterRollback = null;
+          histories.set(history.paymentId, clone(history));
+          if (history.fulfillmentValidated && !history.revokedAt) {
+            packages.set(packageKey(history.userId, history.packageId), {
+              paymentManaged: true,
+            });
+          }
+        }
+        throw error;
+      }
     },
   };
 
@@ -212,6 +242,7 @@ describe("package payment migration cutover", () => {
     expect(migration).toContain(
       'ADD COLUMN "paymentManaged" BOOL NOT NULL DEFAULT true;',
     );
+    expect(migration).not.toContain('UPDATE "UserPackage"');
   });
 });
 
@@ -260,6 +291,28 @@ describe("package payment entitlement state", () => {
     expect(store.package("user-1", "package-1")).toEqual({
       paymentManaged: true,
     });
+  });
+
+  it("does not recreate a paid entry after its active payment disappears", async () => {
+    await recordSuccess("pi_reacquire_race");
+    await revokePackagePayment({
+      paymentId: "pi_reacquire_race",
+      event: {
+        id: "evt_refunded_before_readd",
+        createdAt: REFUNDED_AT,
+        rank: PACKAGE_PAYMENT_EVENT_RANK.refundSucceeded,
+      },
+      reason: "refunded",
+    });
+
+    await expect(
+      createUserPackage({
+        userId: "user-1",
+        packageId: "package-1",
+        requireActivePayment: true,
+      }),
+    ).resolves.toBeNull();
+    expect(store.package("user-1", "package-1")).toBeNull();
   });
 
   it("does not fulfill after the package price changes", async () => {
@@ -404,6 +457,39 @@ describe("package payment entitlement state", () => {
     expect(store.package("user-1", "package-1")).toEqual({
       paymentManaged: true,
     });
+  });
+
+  it("does not re-add a user-removed package on restoration replays", async () => {
+    await recordSuccess("pi_restored_once");
+    await revokePackagePayment({
+      paymentId: "pi_restored_once",
+      event: {
+        id: "evt_dispute_opened",
+        createdAt: REFUNDED_AT,
+        rank: PACKAGE_PAYMENT_EVENT_RANK.disputeRevoked,
+      },
+      reason: "disputed",
+    });
+    await restorePackagePayment({
+      paymentId: "pi_restored_once",
+      event: {
+        id: "evt_dispute_won",
+        createdAt: RESTORED_AT,
+        rank: PACKAGE_PAYMENT_EVENT_RANK.disputeRestored,
+      },
+    });
+    store.removePackage("user-1", "package-1");
+
+    await restorePackagePayment({
+      paymentId: "pi_restored_once",
+      event: {
+        id: "evt_funds_reinstated",
+        createdAt: new Date("2026-08-09T00:03:00.000Z"),
+        rank: PACKAGE_PAYMENT_EVENT_RANK.disputeRestored,
+      },
+    });
+
+    expect(store.package("user-1", "package-1")).toBeNull();
   });
 
   it("lets a terminal dispute resolution win a same-second tie", async () => {

--- a/tests/contract/store-checkout-ownership.test.ts
+++ b/tests/contract/store-checkout-ownership.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import {
+  isOwnedPackagePaymentIntent,
+  packagePaymentIntentMetadata,
+  packagePaymentIntentSearchQuery,
+} from "../../apps/web/src/lib/stripe/store-checkout";
+
+describe("store checkout ownership", () => {
+  it("binds package PaymentIntents to the application and user", () => {
+    expect(packagePaymentIntentMetadata("user-1", "package-1")).toEqual({
+      beutlApplication: "beutl-web",
+      beutlPurchaseKind: "package",
+      beutlUserId: "user-1",
+      packageId: "package-1",
+    });
+    expect(
+      packagePaymentIntentSearchQuery({
+        customerId: "cus_1",
+        userId: "user-1",
+        packageId: "package-1",
+        amount: 1_000,
+        currency: "USD",
+      }),
+    ).toContain('metadata["beutlUserId"]:"user-1"');
+  });
+
+  it("accepts only an exact customer, owner, package, and price match", () => {
+    const paymentIntent = {
+      amount: 1_000,
+      currency: "usd",
+      customer: "cus_1",
+      metadata: packagePaymentIntentMetadata("user-1", "package-1"),
+    };
+    const expected = {
+      customerId: "cus_1",
+      userId: "user-1",
+      packageId: "package-1",
+      amount: 1_000,
+      currency: "USD",
+    };
+
+    expect(
+      isOwnedPackagePaymentIntent(paymentIntent as never, expected),
+    ).toBe(true);
+    expect(
+      isOwnedPackagePaymentIntent(paymentIntent as never, {
+        ...expected,
+        userId: "another-user",
+      }),
+    ).toBe(false);
+    expect(
+      isOwnedPackagePaymentIntent(paymentIntent as never, {
+        ...expected,
+        amount: 999,
+      }),
+    ).toBe(false);
+  });
+
+  it("rejects legacy intents without ownership metadata", () => {
+    expect(
+      isOwnedPackagePaymentIntent(
+        {
+          amount: 1_000,
+          currency: "usd",
+          customer: "cus_1",
+          metadata: { packageId: "package-1" },
+        } as never,
+        {
+          customerId: "cus_1",
+          userId: "user-1",
+          packageId: "package-1",
+        },
+      ),
+    ).toBe(false);
+  });
+});

--- a/tests/contract/store-checkout-ownership.test.ts
+++ b/tests/contract/store-checkout-ownership.test.ts
@@ -13,15 +13,25 @@ describe("store checkout ownership", () => {
       beutlUserId: "user-1",
       packageId: "package-1",
     });
-    expect(
-      packagePaymentIntentSearchQuery({
-        customerId: "cus_1",
-        userId: "user-1",
-        packageId: "package-1",
-        amount: 1_000,
-        currency: "USD",
-      }),
-    ).toContain('metadata["beutlUserId"]:"user-1"');
+    const query = packagePaymentIntentSearchQuery({
+      customerId: "cus_1",
+      userId: "user-1",
+      packageId: "package-1",
+      amount: 1_000,
+      currency: "USD",
+    });
+    for (const filter of [
+      'customer:"cus_1"',
+      'metadata["beutlApplication"]:"beutl-web"',
+      'metadata["beutlPurchaseKind"]:"package"',
+      'metadata["beutlUserId"]:"user-1"',
+      'metadata["packageId"]:"package-1"',
+      "amount:1000",
+      'currency:"usd"',
+      'status:"requires_payment_method"',
+    ]) {
+      expect(query).toContain(filter);
+    }
   });
 
   it("accepts only an exact customer, owner, package, and price match", () => {

--- a/tests/contract/stripe-package-payment.test.ts
+++ b/tests/contract/stripe-package-payment.test.ts
@@ -81,8 +81,14 @@ describe("package PaymentIntent validation", () => {
   });
 
   it.each([
-    [{ amount_received: 999 }, "package, amount, or currency mismatch"],
-    [{ status: "processing" }, "package, amount, or currency mismatch"],
+    [
+      { amount_received: 999 },
+      "payment status, amount, or currency is invalid",
+    ],
+    [
+      { status: "processing" },
+      "payment status, amount, or currency is invalid",
+    ],
   ])("refunds incomplete or invalid billing data", async (overrides, reason) => {
     await expect(
       resolvePackagePayment({
@@ -99,7 +105,7 @@ describe("package PaymentIntent validation", () => {
       resolvePackagePayment({ paymentIntent: paymentIntent(), stripe }),
     ).resolves.toEqual({
       status: "refund",
-      reason: "package, amount, or currency mismatch",
+      reason: "package is unpublished or price changed",
     });
   });
 
@@ -163,6 +169,33 @@ describe("package PaymentIntent validation", () => {
     ).resolves.toEqual({
       status: "refund",
       reason: "Stripe customer owner mismatch",
+    });
+  });
+
+  it("refunds a payment for a deleted Stripe customer", async () => {
+    retrieveCustomer.mockResolvedValue({ id: "cus_1", deleted: true });
+
+    await expect(
+      resolvePackagePayment({ paymentIntent: paymentIntent(), stripe }),
+    ).resolves.toEqual({
+      status: "refund",
+      reason: "Stripe customer is closed",
+    });
+  });
+
+  it("refunds a payment for a missing Stripe customer", async () => {
+    retrieveCustomer.mockRejectedValueOnce(
+      Object.assign(new Error("No such customer"), {
+        statusCode: 404,
+        code: "resource_missing",
+      }),
+    );
+
+    await expect(
+      resolvePackagePayment({ paymentIntent: paymentIntent(), stripe }),
+    ).resolves.toEqual({
+      status: "refund",
+      reason: "Stripe customer is closed",
     });
   });
 

--- a/tests/contract/stripe-package-payment.test.ts
+++ b/tests/contract/stripe-package-payment.test.ts
@@ -1,0 +1,191 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  findCustomerOwnersByStripeId: vi.fn(),
+  findPackage: vi.fn(),
+}));
+
+vi.mock("@beutl/db", () => ({
+  findCustomerOwnersByStripeId: mocks.findCustomerOwnersByStripeId,
+  getDb: async () => ({ package: { findFirst: mocks.findPackage } }),
+}));
+
+import {
+  refundPackagePayment,
+  resolvePackagePayment,
+} from "../../apps/web/src/lib/stripe/package-payment";
+import { packagePaymentIntentMetadata } from "../../apps/web/src/lib/stripe/store-checkout";
+
+function paymentIntent(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "pi_package",
+    amount: 1_000,
+    amount_received: 1_000,
+    currency: "usd",
+    customer: "cus_1",
+    metadata: packagePaymentIntentMetadata("user-1", "package-1"),
+    status: "succeeded",
+    ...overrides,
+  } as never;
+}
+
+describe("package PaymentIntent validation", () => {
+  const retrieveCustomer = vi.fn();
+  const createRefund = vi.fn();
+  const stripe = {
+    customers: { retrieve: retrieveCustomer },
+    refunds: { create: createRefund },
+  } as never;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.findCustomerOwnersByStripeId.mockResolvedValue([
+      { userId: "user-1" },
+    ]);
+    mocks.findPackage.mockResolvedValue({ id: "package-1" });
+    retrieveCustomer.mockResolvedValue({
+      id: "cus_1",
+      deleted: false,
+      metadata: {
+        beutlApplication: "beutl-web",
+        beutlUserId: "user-1",
+      },
+    });
+    createRefund.mockResolvedValue({ id: "re_1" });
+  });
+
+  it("fulfills only a fully paid current package price", async () => {
+    await expect(
+      resolvePackagePayment({ paymentIntent: paymentIntent(), stripe }),
+    ).resolves.toEqual({
+      status: "fulfill",
+      reference: {
+        paymentId: "pi_package",
+        packageId: "package-1",
+        userId: "user-1",
+      },
+    });
+    expect(mocks.findPackage).toHaveBeenCalledWith({
+      where: {
+        id: "package-1",
+        published: true,
+        packagePricing: {
+          some: {
+            price: 1_000,
+            currency: { equals: "usd", mode: "insensitive" },
+          },
+        },
+      },
+      select: { id: true },
+    });
+  });
+
+  it.each([
+    [{ amount_received: 999 }, "package, amount, or currency mismatch"],
+    [{ status: "processing" }, "package, amount, or currency mismatch"],
+  ])("refunds incomplete or invalid billing data", async (overrides, reason) => {
+    await expect(
+      resolvePackagePayment({
+        paymentIntent: paymentIntent(overrides),
+        stripe,
+      }),
+    ).resolves.toEqual({ status: "refund", reason });
+  });
+
+  it("refunds a stale or unpublished package price", async () => {
+    mocks.findPackage.mockResolvedValue(null);
+
+    await expect(
+      resolvePackagePayment({ paymentIntent: paymentIntent(), stripe }),
+    ).resolves.toEqual({
+      status: "refund",
+      reason: "package, amount, or currency mismatch",
+    });
+  });
+
+  it("refunds a legacy intent without an owner binding", async () => {
+    await expect(
+      resolvePackagePayment({
+        paymentIntent: paymentIntent({ metadata: { packageId: "package-1" } }),
+        stripe,
+      }),
+    ).resolves.toEqual({
+      status: "refund",
+      reason: "missing package ownership binding",
+    });
+    expect(retrieveCustomer).not.toHaveBeenCalled();
+  });
+
+  it("refunds duplicate or mismatched customer ownership", async () => {
+    mocks.findCustomerOwnersByStripeId.mockResolvedValue([
+      { userId: "user-1" },
+      { userId: "user-2" },
+    ]);
+
+    await expect(
+      resolvePackagePayment({ paymentIntent: paymentIntent(), stripe }),
+    ).resolves.toEqual({
+      status: "refund",
+      reason: "customer mapping mismatch",
+    });
+  });
+
+  it("refunds conflicting Stripe customer metadata", async () => {
+    retrieveCustomer.mockResolvedValue({
+      id: "cus_1",
+      deleted: false,
+      metadata: {
+        beutlApplication: "beutl-web",
+        beutlUserId: "another-user",
+      },
+    });
+
+    await expect(
+      resolvePackagePayment({ paymentIntent: paymentIntent(), stripe }),
+    ).resolves.toEqual({
+      status: "refund",
+      reason: "Stripe customer owner mismatch",
+    });
+  });
+
+  it("ignores PaymentIntents that are not package purchases", async () => {
+    await expect(
+      resolvePackagePayment({
+        paymentIntent: paymentIntent({ metadata: {} }),
+        stripe,
+      }),
+    ).resolves.toEqual({ status: "unrecognized" });
+  });
+
+  it("uses an idempotent full refund when validation fails", async () => {
+    await refundPackagePayment({
+      paymentIntentId: "pi_package",
+      reason: "package mismatch",
+      stripe,
+    });
+
+    expect(createRefund).toHaveBeenCalledWith(
+      expect.objectContaining({
+        payment_intent: "pi_package",
+        reason: "requested_by_customer",
+      }),
+      { idempotencyKey: "beutl:package-payment:pi_package:refund" },
+    );
+  });
+
+  it("accepts a payment that was already fully refunded", async () => {
+    createRefund.mockRejectedValueOnce(
+      Object.assign(new Error("already refunded"), {
+        code: "charge_already_refunded",
+      }),
+    );
+
+    await expect(
+      refundPackagePayment({
+        paymentIntentId: "pi_package",
+        reason: "package mismatch",
+        stripe,
+      }),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/tests/contract/stripe-package-payment.test.ts
+++ b/tests/contract/stripe-package-payment.test.ts
@@ -116,6 +116,24 @@ describe("package PaymentIntent validation", () => {
     expect(retrieveCustomer).not.toHaveBeenCalled();
   });
 
+  it("refunds a package-marked intent without a package id", async () => {
+    await expect(
+      resolvePackagePayment({
+        paymentIntent: paymentIntent({
+          metadata: {
+            ...packagePaymentIntentMetadata("user-1", "package-1"),
+            packageId: " ",
+          },
+        }),
+        stripe,
+      }),
+    ).resolves.toEqual({
+      status: "refund",
+      reason: "missing package id",
+    });
+    expect(retrieveCustomer).not.toHaveBeenCalled();
+  });
+
   it("refunds duplicate or mismatched customer ownership", async () => {
     mocks.findCustomerOwnersByStripeId.mockResolvedValue([
       { userId: "user-1" },

--- a/tests/contract/stripe-package-webhook.test.ts
+++ b/tests/contract/stripe-package-webhook.test.ts
@@ -1,0 +1,289 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  addAuditLog: vi.fn(),
+  constructEvent: vi.fn(),
+  findPackagePaymentReference: vi.fn(),
+  recordPackagePaymentSucceeded: vi.fn(),
+  refundPackagePayment: vi.fn(),
+  resolvePackagePayment: vi.fn(),
+  resolvePackagePaymentOwner: vi.fn(),
+  restorePackagePayment: vi.fn(),
+  retrieveCharge: vi.fn(),
+  retrieveDispute: vi.fn(),
+  retrievePaymentIntent: vi.fn(),
+  revokePackagePayment: vi.fn(),
+}));
+
+vi.mock("@/lib/audit-log", () => ({
+  addAuditLog: mocks.addAuditLog,
+  auditLogActions: {
+    store: {
+      paymentRestored: "store.paymentRestored",
+      paymentRevoked: "store.paymentRevoked",
+      paymentSucceeded: "store.paymentSucceeded",
+    },
+  },
+}));
+vi.mock("@/lib/stripe/config", () => ({
+  createStripe: () => ({
+    charges: { retrieve: mocks.retrieveCharge },
+    disputes: { retrieve: mocks.retrieveDispute },
+    paymentIntents: { retrieve: mocks.retrievePaymentIntent },
+    webhooks: { constructEvent: mocks.constructEvent },
+  }),
+}));
+vi.mock("@/lib/stripe/package-payment", () => ({
+  refundPackagePayment: mocks.refundPackagePayment,
+  resolvePackagePayment: mocks.resolvePackagePayment,
+  resolvePackagePaymentOwner: mocks.resolvePackagePaymentOwner,
+}));
+vi.mock("@beutl/db", () => ({
+  PACKAGE_PAYMENT_EVENT_RANK: {
+    paymentSucceeded: 10,
+    disputeRestored: 20,
+    disputeRevoked: 30,
+    refundSucceeded: 40,
+  },
+  findPackagePaymentReference: mocks.findPackagePaymentReference,
+  recordPackagePaymentSucceeded: mocks.recordPackagePaymentSucceeded,
+  restorePackagePayment: mocks.restorePackagePayment,
+  revokePackagePayment: mocks.revokePackagePayment,
+}));
+
+import { POST } from "../../apps/web/src/app/api/stripe/webhook/route";
+
+const reference = {
+  paymentId: "pi_package",
+  userId: "user-1",
+  packageId: "package-1",
+};
+
+function request(): Request {
+  return new Request("https://beutl.example/api/stripe/webhook", {
+    method: "POST",
+    headers: { "stripe-signature": "signature" },
+    body: "{}",
+  });
+}
+
+function event(type: string, object: object) {
+  return {
+    id: `evt_${type}`,
+    created: 1_786_060_900,
+    type,
+    data: { object },
+  };
+}
+
+describe("package payment webhook state", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.STRIPE_ENDPOINT_SECRET = "whsec_test";
+    mocks.findPackagePaymentReference.mockResolvedValue(null);
+    mocks.recordPackagePaymentSucceeded.mockResolvedValue({
+      ...reference,
+      active: true,
+      changed: true,
+    });
+    mocks.revokePackagePayment.mockResolvedValue({
+      ...reference,
+      active: false,
+      changed: true,
+    });
+    mocks.restorePackagePayment.mockResolvedValue({
+      ...reference,
+      active: true,
+      changed: true,
+    });
+    mocks.retrievePaymentIntent.mockResolvedValue({
+      id: "pi_package",
+      metadata: {},
+    });
+  });
+
+  it("records only a validated successful package payment", async () => {
+    const paymentIntent = {
+      id: "pi_package",
+      amount: 1_000,
+      currency: "usd",
+    };
+    mocks.constructEvent.mockReturnValue(
+      event("payment_intent.succeeded", paymentIntent),
+    );
+    mocks.resolvePackagePayment.mockResolvedValue({
+      status: "fulfill",
+      reference,
+    });
+
+    expect((await POST(request() as never)).status).toBe(200);
+    expect(mocks.recordPackagePaymentSucceeded).toHaveBeenCalledWith({
+      reference,
+      billing: {
+        amount: 1_000,
+        currency: "usd",
+      },
+      event: expect.objectContaining({
+        id: "evt_payment_intent.succeeded",
+        rank: 10,
+      }),
+    });
+  });
+
+  it("uses an idempotent refund for an invalid successful payment", async () => {
+    mocks.constructEvent.mockReturnValue(
+      event("payment_intent.succeeded", { id: "pi_package" }),
+    );
+    mocks.resolvePackagePayment.mockResolvedValue({
+      status: "refund",
+      reason: "amount mismatch",
+    });
+
+    expect((await POST(request() as never)).status).toBe(200);
+    expect(mocks.refundPackagePayment).toHaveBeenCalledWith(
+      expect.objectContaining({
+        paymentIntentId: "pi_package",
+        reason: "amount mismatch",
+      }),
+    );
+    expect(mocks.recordPackagePaymentSucceeded).not.toHaveBeenCalled();
+  });
+
+  it("does not reprocess a payment already recorded before deployment", async () => {
+    mocks.constructEvent.mockReturnValue(
+      event("payment_intent.succeeded", { id: "pi_package" }),
+    );
+    mocks.findPackagePaymentReference.mockResolvedValue(reference);
+
+    expect((await POST(request() as never)).status).toBe(200);
+    expect(mocks.resolvePackagePayment).not.toHaveBeenCalled();
+    expect(mocks.refundPackagePayment).not.toHaveBeenCalled();
+  });
+
+  it("refunds when the package price changes during fulfillment", async () => {
+    const paymentIntent = {
+      id: "pi_package",
+      amount: 1_000,
+      currency: "usd",
+    };
+    mocks.constructEvent.mockReturnValue(
+      event("payment_intent.succeeded", paymentIntent),
+    );
+    mocks.resolvePackagePayment.mockResolvedValue({
+      status: "fulfill",
+      reference,
+    });
+    mocks.recordPackagePaymentSucceeded.mockResolvedValue(null);
+
+    expect((await POST(request() as never)).status).toBe(200);
+    expect(mocks.refundPackagePayment).toHaveBeenCalledWith(
+      expect.objectContaining({
+        paymentIntentId: "pi_package",
+        reason: "package price changed before fulfillment",
+      }),
+    );
+  });
+
+  it("revokes package access after a refund", async () => {
+    mocks.findPackagePaymentReference.mockResolvedValue(reference);
+    mocks.constructEvent.mockReturnValue(
+      event("charge.refunded", { id: "ch_1" }),
+    );
+    mocks.retrieveCharge.mockResolvedValue({
+      id: "ch_1",
+      amount_refunded: 1_000,
+      payment_intent: "pi_package",
+    });
+
+    expect((await POST(request() as never)).status).toBe(200);
+    expect(mocks.revokePackagePayment).toHaveBeenCalledWith(
+      expect.objectContaining({
+        paymentId: "pi_package",
+        reason: "charge refunded: ch_1",
+        event: expect.objectContaining({ rank: 40 }),
+      }),
+    );
+  });
+
+  it("revokes access while a dispute is open", async () => {
+    mocks.findPackagePaymentReference.mockResolvedValue(reference);
+    mocks.constructEvent.mockReturnValue(
+      event("charge.dispute.created", { id: "dp_1" }),
+    );
+    mocks.retrieveDispute.mockResolvedValue({
+      id: "dp_1",
+      charge: "ch_1",
+      payment_intent: "pi_package",
+      status: "under_review",
+    });
+
+    expect((await POST(request() as never)).status).toBe(200);
+    expect(mocks.revokePackagePayment).toHaveBeenCalledWith(
+      expect.objectContaining({
+        paymentId: "pi_package",
+        event: expect.objectContaining({ rank: 30 }),
+      }),
+    );
+  });
+
+  it("restores access after a won dispute when no refund remains", async () => {
+    mocks.findPackagePaymentReference.mockResolvedValue(reference);
+    mocks.constructEvent.mockReturnValue(
+      event("charge.dispute.closed", { id: "dp_1" }),
+    );
+    mocks.retrieveDispute.mockResolvedValue({
+      id: "dp_1",
+      charge: "ch_1",
+      payment_intent: "pi_package",
+      status: "won",
+    });
+    mocks.retrieveCharge.mockResolvedValue({
+      id: "ch_1",
+      amount_refunded: 0,
+    });
+
+    expect((await POST(request() as never)).status).toBe(200);
+    expect(mocks.restorePackagePayment).toHaveBeenCalledWith(
+      expect.objectContaining({
+        paymentId: "pi_package",
+        event: expect.objectContaining({ rank: 20 }),
+      }),
+    );
+  });
+
+  it("does not restore a won dispute after any refund", async () => {
+    mocks.findPackagePaymentReference.mockResolvedValue(reference);
+    mocks.constructEvent.mockReturnValue(
+      event("charge.dispute.closed", { id: "dp_1" }),
+    );
+    mocks.retrieveDispute.mockResolvedValue({
+      id: "dp_1",
+      charge: "ch_1",
+      payment_intent: "pi_package",
+      status: "won",
+    });
+    mocks.retrieveCharge.mockResolvedValue({
+      id: "ch_1",
+      amount_refunded: 1,
+    });
+
+    expect((await POST(request() as never)).status).toBe(200);
+    expect(mocks.restorePackagePayment).not.toHaveBeenCalled();
+  });
+
+  it("does not change access for a warning inquiry", async () => {
+    mocks.constructEvent.mockReturnValue(
+      event("charge.dispute.updated", { id: "dp_warning" }),
+    );
+    mocks.retrieveDispute.mockResolvedValue({
+      id: "dp_warning",
+      charge: "ch_1",
+      payment_intent: "pi_package",
+      status: "warning_under_review",
+    });
+
+    expect((await POST(request() as never)).status).toBe(200);
+    expect(mocks.revokePackagePayment).not.toHaveBeenCalled();
+    expect(mocks.restorePackagePayment).not.toHaveBeenCalled();
+  });
+});

--- a/tests/contract/stripe-package-webhook.test.ts
+++ b/tests/contract/stripe-package-webhook.test.ts
@@ -254,6 +254,59 @@ describe("package payment webhook state", () => {
     );
   });
 
+  it("finds a succeeded refund on a later page", async () => {
+    mocks.findPackagePaymentReference.mockResolvedValue(validatedReference);
+    mocks.constructEvent.mockReturnValue(
+      event("charge.refunded", { id: "ch_paged" }),
+    );
+    mocks.retrieveCharge.mockResolvedValue({
+      id: "ch_paged",
+      amount_refunded: 1_000,
+      payment_intent: "pi_package",
+    });
+    mocks.listRefunds
+      .mockResolvedValueOnce({
+        data: [{ id: "re_pending", status: "pending" }],
+        has_more: true,
+      })
+      .mockResolvedValueOnce({
+        data: [{ id: "re_succeeded", status: "succeeded" }],
+        has_more: false,
+      });
+
+    expect((await POST(request() as never)).status).toBe(200);
+    expect(mocks.listRefunds).toHaveBeenNthCalledWith(2, {
+      charge: "ch_paged",
+      limit: 100,
+      starting_after: "re_pending",
+    });
+    expect(mocks.revokePackagePayment).toHaveBeenCalledWith(
+      expect.objectContaining({ reason: "refund succeeded: re_succeeded" }),
+    );
+  });
+
+  it("rejects an empty refund page that claims more results", async () => {
+    mocks.constructEvent.mockReturnValue(
+      event("charge.refunded", { id: "ch_empty_page" }),
+    );
+    mocks.retrieveCharge.mockResolvedValue({
+      id: "ch_empty_page",
+      amount_refunded: 1_000,
+      payment_intent: "pi_package",
+    });
+    mocks.listRefunds.mockResolvedValue({ data: [], has_more: true });
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+
+    expect((await POST(request() as never)).status).toBe(500);
+    expect(consoleError).toHaveBeenCalledWith(
+      "Stripe webhook handler failed",
+      expect.any(Error),
+    );
+    consoleError.mockRestore();
+  });
+
   it("keeps access while an asynchronous refund is pending", async () => {
     mocks.findPackagePaymentReference.mockResolvedValue(validatedReference);
     mocks.constructEvent.mockReturnValue(
@@ -343,6 +396,33 @@ describe("package payment webhook state", () => {
     expect((await POST(request() as never)).status).toBe(500);
     expect(consoleError).toHaveBeenCalledWith(
       "Stripe webhook handler failed",
+      expect.any(Error),
+    );
+    consoleError.mockRestore();
+  });
+
+  it("keeps a committed payment when the audit log write fails", async () => {
+    mocks.constructEvent.mockReturnValue(
+      event("payment_intent.succeeded", {
+        id: "pi_package",
+        amount: 1_000,
+        currency: "usd",
+      }),
+    );
+    mocks.resolvePackagePayment.mockResolvedValue({
+      status: "fulfill",
+      reference,
+    });
+    mocks.addAuditLog.mockRejectedValueOnce(new Error("audit unavailable"));
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+
+    expect((await POST(request() as never)).status).toBe(200);
+    expect(mocks.recordPackagePaymentSucceeded).toHaveBeenCalled();
+    expect(mocks.refundPackagePayment).not.toHaveBeenCalled();
+    expect(consoleError).toHaveBeenCalledWith(
+      "Failed to record package-payment audit log",
       expect.any(Error),
     );
     consoleError.mockRestore();

--- a/tests/contract/stripe-package-webhook.test.ts
+++ b/tests/contract/stripe-package-webhook.test.ts
@@ -9,9 +9,11 @@ const mocks = vi.hoisted(() => ({
   resolvePackagePayment: vi.fn(),
   resolvePackagePaymentOwner: vi.fn(),
   restorePackagePayment: vi.fn(),
+  listRefunds: vi.fn(),
   retrieveCharge: vi.fn(),
   retrieveDispute: vi.fn(),
   retrievePaymentIntent: vi.fn(),
+  retrieveRefund: vi.fn(),
   revokePackagePayment: vi.fn(),
 }));
 
@@ -21,6 +23,8 @@ vi.mock("@/lib/audit-log", () => ({
     store: {
       paymentRestored: "store.paymentRestored",
       paymentRevoked: "store.paymentRevoked",
+      paymentRefundFailed: "store.paymentRefundFailed",
+      paymentRefundRequiresAction: "store.paymentRefundRequiresAction",
       paymentSucceeded: "store.paymentSucceeded",
     },
   },
@@ -30,6 +34,10 @@ vi.mock("@/lib/stripe/config", () => ({
     charges: { retrieve: mocks.retrieveCharge },
     disputes: { retrieve: mocks.retrieveDispute },
     paymentIntents: { retrieve: mocks.retrievePaymentIntent },
+    refunds: {
+      list: mocks.listRefunds,
+      retrieve: mocks.retrieveRefund,
+    },
     webhooks: { constructEvent: mocks.constructEvent },
   }),
 }));
@@ -41,8 +49,8 @@ vi.mock("@/lib/stripe/package-payment", () => ({
 vi.mock("@beutl/db", () => ({
   PACKAGE_PAYMENT_EVENT_RANK: {
     paymentSucceeded: 10,
-    disputeRestored: 20,
-    disputeRevoked: 30,
+    disputeRevoked: 20,
+    disputeRestored: 30,
     refundSucceeded: 40,
   },
   findPackagePaymentReference: mocks.findPackagePaymentReference,
@@ -57,6 +65,14 @@ const reference = {
   paymentId: "pi_package",
   userId: "user-1",
   packageId: "package-1",
+};
+const validatedReference = {
+  ...reference,
+  fulfillmentValidated: true,
+};
+const tombstoneReference = {
+  ...reference,
+  fulfillmentValidated: false,
 };
 
 function request(): Request {
@@ -100,6 +116,7 @@ describe("package payment webhook state", () => {
       id: "pi_package",
       metadata: {},
     });
+    mocks.listRefunds.mockResolvedValue({ data: [], has_more: false });
   });
 
   it("records only a validated successful package payment", async () => {
@@ -153,11 +170,33 @@ describe("package payment webhook state", () => {
     mocks.constructEvent.mockReturnValue(
       event("payment_intent.succeeded", { id: "pi_package" }),
     );
-    mocks.findPackagePaymentReference.mockResolvedValue(reference);
+    mocks.findPackagePaymentReference.mockResolvedValue(validatedReference);
 
     expect((await POST(request() as never)).status).toBe(200);
     expect(mocks.resolvePackagePayment).not.toHaveBeenCalled();
     expect(mocks.refundPackagePayment).not.toHaveBeenCalled();
+  });
+
+  it("validates a reversal tombstone when success arrives late", async () => {
+    const paymentIntent = {
+      id: "pi_package",
+      amount: 1_000,
+      currency: "usd",
+    };
+    mocks.constructEvent.mockReturnValue(
+      event("payment_intent.succeeded", paymentIntent),
+    );
+    mocks.findPackagePaymentReference.mockResolvedValue(tombstoneReference);
+    mocks.resolvePackagePayment.mockResolvedValue({
+      status: "fulfill",
+      reference,
+    });
+
+    expect((await POST(request() as never)).status).toBe(200);
+    expect(mocks.resolvePackagePayment).toHaveBeenCalled();
+    expect(mocks.recordPackagePaymentSucceeded).toHaveBeenCalledWith(
+      expect.objectContaining({ reference }),
+    );
   });
 
   it("refunds when the package price changes during fulfillment", async () => {
@@ -185,7 +224,7 @@ describe("package payment webhook state", () => {
   });
 
   it("revokes package access after a refund", async () => {
-    mocks.findPackagePaymentReference.mockResolvedValue(reference);
+    mocks.findPackagePaymentReference.mockResolvedValue(validatedReference);
     mocks.constructEvent.mockReturnValue(
       event("charge.refunded", { id: "ch_1" }),
     );
@@ -194,19 +233,170 @@ describe("package payment webhook state", () => {
       amount_refunded: 1_000,
       payment_intent: "pi_package",
     });
+    mocks.listRefunds.mockResolvedValue({
+      data: [
+        {
+          id: "re_1",
+          payment_intent: "pi_package",
+          status: "succeeded",
+        },
+      ],
+      has_more: false,
+    });
 
     expect((await POST(request() as never)).status).toBe(200);
     expect(mocks.revokePackagePayment).toHaveBeenCalledWith(
       expect.objectContaining({
         paymentId: "pi_package",
-        reason: "charge refunded: ch_1",
+        reason: "refund succeeded: re_1",
         event: expect.objectContaining({ rank: 40 }),
       }),
     );
   });
 
+  it("keeps access while an asynchronous refund is pending", async () => {
+    mocks.findPackagePaymentReference.mockResolvedValue(validatedReference);
+    mocks.constructEvent.mockReturnValue(
+      event("charge.refunded", { id: "ch_pending" }),
+    );
+    mocks.retrieveCharge.mockResolvedValue({
+      id: "ch_pending",
+      amount_refunded: 1_000,
+      payment_intent: "pi_package",
+    });
+    mocks.listRefunds.mockResolvedValue({
+      data: [{ id: "re_pending", status: "pending" }],
+      has_more: false,
+    });
+
+    expect((await POST(request() as never)).status).toBe(200);
+    expect(mocks.revokePackagePayment).not.toHaveBeenCalled();
+  });
+
+  it("revokes access when an asynchronous refund later succeeds", async () => {
+    mocks.findPackagePaymentReference.mockResolvedValue(validatedReference);
+    mocks.constructEvent.mockReturnValue(
+      event("refund.updated", { id: "re_async" }),
+    );
+    mocks.retrieveRefund.mockResolvedValue({
+      id: "re_async",
+      charge: "ch_1",
+      payment_intent: "pi_package",
+      status: "succeeded",
+    });
+
+    expect((await POST(request() as never)).status).toBe(200);
+    expect(mocks.revokePackagePayment).toHaveBeenCalledWith(
+      expect.objectContaining({
+        paymentId: "pi_package",
+        reason: "refund succeeded: re_async",
+        event: expect.objectContaining({ rank: 40 }),
+      }),
+    );
+  });
+
+  it.each([
+    { eventType: "refund.failed", status: "failed" },
+    { eventType: "refund.updated", status: "canceled" },
+    { eventType: "refund.updated", status: "requires_action" },
+  ])(
+    "keeps access when an asynchronous refund reaches $status",
+    async ({ eventType, status }) => {
+      mocks.findPackagePaymentReference.mockResolvedValue(validatedReference);
+      mocks.constructEvent.mockReturnValue(
+        event(eventType, { id: "re_unsuccessful" }),
+      );
+      mocks.retrieveRefund.mockResolvedValue({
+        id: "re_unsuccessful",
+        charge: "ch_1",
+        payment_intent: "pi_package",
+        status,
+      });
+
+      expect((await POST(request() as never)).status).toBe(200);
+      expect(mocks.revokePackagePayment).not.toHaveBeenCalled();
+      expect(mocks.restorePackagePayment).not.toHaveBeenCalled();
+      expect(mocks.addAuditLog).not.toHaveBeenCalled();
+    },
+  );
+
+  it("retries when an automatic-refund incident cannot be persisted", async () => {
+    mocks.constructEvent.mockReturnValue(
+      event("refund.failed", { id: "re_automatic" }),
+    );
+    mocks.retrieveRefund.mockResolvedValue({
+      id: "re_automatic",
+      charge: "ch_automatic",
+      payment_intent: "pi_package",
+      status: "failed",
+      failure_reason: "insufficient_funds",
+      metadata: {
+        beutlDisposition: "package-payment-validation-failed",
+        beutlDispositionReason: "amount mismatch",
+      },
+    });
+    mocks.addAuditLog.mockRejectedValueOnce(new Error("audit unavailable"));
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+
+    expect((await POST(request() as never)).status).toBe(500);
+    expect(consoleError).toHaveBeenCalledWith(
+      "Stripe webhook handler failed",
+      expect.any(Error),
+    );
+    consoleError.mockRestore();
+  });
+
+  it.each([
+    {
+      action: "store.paymentRefundFailed",
+      eventType: "refund.failed",
+      status: "failed",
+    },
+    {
+      action: "store.paymentRefundFailed",
+      eventType: "refund.updated",
+      status: "canceled",
+    },
+    {
+      action: "store.paymentRefundRequiresAction",
+      eventType: "refund.updated",
+      status: "requires_action",
+    },
+  ])(
+    "persists an intervention when an automatic refund reaches $status",
+    async ({ action, eventType, status }) => {
+      mocks.constructEvent.mockReturnValue(
+        event(eventType, { id: "re_automatic" }),
+      );
+      mocks.retrieveRefund.mockResolvedValue({
+        id: "re_automatic",
+        charge: "ch_automatic",
+        payment_intent: "pi_package",
+        status,
+        failure_reason: "insufficient_funds",
+        metadata: {
+          beutlDisposition: "package-payment-validation-failed",
+          beutlDispositionReason: "amount mismatch",
+        },
+      });
+
+      expect((await POST(request() as never)).status).toBe(200);
+      expect(mocks.addAuditLog).toHaveBeenCalledWith({
+        userId: null,
+        action,
+        details: expect.stringContaining(
+          `refundId: re_automatic, refundStatus: ${status}`,
+        ),
+      });
+      expect(mocks.revokePackagePayment).not.toHaveBeenCalled();
+      expect(mocks.restorePackagePayment).not.toHaveBeenCalled();
+    },
+  );
+
   it("revokes access while a dispute is open", async () => {
-    mocks.findPackagePaymentReference.mockResolvedValue(reference);
+    mocks.findPackagePaymentReference.mockResolvedValue(validatedReference);
     mocks.constructEvent.mockReturnValue(
       event("charge.dispute.created", { id: "dp_1" }),
     );
@@ -221,13 +411,13 @@ describe("package payment webhook state", () => {
     expect(mocks.revokePackagePayment).toHaveBeenCalledWith(
       expect.objectContaining({
         paymentId: "pi_package",
-        event: expect.objectContaining({ rank: 30 }),
+        event: expect.objectContaining({ rank: 20 }),
       }),
     );
   });
 
   it("restores access after a won dispute when no refund remains", async () => {
-    mocks.findPackagePaymentReference.mockResolvedValue(reference);
+    mocks.findPackagePaymentReference.mockResolvedValue(validatedReference);
     mocks.constructEvent.mockReturnValue(
       event("charge.dispute.closed", { id: "dp_1" }),
     );
@@ -246,13 +436,13 @@ describe("package payment webhook state", () => {
     expect(mocks.restorePackagePayment).toHaveBeenCalledWith(
       expect.objectContaining({
         paymentId: "pi_package",
-        event: expect.objectContaining({ rank: 20 }),
+        event: expect.objectContaining({ rank: 30 }),
       }),
     );
   });
 
-  it("does not restore a won dispute after any refund", async () => {
-    mocks.findPackagePaymentReference.mockResolvedValue(reference);
+  it("does not restore a won dispute after a succeeded refund", async () => {
+    mocks.findPackagePaymentReference.mockResolvedValue(validatedReference);
     mocks.constructEvent.mockReturnValue(
       event("charge.dispute.closed", { id: "dp_1" }),
     );
@@ -266,9 +456,110 @@ describe("package payment webhook state", () => {
       id: "ch_1",
       amount_refunded: 1,
     });
+    mocks.listRefunds.mockResolvedValue({
+      data: [{ id: "re_1", status: "succeeded" }],
+      has_more: false,
+    });
 
     expect((await POST(request() as never)).status).toBe(200);
     expect(mocks.restorePackagePayment).not.toHaveBeenCalled();
+  });
+
+  it("restores a won dispute after an unsuccessful refund", async () => {
+    mocks.findPackagePaymentReference.mockResolvedValue(validatedReference);
+    mocks.constructEvent.mockReturnValue(
+      event("charge.dispute.closed", { id: "dp_1" }),
+    );
+    mocks.retrieveDispute.mockResolvedValue({
+      id: "dp_1",
+      charge: "ch_1",
+      payment_intent: "pi_package",
+      status: "won",
+    });
+    mocks.retrieveCharge.mockResolvedValue({
+      id: "ch_1",
+      amount_refunded: 1,
+    });
+    mocks.listRefunds.mockResolvedValue({
+      data: [{ id: "re_failed", status: "failed" }],
+      has_more: false,
+    });
+
+    expect((await POST(request() as never)).status).toBe(200);
+    expect(mocks.restorePackagePayment).toHaveBeenCalledWith(
+      expect.objectContaining({
+        paymentId: "pi_package",
+        event: expect.objectContaining({ rank: 30 }),
+      }),
+    );
+  });
+
+  it("does not restore an invalid reversal tombstone", async () => {
+    mocks.findPackagePaymentReference.mockResolvedValue(tombstoneReference);
+    mocks.constructEvent.mockReturnValue(
+      event("charge.dispute.closed", { id: "dp_tombstone" }),
+    );
+    mocks.retrieveDispute.mockResolvedValue({
+      id: "dp_tombstone",
+      charge: "ch_1",
+      payment_intent: "pi_package",
+      status: "won",
+    });
+    mocks.retrievePaymentIntent.mockResolvedValue({
+      id: "pi_package",
+      amount: 1_000,
+      currency: "usd",
+      metadata: {},
+    });
+    mocks.resolvePackagePayment.mockResolvedValue({
+      status: "refund",
+      reason: "package, amount, or currency mismatch",
+    });
+    mocks.retrieveCharge.mockResolvedValue({
+      id: "ch_1",
+      amount_refunded: 0,
+    });
+
+    expect((await POST(request() as never)).status).toBe(200);
+    expect(mocks.recordPackagePaymentSucceeded).not.toHaveBeenCalled();
+    expect(mocks.restorePackagePayment).not.toHaveBeenCalled();
+  });
+
+  it("revalidates a reversal tombstone before restoring it", async () => {
+    mocks.findPackagePaymentReference.mockResolvedValue(tombstoneReference);
+    mocks.constructEvent.mockReturnValue(
+      event("charge.dispute.closed", { id: "dp_tombstone" }),
+    );
+    mocks.retrieveDispute.mockResolvedValue({
+      id: "dp_tombstone",
+      charge: "ch_1",
+      payment_intent: "pi_package",
+      status: "won",
+    });
+    mocks.retrievePaymentIntent.mockResolvedValue({
+      id: "pi_package",
+      amount: 1_000,
+      currency: "usd",
+      metadata: {},
+    });
+    mocks.resolvePackagePayment.mockResolvedValue({
+      status: "fulfill",
+      reference,
+    });
+    mocks.retrieveCharge.mockResolvedValue({
+      id: "ch_1",
+      amount_refunded: 0,
+    });
+
+    expect((await POST(request() as never)).status).toBe(200);
+    expect(mocks.recordPackagePaymentSucceeded).toHaveBeenCalledWith({
+      reference,
+      billing: { amount: 1_000, currency: "usd" },
+      event: expect.objectContaining({ rank: 10 }),
+    });
+    expect(mocks.restorePackagePayment).toHaveBeenCalledWith(
+      expect.objectContaining({ paymentId: "pi_package" }),
+    );
   });
 
   it("does not change access for a warning inquiry", async () => {


### PR DESCRIPTION
## Summary

- bind each package PaymentIntent to the Beutl application, app user, Stripe customer, and package
- make Stripe customer ownership unique and replace ambiguous or conflicting legacy mappings
- require a fully received, exact current amount and currency before fulfillment, with a second transactional price check
- automatically and idempotently refund charged payments that fail validation
- persist ordered package-payment state so refunds and chargebacks revoke access without stale webhook deliveries restoring it
- restore access only after a safe dispute resolution and never while any refund remains
- add a dry-run-by-default reconciliation command for refunds and disputes that predate this deployment

## Root cause

Package fulfillment trusted mutable PaymentIntent metadata and the current customer lookup without an exact amount, currency, publication, or durable owner check. Entitlement and payment-history writes were separate, and refund or dispute events did not update package access.

## Impact

New purchases fail closed when ownership or billing data is inconsistent. Successful refunds and active or lost disputes remove payment-derived access atomically; won or prevented disputes can restore it. Manually managed library entries and additional active purchases remain intact.

## Deployment

1. Apply the included Prisma migration before deploying the application.
2. Deploy the webhook and checkout changes.
3. Subscribe the Stripe endpoint to `charge.refunded` and the `charge.dispute.*` events handled by this route, in addition to `payment_intent.succeeded`.
4. Inspect historical state without writes:
   `pnpm --filter @beutl/web reconcile:package-payments`
5. After reviewing the output, apply it explicitly:
   `pnpm --filter @beutl/web reconcile:package-payments -- --apply`

The reconciliation command requires production `DATABASE_URL` and `STRIPE_SECRET_KEY`. Legacy in-flight PaymentIntents without owner bindings are not fulfilled; charged ones are refunded. Payments already recorded before deployment remain idempotent.

## Checks

- `corepack pnpm test` (51 tests passed)
- `corepack pnpm --filter @beutl/web exec tsc --noEmit`
- `corepack pnpm --filter @beutl/api build`
- `corepack pnpm --filter @beutl/web lint`
- `corepack pnpm --filter @beutl/web exec prisma validate --schema prisma/schema.prisma`
- `node --check apps/web/scripts/reconcile-package-payments.mjs`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added clearer package checkout statuses, including processing, refunded, and revoked payments.
  - Checkout now refreshes automatically while payment fulfillment is processing.
  - Added validation for package, customer, price, and currency matching.
  - Package access is granted, revoked, or restored based on payment, refund, and dispute activity.
  - Added historical payment reconciliation and safer handling of duplicate or invalid payments.

- **Localization**
  - Added English and Japanese messaging for refunded and revoked purchases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->