### PR TITLE
fix: avoid billing entitlement transaction timeout

### DIFF
--- a/apps/admin/src/prisma.ts
+++ b/apps/admin/src/prisma.ts
@@ -19,7 +19,7 @@ const createPrismaClient = async () => {
     throw new Error("Hyperdrive connection string not available");
   }
 
-  const adapter = new PrismaPg({ connectionString, max: 5, maxUses: 1 });
+  const adapter = new PrismaPg({ connectionString, maxUses: 1 });
   const prisma = new PrismaClient({ adapter });
   after(() => prisma.$disconnect());
   return prisma;

--- a/apps/admin/src/prisma.ts
+++ b/apps/admin/src/prisma.ts
@@ -19,7 +19,7 @@ const createPrismaClient = async () => {
     throw new Error("Hyperdrive connection string not available");
   }
 
-  const adapter = new PrismaPg({ connectionString, maxUses: 1 });
+  const adapter = new PrismaPg({ connectionString, max: 5, maxUses: 1 });
   const prisma = new PrismaClient({ adapter });
   after(() => prisma.$disconnect());
   return prisma;

--- a/apps/web/src/app/[lang]/(dashboard)/dashboard/account/billing/queries.ts
+++ b/apps/web/src/app/[lang]/(dashboard)/dashboard/account/billing/queries.ts
@@ -61,12 +61,11 @@ async function retrieveBillingDocumentsIfReachable({
 }
 
 export async function retrieveBillingPage(userId: string) {
-  // Explicitly share the request-scoped PrismaClient across billing reads.
-  // The entitlement summary owns its consistent transaction.
+  // Explicitly share the render-scoped PrismaClient across all billing reads.
   const prisma = await getDb();
   const [entitlements, customer, payments, creditPurchases] = await Promise.all(
     [
-      getEntitlementSummary(userId),
+      getEntitlementSummary(userId, { prisma }),
       findCustomerByUserId({ userId, prisma }),
       getUserPaymentHistory({ userId, prisma }),
       getCreditPurchasesByUserId({ userId, prisma }),

--- a/apps/web/src/app/[lang]/(dashboard)/dashboard/queries.ts
+++ b/apps/web/src/app/[lang]/(dashboard)/dashboard/queries.ts
@@ -8,8 +8,7 @@ import { retrievePackages } from "./library/actions";
 export const LIBRARY_PREVIEW_COUNT = 6;
 
 export async function retrieveDashboardOverview(userId: string) {
-  // Explicitly share the request-scoped PrismaClient between the library and
-  // storage reads. The entitlement summary owns its consistent transaction.
+  // Explicitly share the render-scoped PrismaClient across all overview reads.
   const prisma = await getDb();
   const [libraryPackages, storageUsedBytes, entitlements] = await Promise.all([
     retrievePackages(userId, { prisma, take: LIBRARY_PREVIEW_COUNT }),
@@ -17,7 +16,7 @@ export async function retrieveDashboardOverview(userId: string) {
     // 概要ページはストレージ・ライブラリ・AI の 3 つを並べただけの画面で、
     // どれか 1 つが読めなくても残りは出せる。AI の残高だけのために
     // ページ全体を 500 にしない。
-    getEntitlementSummary(userId).catch((error) => {
+    getEntitlementSummary(userId, { prisma }).catch((error) => {
       console.error("Failed to read AI entitlements for the dashboard", error);
       return null;
     }),

--- a/apps/web/src/prisma.ts
+++ b/apps/web/src/prisma.ts
@@ -20,7 +20,7 @@ const createPrismaClient = async () => {
     throw new Error("Hyperdrive connection string not available");
   }
 
-  const adapter = new PrismaPg({ connectionString, maxUses: 1 });
+  const adapter = new PrismaPg({ connectionString, max: 5, maxUses: 1 });
   const prisma = new PrismaClient({ adapter });
   after(() => prisma.$disconnect());
   return prisma;

--- a/packages/api/src/ai/entitlements.ts
+++ b/packages/api/src/ai/entitlements.ts
@@ -1,6 +1,7 @@
 import {
   findAccountDeletionIntentByUserId,
   findCreditAccount,
+  getDb,
   getSubscriptionByUserId,
   startRetryableTransaction,
   type PrismaTransaction,
@@ -282,11 +283,15 @@ async function loadEntitlementSnapshot(
 // both of which can be comparatively large on a 128 MiB Worker isolate.
 export async function getEntitlementSummary(
   userId: string,
+  options: { prisma?: PrismaTransaction } = {},
 ): Promise<EntitlementSummaryResponse> {
-  return await startRetryableTransaction(async (prisma) => {
-    const { summary } = await loadEntitlementSnapshot(userId, prisma);
-    return summary;
-  });
+  // This snapshot only drives account presentation. Every paid operation
+  // revalidates entitlement inside its own transaction, so keeping several UI
+  // reads in an interactive transaction adds a fragile connection-start
+  // deadline without providing an authorization guarantee.
+  const prisma = options.prisma ?? await getDb();
+  const { summary } = await loadEntitlementSnapshot(userId, prisma);
+  return summary;
 }
 
 export async function getEntitlements(

--- a/tests/contract/ai-entitlements.test.ts
+++ b/tests/contract/ai-entitlements.test.ts
@@ -75,6 +75,37 @@ describe("AI entitlements", () => {
     expect(summary).not.toHaveProperty("modelAvailability");
   });
 
+  it("does not use an interactive transaction for account presentation", async () => {
+    await activatePro();
+    const transaction = vi
+      .spyOn(prisma, "$transaction")
+      .mockRejectedValue(
+        Object.assign(new Error("Unable to start a transaction in time"), {
+          code: "P2028",
+        }),
+      );
+
+    const summary = await getEntitlementSummary(USER_ID, {
+      prisma: prisma as never,
+    });
+
+    expect(summary.canUseAi).toBe(true);
+    expect(transaction).not.toHaveBeenCalled();
+  });
+
+  it("uses an explicitly supplied client without resolving the provider", async () => {
+    await activatePro();
+    setDbProvider(async () => {
+      throw new Error("the configured provider must not be used");
+    });
+
+    const summary = await getEntitlementSummary(USER_ID, {
+      prisma: prisma as never,
+    });
+
+    expect(summary.canUseAi).toBe(true);
+  });
+
   it("keeps summary fields identical to the full entitlement response", async () => {
     await activatePro();
     await consumeUsage({

--- a/tests/contract/web-request-scope.test.ts
+++ b/tests/contract/web-request-scope.test.ts
@@ -13,6 +13,9 @@ describe("server-render database resources", () => {
     expect(prisma).toContain(
       "const getPrismaClient = cache(createPrismaClient);",
     );
+    expect(prisma).toContain(
+      "new PrismaPg({ connectionString, max: 5, maxUses: 1 })",
+    );
     expect(prisma).toContain("setDbProvider(getPrismaClient);");
     expect(prisma).toContain('import { after } from "next/server";');
     expect(prisma).toContain("after(() => prisma.$disconnect());");
@@ -26,6 +29,9 @@ describe("server-render database resources", () => {
     expect(prisma).toContain('import { cache } from "react";');
     expect(prisma).toContain(
       "const getPrismaClient = cache(createPrismaClient);",
+    );
+    expect(prisma).toContain(
+      "new PrismaPg({ connectionString, max: 5, maxUses: 1 })",
     );
     expect(prisma).toContain("setDbProvider(getPrismaClient);");
     expect(prisma).toContain('import { after } from "next/server";');
@@ -67,5 +73,18 @@ describe("server-render database resources", () => {
       "getSocialProfilesByUserId(session.user.id, prisma)",
     );
     expect(profilePage).not.toContain("auth.api.getSession");
+  });
+
+  it("shares one render client with entitlement summaries", () => {
+    for (const path of [
+      "apps/web/src/app/[lang]/(dashboard)/dashboard/queries.ts",
+      "apps/web/src/app/[lang]/(dashboard)/dashboard/account/billing/queries.ts",
+    ]) {
+      const query = source(path);
+      expect(query.match(/await getDb\(\)/g), path).toHaveLength(1);
+      expect(query, path).toContain(
+        "getEntitlementSummary(userId, { prisma })",
+      );
+    }
   });
 });

--- a/tests/contract/web-request-scope.test.ts
+++ b/tests/contract/web-request-scope.test.ts
@@ -30,9 +30,6 @@ describe("server-render database resources", () => {
     expect(prisma).toContain(
       "const getPrismaClient = cache(createPrismaClient);",
     );
-    expect(prisma).toContain(
-      "new PrismaPg({ connectionString, max: 5, maxUses: 1 })",
-    );
     expect(prisma).toContain("setDbProvider(getPrismaClient);");
     expect(prisma).toContain('import { after } from "next/server";');
     expect(prisma).toContain("after(() => prisma.$disconnect());");


### PR DESCRIPTION
## Description

- Read the presentation-only entitlement summary without opening a Prisma interactive transaction.
- Reuse the render-scoped Prisma client already owned by the billing and dashboard queries.
- Keep transactional entitlement checks unchanged for authorization, credit reservation, and paid operations.
- Limit the Web PrismaPg pool to five connections, following the Cloudflare Hyperdrive recommendation and leaving capacity below the six simultaneous-connection limit.
- Add regressions proving that a P2028 transaction-start failure cannot affect the summary path and that an explicitly supplied client bypasses provider resolution.
- Verified with 1,771 passing tests (20 skipped), Web/Admin/API typechecks, Web/Admin OpenNext builds, Web/Admin Wrangler dry-runs, and 20 successful read-only runs against the production database.

## Breaking changes

None.

## Fixed issues

- Prevents the billing page from returning 500 when the display-only entitlement transaction cannot start within Prisma default maxWait.
- Avoids unnecessary interactive transaction and connection pressure on dashboard entitlement reads.