### PR TITLE
feat: enable promotion codes for AI checkout

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,12 @@ money. Without them the page falls back to the recorded offer and says so, and
 when Stripe and the stored offer disagree it flags that too (purchases still
 settle against the stored terms).
 
+Pro and credit top-up Checkout Sessions let customers enter active Stripe
+promotion codes. Create and constrain those codes in the Stripe Dashboard; the
+package store does not accept them. A top-up promotion must leave a positive
+amount to pay because credit fulfillment is tied to its successful
+PaymentIntent, so do not make a 100%-off code eligible for the top-up Price.
+
 Costs come from OpenRouter's public price endpoints, which need no API key, so
 the admin Worker holds no provider credentials. They
 are estimates from a published rate card, not recorded spend: where a rate is

--- a/apps/web/src/app/[lang]/(dashboard)/dashboard/account/billing/actions.ts
+++ b/apps/web/src/app/[lang]/(dashboard)/dashboard/account/billing/actions.ts
@@ -27,6 +27,10 @@ import {
   PRO_PLAN,
 } from "@beutl/api";
 import {
+  allowsStripePromotionCodes,
+  isValidStripeCheckoutSessionAmount,
+} from "@beutl/core";
+import {
   bindTopUpCheckoutCreation,
   bindProCheckoutSession,
   claimTopUpCheckoutCreation,
@@ -45,6 +49,7 @@ import {
   releaseTopUpCheckoutCreation,
   requireTopUpRefund,
   scheduleBillingRefundAttempt,
+  setProCheckoutAttemptParams,
   startRetryableTransaction,
 } from "@beutl/db";
 import { redirect } from "next/navigation";
@@ -105,6 +110,21 @@ function subscriptionMatchesOffer(
     item.price.recurring.interval_count ===
       billingOffer.recurringIntervalCount
   );
+}
+
+function persistedProCheckoutParams(
+  paramsJson: string,
+  current: Stripe.Checkout.SessionCreateParams,
+): Stripe.Checkout.SessionCreateParams {
+  const legacy = { ...current };
+  delete legacy.allow_promotion_codes;
+  if (
+    paramsJson !== JSON.stringify(current) &&
+    paramsJson !== JSON.stringify(legacy)
+  ) {
+    throw new Error("Persisted Pro Checkout parameters do not match the current offer");
+  }
+  return JSON.parse(paramsJson) as Stripe.Checkout.SessionCreateParams;
 }
 
 async function compensateSupersededProCheckout({
@@ -467,6 +487,7 @@ export async function createProCheckout(): Promise<void> {
   const proCheckoutParams: Stripe.Checkout.SessionCreateParams = {
     customer: customerId,
     mode: "subscription",
+    allow_promotion_codes: true,
     line_items: [{ price: offer.stripePriceId, quantity: 1 }],
     metadata: { ...stripeOwnerMetadata(session.user.id), planId: PRO_PLAN.id, billingOfferId: offer.id },
     subscription_data: { metadata: { ...stripeOwnerMetadata(session.user.id), planId: PRO_PLAN.id, billingOfferId: offer.id } },
@@ -610,8 +631,27 @@ export async function createProCheckout(): Promise<void> {
       );
     }
 
+    let createParams = proCheckoutParams;
+    if (attempt.paramsJson) {
+      // Preserve the exact parameters attached to this idempotency key. An
+      // attempt started before promotion codes were enabled may already exist
+      // at Stripe even when its create response never reached this process.
+      createParams = persistedProCheckoutParams(
+        attempt.paramsJson,
+        proCheckoutParams,
+      );
+    } else {
+      const persisted = await setProCheckoutAttemptParams({
+        userId: session.user.id,
+        checkoutKey: attempt.checkoutKey,
+        paramsJson: JSON.stringify(proCheckoutParams),
+      });
+      if (persisted.count !== 1) {
+        continue;
+      }
+    }
     const checkoutSession = await stripe.checkout.sessions.create(
-      proCheckoutParams,
+      createParams,
       {
         idempotencyKey: `ai-pro-checkout:${attempt.checkoutKey}`,
       },
@@ -708,6 +748,7 @@ function buildTopUpCheckoutParams({
   return {
     customer: customerId,
     mode: "payment",
+    allow_promotion_codes: true,
     line_items: [{ price: offer.stripePriceId, quantity: 1 }],
     metadata: {
       ...stripeOwnerMetadata(userId),
@@ -767,6 +808,7 @@ function topUpSessionMatchesAttempt({
   offer,
   userId,
   requireLineItems,
+  promotionCodesEnabled,
 }: {
   checkoutSession: Stripe.Checkout.Session;
   attemptId: string;
@@ -774,6 +816,7 @@ function topUpSessionMatchesAttempt({
   offer: PersistedBillingOffer;
   userId: string;
   requireLineItems: boolean;
+  promotionCodesEnabled: boolean;
 }): boolean {
   const lines = checkoutSession.line_items?.data;
   const lineMatches = lines === undefined
@@ -787,8 +830,15 @@ function topUpSessionMatchesAttempt({
     checkoutSession.metadata?.topUpAttemptId === attemptId &&
     checkoutSession.metadata?.billingOfferId === offer.id &&
     checkoutSession.metadata?.creditAmount === String(offer.creditAmount) &&
-    (checkoutSession.amount_total === null ||
-      checkoutSession.amount_total === offer.unitAmount) &&
+    isValidStripeCheckoutSessionAmount(
+      {
+        amountSubtotal: checkoutSession.amount_subtotal,
+        amountTotal: checkoutSession.amount_total,
+      },
+      offer.unitAmount,
+      promotionCodesEnabled,
+      true,
+    ) &&
     (checkoutSession.currency === null ||
       checkoutSession.currency.toLowerCase() === offer.currency.toLowerCase()) &&
     lineMatches;
@@ -850,6 +900,7 @@ export async function createCreditCheckout(): Promise<void> {
         offer,
         userId: authSession.user.id,
         requireLineItems: true,
+        promotionCodesEnabled: allowsStripePromotionCodes(attempt.paramsJson),
       })) {
         throw new Error("Bound top-up Checkout failed canonical validation");
       }
@@ -926,6 +977,7 @@ export async function createCreditCheckout(): Promise<void> {
           offer,
           userId: authSession.user.id,
           requireLineItems: true,
+          promotionCodesEnabled: allowsStripePromotionCodes(params),
         })) {
           throw new Error("Discovered top-up Checkout failed canonical validation");
         }
@@ -976,6 +1028,7 @@ export async function createCreditCheckout(): Promise<void> {
           offer,
           userId: authSession.user.id,
           requireLineItems: false,
+          promotionCodesEnabled: allowsStripePromotionCodes(params),
         })) {
           throw new Error("Created top-up Checkout failed canonical validation");
         }

--- a/apps/web/src/app/[lang]/(dashboard)/dashboard/account/billing/actions.ts
+++ b/apps/web/src/app/[lang]/(dashboard)/dashboard/account/billing/actions.ts
@@ -29,6 +29,7 @@ import {
 import {
   allowsStripePromotionCodes,
   isValidStripeCheckoutSessionAmount,
+  isZeroCostStripeCheckoutSessionAmount,
 } from "@beutl/core";
 import {
   bindTopUpCheckoutCreation,
@@ -112,19 +113,48 @@ function subscriptionMatchesOffer(
   );
 }
 
+function canonicalizeCheckoutParams(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(canonicalizeCheckoutParams);
+  }
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>)
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([key, item]) => [key, canonicalizeCheckoutParams(item)]),
+    );
+  }
+  return value;
+}
+
 function persistedProCheckoutParams(
   paramsJson: string,
   current: Stripe.Checkout.SessionCreateParams,
 ): Stripe.Checkout.SessionCreateParams {
+  let persisted: unknown;
+  try {
+    persisted = JSON.parse(paramsJson);
+  } catch {
+    throw new Error(
+      "Persisted Pro Checkout parameters do not match the current offer",
+    );
+  }
   const legacy = { ...current };
   delete legacy.allow_promotion_codes;
+  const canonicalPersisted = JSON.stringify(
+    canonicalizeCheckoutParams(persisted),
+  );
+  const canonicalCurrent = JSON.stringify(canonicalizeCheckoutParams(current));
+  const canonicalLegacy = JSON.stringify(canonicalizeCheckoutParams(legacy));
   if (
-    paramsJson !== JSON.stringify(current) &&
-    paramsJson !== JSON.stringify(legacy)
+    canonicalPersisted !== canonicalCurrent &&
+    canonicalPersisted !== canonicalLegacy
   ) {
-    throw new Error("Persisted Pro Checkout parameters do not match the current offer");
+    throw new Error(
+      "Persisted Pro Checkout parameters do not match the current offer",
+    );
   }
-  return JSON.parse(paramsJson) as Stripe.Checkout.SessionCreateParams;
+  return persisted as Stripe.Checkout.SessionCreateParams;
 }
 
 async function compensateSupersededProCheckout({
@@ -801,35 +831,48 @@ function topUpParamsMatchAttempt({
       String(offer.creditAmount);
 }
 
-function topUpSessionMatchesAttempt({
-  checkoutSession,
-  attemptId,
-  customerId,
-  offer,
-  userId,
-  requireLineItems,
-  promotionCodesEnabled,
-}: {
+type TopUpSessionIdentityExpectation = {
   checkoutSession: Stripe.Checkout.Session;
   attemptId: string;
   customerId: string;
   offer: PersistedBillingOffer;
   userId: string;
   requireLineItems: boolean;
-  promotionCodesEnabled: boolean;
-}): boolean {
+};
+
+function topUpSessionIdentityMatches({
+  checkoutSession,
+  attemptId,
+  customerId,
+  offer,
+  userId,
+  requireLineItems,
+}: TopUpSessionIdentityExpectation): boolean {
   const lines = checkoutSession.line_items?.data;
   const lineMatches = lines === undefined
     ? !requireLineItems
     : lines.length === 1 && lines[0]?.quantity === 1 &&
       expandableId(lines[0].price) === offer.stripePriceId;
-  return checkoutSession.mode === "payment" &&
+  return offer.kind === "top_up" &&
+    checkoutSession.mode === "payment" &&
     expandableId(checkoutSession.customer) === customerId &&
     checkoutSession.metadata?.beutlApplication === "beutl-web" &&
     checkoutSession.metadata?.beutlUserId === userId &&
     checkoutSession.metadata?.topUpAttemptId === attemptId &&
     checkoutSession.metadata?.billingOfferId === offer.id &&
     checkoutSession.metadata?.creditAmount === String(offer.creditAmount) &&
+    (checkoutSession.currency === null ||
+      checkoutSession.currency.toLowerCase() === offer.currency.toLowerCase()) &&
+    lineMatches;
+}
+
+function topUpSessionMatchesAttempt(
+  expectation: TopUpSessionIdentityExpectation & {
+    promotionCodesEnabled: boolean;
+  },
+): boolean {
+  const { checkoutSession, offer, promotionCodesEnabled } = expectation;
+  return topUpSessionIdentityMatches(expectation) &&
     isValidStripeCheckoutSessionAmount(
       {
         amountSubtotal: checkoutSession.amount_subtotal,
@@ -838,10 +881,28 @@ function topUpSessionMatchesAttempt({
       offer.unitAmount,
       promotionCodesEnabled,
       true,
-    ) &&
-    (checkoutSession.currency === null ||
-      checkoutSession.currency.toLowerCase() === offer.currency.toLowerCase()) &&
-    lineMatches;
+    );
+}
+
+function isCompletedZeroCostTopUpSession(
+  expectation: TopUpSessionIdentityExpectation & {
+    promotionCodesEnabled: boolean;
+  },
+): boolean {
+  const { checkoutSession, offer, promotionCodesEnabled } = expectation;
+  return topUpSessionIdentityMatches(expectation) &&
+    checkoutSession.status === "complete" &&
+    (checkoutSession.payment_status === "paid" ||
+      checkoutSession.payment_status === "no_payment_required") &&
+    checkoutSession.payment_intent === null &&
+    isZeroCostStripeCheckoutSessionAmount(
+      {
+        amountSubtotal: checkoutSession.amount_subtotal,
+        amountTotal: checkoutSession.amount_total,
+      },
+      offer.unitAmount,
+      promotionCodesEnabled,
+    );
 }
 
 export async function createCreditCheckout(): Promise<void> {
@@ -893,7 +954,7 @@ export async function createCreditCheckout(): Promise<void> {
         attempt.stripeCheckoutSessionId,
         { expand: ["line_items.data.price"] },
       );
-      if (!topUpSessionMatchesAttempt({
+      const sessionExpectation = {
         checkoutSession: existing,
         attemptId: attempt.id,
         customerId: attempt.stripeCustomerId,
@@ -901,7 +962,21 @@ export async function createCreditCheckout(): Promise<void> {
         userId: authSession.user.id,
         requireLineItems: true,
         promotionCodesEnabled: allowsStripePromotionCodes(attempt.paramsJson),
-      })) {
+      };
+      if (isCompletedZeroCostTopUpSession(sessionExpectation)) {
+        const terminalized = await expireTopUpCheckoutAttempt({
+          attemptId: attempt.id,
+          ownerUserId: authSession.user.id,
+          stripeCheckoutSessionId: existing.id,
+        });
+        if (terminalized.count !== 1) {
+          throw new Error(
+            "Zero-cost top-up Checkout changed during terminalization",
+          );
+        }
+        continue;
+      }
+      if (!topUpSessionMatchesAttempt(sessionExpectation)) {
         throw new Error("Bound top-up Checkout failed canonical validation");
       }
       if (existing.status === "expired") {
@@ -970,7 +1045,7 @@ export async function createCreditCheckout(): Promise<void> {
           discovery.session.id,
           { expand: ["line_items.data.price"] },
         );
-        if (!topUpSessionMatchesAttempt({
+        const sessionExpectation = {
           checkoutSession,
           attemptId: claim.attempt.id,
           customerId: claim.attempt.stripeCustomerId,
@@ -978,7 +1053,20 @@ export async function createCreditCheckout(): Promise<void> {
           userId: authSession.user.id,
           requireLineItems: true,
           promotionCodesEnabled: allowsStripePromotionCodes(params),
-        })) {
+        };
+        if (isCompletedZeroCostTopUpSession(sessionExpectation)) {
+          const terminalized = await expireTopUpCheckoutAttempt({
+            attemptId: claim.attempt.id,
+            ownerUserId: authSession.user.id,
+            stripeCheckoutSessionId: null,
+            leaseToken,
+          });
+          if (terminalized.count !== 1) {
+            throw new Error("Zero-cost top-up discovery lease was lost");
+          }
+          continue;
+        }
+        if (!topUpSessionMatchesAttempt(sessionExpectation)) {
           throw new Error("Discovered top-up Checkout failed canonical validation");
         }
       } else {
@@ -1021,7 +1109,7 @@ export async function createCreditCheckout(): Promise<void> {
           timeout: 20_000,
           maxNetworkRetries: 2,
         });
-        if (!topUpSessionMatchesAttempt({
+        const sessionExpectation = {
           checkoutSession,
           attemptId: claim.attempt.id,
           customerId: claim.attempt.stripeCustomerId,
@@ -1029,7 +1117,20 @@ export async function createCreditCheckout(): Promise<void> {
           userId: authSession.user.id,
           requireLineItems: false,
           promotionCodesEnabled: allowsStripePromotionCodes(params),
-        })) {
+        };
+        if (isCompletedZeroCostTopUpSession(sessionExpectation)) {
+          const terminalized = await expireTopUpCheckoutAttempt({
+            attemptId: claim.attempt.id,
+            ownerUserId: authSession.user.id,
+            stripeCheckoutSessionId: null,
+            leaseToken,
+          });
+          if (terminalized.count !== 1) {
+            throw new Error("Zero-cost top-up replay lease was lost");
+          }
+          continue;
+        }
+        if (!topUpSessionMatchesAttempt(sessionExpectation)) {
           throw new Error("Created top-up Checkout failed canonical validation");
         }
       }
@@ -1099,7 +1200,6 @@ export async function reconcileAiCheckoutSuccess(
   if (
     checkoutSession.id !== stripeCheckoutSessionId ||
     checkoutSession.status !== "complete" ||
-    checkoutSession.payment_status !== "paid" ||
     !customerId ||
     !hasStripeOwnerMetadata(checkoutSession.metadata, authSession.user.id)
   ) {
@@ -1124,6 +1224,12 @@ export async function reconcileAiCheckoutSuccess(
   const usesCurrentCustomer = currentCustomer?.stripeId === customerId;
 
   if (checkoutSession.mode === "subscription") {
+    if (
+      checkoutSession.payment_status !== "paid" &&
+      checkoutSession.payment_status !== "no_payment_required"
+    ) {
+      return false;
+    }
     const subscriptionId =
       typeof checkoutSession.subscription === "string"
         ? checkoutSession.subscription
@@ -1278,6 +1384,29 @@ export async function reconcileAiCheckoutSuccess(
       checkoutSession.metadata?.topUpAttemptId !== attempt.id ||
       checkoutSession.metadata?.billingOfferId !== attempt.billingOfferId
     ) {
+      return false;
+    }
+    const offer = await findBillingOfferById({ id: attempt.billingOfferId });
+    if (!offer || offer.kind !== "top_up") {
+      return false;
+    }
+    if (isCompletedZeroCostTopUpSession({
+      checkoutSession,
+      attemptId: attempt.id,
+      customerId: attempt.stripeCustomerId,
+      offer,
+      userId: authSession.user.id,
+      requireLineItems: false,
+      promotionCodesEnabled: allowsStripePromotionCodes(attempt.paramsJson),
+    })) {
+      await expireTopUpCheckoutAttempt({
+        attemptId: attempt.id,
+        ownerUserId: authSession.user.id,
+        stripeCheckoutSessionId,
+      });
+      return false;
+    }
+    if (checkoutSession.payment_status !== "paid") {
       return false;
     }
     const paymentIntentId =

--- a/apps/web/src/lib/stripe/ai-billing.ts
+++ b/apps/web/src/lib/stripe/ai-billing.ts
@@ -4,6 +4,10 @@ import {
   PRO_PLAN,
 } from "@beutl/api";
 import {
+  allowsStripePromotionCodes,
+  isValidStripeCheckoutAmount,
+} from "@beutl/core";
+import {
   activateBillingOffer,
   findBillingOfferByStripePriceId,
   findTopUpCheckoutAttempt,
@@ -293,11 +297,17 @@ export function blocksNewProCheckout(
 export function topUpPaymentMatchesOffer(
   paymentIntent: Stripe.PaymentIntent,
   offer: BillingOfferRecord,
+  promotionCodesEnabled = false,
 ): boolean {
   return (
     offer.kind === "top_up" &&
     paymentIntent.metadata?.billingOfferId === offer.id &&
-    paymentIntent.amount_received === offer.unitAmount &&
+    paymentIntent.amount_received === paymentIntent.amount &&
+    isValidStripeCheckoutAmount(
+      paymentIntent.amount,
+      offer.unitAmount,
+      promotionCodesEnabled,
+    ) &&
     paymentIntent.currency.toLowerCase() === offer.currency.toLowerCase() &&
     Number(paymentIntent.metadata?.creditAmount) === offer.creditAmount
   );
@@ -322,6 +332,7 @@ export async function resolveTopUpPayment(
     !topUpPaymentMatchesOffer(
       paymentIntent,
       attempt.billingOffer as BillingOfferRecord,
+      allowsStripePromotionCodes(attempt.paramsJson),
     )
   ) {
     return { status: "invalid" as const, attempt };

--- a/packages/api/src/ai/stripe-checkout-cleanups.ts
+++ b/packages/api/src/ai/stripe-checkout-cleanups.ts
@@ -556,13 +556,35 @@ export async function reconcileStripeCheckoutCleanups(
         inactiveLegacy;
       const resolveCompleted = async (completed: Stripe.Checkout.Session[]) => {
         if (attempt.accountDeletionAt !== null && completed.length === 1) {
-          const [canonical] = completed;
+          const canonical = completed[0]!;
+          const paymentIntentId = typeof canonical.payment_intent === "string"
+            ? canonical.payment_intent
+            : canonical.payment_intent?.id;
+          if (!paymentIntentId) {
+            const hydrated = await hydrateTopUpPayments(
+              stripe,
+              [canonical],
+              attempt,
+            );
+            if (hydrated.length !== 0) {
+              throw new Error(
+                "Top-up recovery returned a payment without a PaymentIntent",
+              );
+            }
+            if ((await markDetachedTopUpCheckoutRecoveryTerminal({
+              attemptId: attempt.id,
+              leaseToken: recoveryLeaseToken,
+            })).count !== 1) {
+              throw new Error("Zero-cost top-up terminalization lease lost");
+            }
+            return;
+          }
           const stored = await completeDetachedTopUpCheckoutRecovery({
             attemptId: attempt.id,
             leaseToken: recoveryLeaseToken,
-            stripeCheckoutSessionId: canonical!.id,
-            expiresAt: canonical!.expires_at
-              ? new Date(canonical!.expires_at * 1_000)
+            stripeCheckoutSessionId: canonical.id,
+            expiresAt: canonical.expires_at
+              ? new Date(canonical.expires_at * 1_000)
               : attempt.expiresAt,
           });
           if (stored === "not-stored") {
@@ -714,12 +736,9 @@ export async function reconcileStripeCheckoutCleanups(
         }
         if (discovered.status === "expired") {
           await markDetachedTopUpCheckoutRecoveryTerminal({ attemptId: attempt.id, leaseToken: recoveryLeaseToken });
-        } else if (
-          discovered.status === "complete" &&
-          attempt.accountDeletionAt === null
-        ) {
+        } else if (discovered.status === "complete") {
           await resolveCompleted([discovered]);
-        } else if (discovered.status === "open" || discovered.status === "complete") {
+        } else if (discovered.status === "open") {
           const stored = await completeDetachedTopUpCheckoutRecovery({ attemptId: attempt.id, leaseToken: recoveryLeaseToken, stripeCheckoutSessionId: discovered.id, expiresAt: discovered.expires_at ? new Date(discovered.expires_at * 1000) : attempt.expiresAt });
           if (stored === "not-stored") throw new Error("Top-up discovery lease lost");
         } else {

--- a/packages/api/src/ai/stripe-checkout-cleanups.ts
+++ b/packages/api/src/ai/stripe-checkout-cleanups.ts
@@ -1,4 +1,9 @@
 import Stripe from "stripe";
+import {
+  allowsStripePromotionCodes,
+  isValidStripeCheckoutAmount,
+  isValidStripeCheckoutSessionAmount,
+} from "@beutl/core";
 import { discoverPackageCheckoutAttempt, discoverTopUpCheckoutAttempt, discoverLegacyPackageCheckoutAttempt } from "../package-checkout-discovery";
 import {
   completeStripeCheckoutCleanup,
@@ -123,6 +128,7 @@ async function hydrateTopUpPayments(
     ownerUserId: string;
     stripeCustomerId: string;
     billingOfferId: string;
+    paramsJson?: string | null;
   },
 ): Promise<HydratedTopUpPayment[]> {
   const offer = await findBillingOfferById({ id: attempt.billingOfferId });
@@ -136,6 +142,7 @@ async function hydrateTopUpPayments(
   ) {
     throw new Error("Top-up recovery billing offer is invalid");
   }
+  const promotionCodesEnabled = allowsStripePromotionCodes(attempt.paramsJson);
   const hydrated: HydratedTopUpPayment[] = [];
   for (const session of sessions) {
     const paymentIntentId = typeof session.payment_intent === "string"
@@ -159,10 +166,21 @@ async function hydrateTopUpPayments(
       paymentIntent.metadata?.beutlUserId !== attempt.ownerUserId ||
       paymentIntent.metadata?.billingOfferId !== attempt.billingOfferId ||
       paymentIntent.metadata?.creditAmount !== String(offer.creditAmount) ||
-      paymentIntent.amount !== offer.unitAmount ||
+      !isValidStripeCheckoutAmount(
+        paymentIntent.amount,
+        offer.unitAmount,
+        promotionCodesEnabled,
+      ) ||
       paymentIntent.currency.toLowerCase() !== offer.currency.toLowerCase() ||
-      (session.amount_total !== null &&
-        session.amount_total !== offer.unitAmount) ||
+      !isValidStripeCheckoutSessionAmount(
+        {
+          amountSubtotal: session.amount_subtotal,
+          amountTotal: session.amount_total,
+        },
+        offer.unitAmount,
+        promotionCodesEnabled,
+      ) ||
+      session.amount_total !== paymentIntent.amount ||
       (session.currency !== null &&
         session.currency.toLowerCase() !== offer.currency.toLowerCase()) ||
       !paymentIntent.latest_charge ||

--- a/packages/api/src/ai/stripe-checkout-cleanups.ts
+++ b/packages/api/src/ai/stripe-checkout-cleanups.ts
@@ -3,6 +3,7 @@ import {
   allowsStripePromotionCodes,
   isValidStripeCheckoutAmount,
   isValidStripeCheckoutSessionAmount,
+  isZeroCostStripeCheckoutSessionAmount,
 } from "@beutl/core";
 import { discoverPackageCheckoutAttempt, discoverTopUpCheckoutAttempt, discoverLegacyPackageCheckoutAttempt } from "../package-checkout-discovery";
 import {
@@ -145,10 +146,35 @@ async function hydrateTopUpPayments(
   const promotionCodesEnabled = allowsStripePromotionCodes(attempt.paramsJson);
   const hydrated: HydratedTopUpPayment[] = [];
   for (const session of sessions) {
+    const sessionCustomer = typeof session.customer === "string"
+      ? session.customer
+      : session.customer?.id;
     const paymentIntentId = typeof session.payment_intent === "string"
       ? session.payment_intent
       : session.payment_intent?.id;
     if (!paymentIntentId) {
+      if (
+        session.status === "complete" &&
+        session.mode === "payment" &&
+        sessionCustomer === attempt.stripeCustomerId &&
+        session.metadata?.beutlApplication === "beutl-web" &&
+        session.metadata?.beutlUserId === attempt.ownerUserId &&
+        session.metadata?.topUpAttemptId === attempt.id &&
+        session.metadata?.billingOfferId === attempt.billingOfferId &&
+        session.metadata?.creditAmount === String(offer.creditAmount) &&
+        (session.currency === null ||
+          session.currency.toLowerCase() === offer.currency.toLowerCase()) &&
+        isZeroCostStripeCheckoutSessionAmount(
+          {
+            amountSubtotal: session.amount_subtotal,
+            amountTotal: session.amount_total,
+          },
+          offer.unitAmount,
+          promotionCodesEnabled,
+        )
+      ) {
+        continue;
+      }
       throw new Error(`Completed top-up Session ${session.id} has no PaymentIntent`);
     }
     const paymentIntent = await stripe.paymentIntents.retrieve(
@@ -179,8 +205,11 @@ async function hydrateTopUpPayments(
         },
         offer.unitAmount,
         promotionCodesEnabled,
+        !promotionCodesEnabled,
       ) ||
-      session.amount_total !== paymentIntent.amount ||
+      (session.amount_total !== null &&
+        session.amount_total !== undefined &&
+        session.amount_total !== paymentIntent.amount) ||
       (session.currency !== null &&
         session.currency.toLowerCase() !== offer.currency.toLowerCase()) ||
       !paymentIntent.latest_charge ||

--- a/packages/api/src/ai/top-up-refunds.ts
+++ b/packages/api/src/ai/top-up-refunds.ts
@@ -3,12 +3,17 @@ import {
   attachTopUpRefundId,
   attachTopUpRefundPaymentIntent,
   claimTopUpRefundAttempt,
+  findBillingOfferById,
   listDueTopUpRefundAttempts,
   markTopUpRefundInterventionRequired,
   markTopUpRefundNotRequired,
   recordTopUpRefund,
   rescheduleTopUpRefundAttempt,
 } from "@beutl/db";
+import {
+  allowsStripePromotionCodes,
+  isZeroCostStripeCheckoutSessionAmount,
+} from "@beutl/core";
 import Stripe from "stripe";
 import {
   getCanonicalPaymentRefundState,
@@ -169,7 +174,7 @@ async function resolvePaymentIntent({
 
   const session = await stripe.checkout.sessions.retrieve(
     attempt.stripeCheckoutSessionId,
-    { expand: ["payment_intent"] },
+    { expand: ["payment_intent", "line_items.data.price"] },
   );
   assertStripeOwner(
     `Checkout Session ${session.id}`,
@@ -187,6 +192,46 @@ async function resolvePaymentIntent({
     return attached
       ? { outcome: "resolved", stripePaymentIntentId }
       : { outcome: "lost" };
+  }
+
+  if (
+    session.status === "complete" &&
+    (session.payment_status === "paid" ||
+      session.payment_status === "no_payment_required")
+  ) {
+    const offer = await findBillingOfferById({ id: attempt.billingOfferId });
+    const lines = session.line_items?.data;
+    const line = lines?.[0];
+    const isOwnedZeroCostTopUp =
+      offer?.kind === "top_up" &&
+      Number.isSafeInteger(offer.creditAmount) &&
+      (offer.creditAmount ?? 0) > 0 &&
+      lines?.length === 1 &&
+      line?.quantity === 1 &&
+      expandableId(line.price) === offer.stripePriceId &&
+      session.mode === "payment" &&
+      session.metadata?.beutlApplication === "beutl-web" &&
+      session.metadata?.beutlUserId === attempt.ownerUserId &&
+      session.metadata?.topUpAttemptId === attempt.id &&
+      session.metadata?.billingOfferId === attempt.billingOfferId &&
+      session.metadata?.creditAmount === String(offer.creditAmount) &&
+      session.currency?.toLowerCase() === offer.currency.toLowerCase() &&
+      isZeroCostStripeCheckoutSessionAmount(
+        {
+          amountSubtotal: session.amount_subtotal,
+          amountTotal: session.amount_total,
+        },
+        offer.unitAmount,
+        allowsStripePromotionCodes(attempt.paramsJson),
+      );
+    if (isOwnedZeroCostTopUp) {
+      const marked = await markTopUpRefundNotRequired({
+        attemptId: attempt.id,
+        refundLeaseToken,
+        now,
+      });
+      return { outcome: marked ? "no-refund-required" : "lost" };
+    }
   }
 
   const canCloseWithoutRefund =

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -109,4 +109,5 @@ export {
   allowsStripePromotionCodes,
   isValidStripeCheckoutAmount,
   isValidStripeCheckoutSessionAmount,
+  isZeroCostStripeCheckoutSessionAmount,
 } from "./stripe-checkout";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -105,3 +105,8 @@ export type {
   AiAllowanceQuantityKind,
   AiUnitValue,
 } from "./ai-allowance";
+export {
+  allowsStripePromotionCodes,
+  isValidStripeCheckoutAmount,
+  isValidStripeCheckoutSessionAmount,
+} from "./stripe-checkout";

--- a/packages/core/src/stripe-checkout.ts
+++ b/packages/core/src/stripe-checkout.ts
@@ -1,0 +1,66 @@
+type StripeCheckoutAmounts = {
+  amountSubtotal: number | null | undefined;
+  amountTotal: number | null | undefined;
+};
+
+export function allowsStripePromotionCodes(params: unknown): boolean {
+  let value = params;
+  if (typeof value === "string") {
+    try {
+      value = JSON.parse(value);
+    } catch {
+      return false;
+    }
+  }
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    !Array.isArray(value) &&
+    (value as { allow_promotion_codes?: unknown }).allow_promotion_codes === true
+  );
+}
+
+export function isValidStripeCheckoutAmount(
+  amount: number,
+  undiscountedAmount: number,
+  promotionCodesEnabled: boolean,
+): boolean {
+  return (
+    Number.isSafeInteger(amount) &&
+    amount > 0 &&
+    Number.isSafeInteger(undiscountedAmount) &&
+    undiscountedAmount > 0 &&
+    amount <= undiscountedAmount &&
+    (amount === undiscountedAmount || promotionCodesEnabled)
+  );
+}
+
+export function isValidStripeCheckoutSessionAmount(
+  { amountSubtotal, amountTotal }: StripeCheckoutAmounts,
+  undiscountedAmount: number,
+  promotionCodesEnabled: boolean,
+  allowMissingAmounts = false,
+): boolean {
+  if (!Number.isSafeInteger(undiscountedAmount) || undiscountedAmount <= 0) {
+    return false;
+  }
+  if (amountSubtotal === null || amountSubtotal === undefined) {
+    if (amountTotal === null || amountTotal === undefined) {
+      return allowMissingAmounts;
+    }
+    // Older Session fixtures and records may not have retained the subtotal.
+    // Without it, only the undiscounted total proves the configured Price.
+    return amountTotal === undiscountedAmount;
+  }
+  if (amountSubtotal !== undiscountedAmount) {
+    return false;
+  }
+  if (amountTotal === null || amountTotal === undefined) {
+    return allowMissingAmounts;
+  }
+  return isValidStripeCheckoutAmount(
+    amountTotal,
+    undiscountedAmount,
+    promotionCodesEnabled,
+  );
+}

--- a/packages/core/src/stripe-checkout.ts
+++ b/packages/core/src/stripe-checkout.ts
@@ -64,3 +64,17 @@ export function isValidStripeCheckoutSessionAmount(
     promotionCodesEnabled,
   );
 }
+
+export function isZeroCostStripeCheckoutSessionAmount(
+  { amountSubtotal, amountTotal }: StripeCheckoutAmounts,
+  undiscountedAmount: number,
+  promotionCodesEnabled: boolean,
+): boolean {
+  return (
+    promotionCodesEnabled &&
+    Number.isSafeInteger(undiscountedAmount) &&
+    undiscountedAmount > 0 &&
+    amountSubtotal === undiscountedAmount &&
+    amountTotal === 0
+  );
+}

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -7,6 +7,7 @@
     ".": "./src/index.ts"
   },
   "dependencies": {
+    "@beutl/core": "workspace:*",
     "@prisma/client": "^7.9.1"
   }
 }

--- a/packages/db/src/top-up-checkout-attempt.ts
+++ b/packages/db/src/top-up-checkout-attempt.ts
@@ -1,4 +1,8 @@
 import { addPurchasedCredits, type StripePaymentDetails } from "./credit-account";
+import {
+  allowsStripePromotionCodes,
+  isValidStripeCheckoutAmount,
+} from "@beutl/core";
 import { getDb } from "./provider";
 import {
   startRetryableTransaction,
@@ -549,7 +553,11 @@ export async function fulfillTopUpCheckoutAttempt({
       return { status: "invalid" as const };
     }
     if (
-      attempt.billingOffer.unitAmount !== stripePayment.amount ||
+      !isValidStripeCheckoutAmount(
+        stripePayment.amount,
+        attempt.billingOffer.unitAmount,
+        allowsStripePromotionCodes(attempt.paramsJson),
+      ) ||
       attempt.billingOffer.currency.toLowerCase() !==
         stripePayment.currency.toLowerCase() ||
       !Number.isSafeInteger(attempt.billingOffer.creditAmount) ||

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -351,6 +351,9 @@ importers:
 
   packages/db:
     dependencies:
+      '@beutl/core':
+        specifier: workspace:*
+        version: link:../core
       '@prisma/client':
         specifier: ^7.9.1
         version: 7.9.1(prisma@7.9.1(@types/react-dom@19.1.1(@types/react@19.1.0))(@types/react@19.1.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.7.3))(typescript@5.7.3)

--- a/tests/contract/ai-checkout-reconciliation.test.ts
+++ b/tests/contract/ai-checkout-reconciliation.test.ts
@@ -4,10 +4,12 @@ const mocks = vi.hoisted(() => ({
   cancelSubscription: vi.fn(),
   checkoutRetrieve: vi.fn(),
   deleteBoundProCheckoutAttempt: vi.fn(),
+  expireTopUpCheckoutAttempt: vi.fn(),
   findBillingOfferById: vi.fn(),
   findProCheckoutAttemptBySessionId: vi.fn(),
   findCustomerByUserId: vi.fn(),
   findStripeCustomerOwnershipByStripeId: vi.fn(),
+  findTopUpCheckoutAttemptBySessionId: vi.fn(),
   getSubscriptionByUserId: vi.fn(),
   invoicePaymentList: vi.fn(),
   reconcileSubscriptionObservation: vi.fn(),
@@ -63,12 +65,15 @@ vi.mock("@beutl/db", () => ({
   LEGACY_STRIPE_CUSTOMER_MIGRATION_COHORT:
     "pre-owner-metadata-2026-08-09",
   deleteBoundProCheckoutAttempt: mocks.deleteBoundProCheckoutAttempt,
+  expireTopUpCheckoutAttempt: mocks.expireTopUpCheckoutAttempt,
   findBillingOfferById: mocks.findBillingOfferById,
   findCustomerByUserId: mocks.findCustomerByUserId,
   findProCheckoutAttemptBySessionId:
     mocks.findProCheckoutAttemptBySessionId,
   findStripeCustomerOwnershipByStripeId:
     mocks.findStripeCustomerOwnershipByStripeId,
+  findTopUpCheckoutAttemptBySessionId:
+    mocks.findTopUpCheckoutAttemptBySessionId,
   getSubscriptionByUserId: mocks.getSubscriptionByUserId,
   reconcileSubscriptionObservation: mocks.reconcileSubscriptionObservation,
   recordBillingRefundCancellation: mocks.recordBillingRefundCancellation,
@@ -137,6 +142,8 @@ describe("AI Checkout return reconciliation", () => {
     });
     mocks.getSubscriptionByUserId.mockResolvedValue(null);
     mocks.findBillingOfferById.mockResolvedValue(proOffer);
+    mocks.expireTopUpCheckoutAttempt.mockResolvedValue({ count: 1 });
+    mocks.findTopUpCheckoutAttemptBySessionId.mockResolvedValue(null);
     mocks.reconcileSubscriptionObservation.mockResolvedValue({
       applied: true,
       subscription: { stripeSubscriptionId: "sub_1" },
@@ -267,6 +274,56 @@ describe("AI Checkout return reconciliation", () => {
       reconcileAiCheckoutSuccess("cs_verified"),
     ).resolves.toBe(false);
     expect(mocks.retrieveSubscription).not.toHaveBeenCalled();
+  });
+
+  it("releases a completed zero-cost top-up without granting credits", async () => {
+    const topUpOffer = {
+      ...proOffer,
+      id: "offer_top_up",
+      kind: "top_up",
+      stripePriceId: "price_top_up",
+      stripeProductId: "prod_top_up",
+      unitAmount: 1_000,
+      creditAmount: 500,
+      recurringInterval: null,
+      recurringIntervalCount: null,
+    };
+    mocks.checkoutRetrieve.mockResolvedValue({
+      id: "cs_zero_cost",
+      status: "complete",
+      payment_status: "no_payment_required",
+      mode: "payment",
+      customer: "cus_1",
+      payment_intent: null,
+      amount_subtotal: 1_000,
+      amount_total: 0,
+      currency: "usd",
+      metadata: {
+        beutlApplication: "beutl-web",
+        beutlUserId: "user-1",
+        topUpAttemptId: "topup-attempt-1",
+        billingOfferId: "offer_top_up",
+        creditAmount: "500",
+      },
+    });
+    mocks.findTopUpCheckoutAttemptBySessionId.mockResolvedValue({
+      id: "topup-attempt-1",
+      ownerUserId: "user-1",
+      stripeCustomerId: "cus_1",
+      billingOfferId: "offer_top_up",
+      stripeCheckoutSessionId: "cs_zero_cost",
+      paramsJson: JSON.stringify({ allow_promotion_codes: true }),
+    });
+    mocks.findBillingOfferById.mockResolvedValue(topUpOffer);
+
+    await expect(reconcileAiCheckoutSuccess("cs_zero_cost"))
+      .resolves.toBe(false);
+
+    expect(mocks.expireTopUpCheckoutAttempt).toHaveBeenCalledWith({
+      attemptId: "topup-attempt-1",
+      ownerUserId: "user-1",
+      stripeCheckoutSessionId: "cs_zero_cost",
+    });
   });
 
   it("cancels and refunds a completed Session for a superseded customer", async () => {

--- a/tests/contract/ai-checkout.test.ts
+++ b/tests/contract/ai-checkout.test.ts
@@ -332,18 +332,33 @@ describe("AI checkout actions", () => {
         "https://beutl.example/dashboard/account/billing?checkout=success&session_id={CHECKOUT_SESSION_ID}",
       cancel_url: "https://beutl.example/dashboard/account/billing",
     };
+    const reorderedLegacyParams = {
+      cancel_url: legacyParams.cancel_url,
+      success_url: legacyParams.success_url,
+      subscription_data: {
+        metadata: Object.fromEntries(
+          Object.entries(legacyParams.subscription_data.metadata).reverse(),
+        ),
+      },
+      metadata: Object.fromEntries(
+        Object.entries(legacyParams.metadata).reverse(),
+      ),
+      line_items: legacyParams.line_items,
+      mode: legacyParams.mode,
+      customer: legacyParams.customer,
+    };
     mocks.getOrCreateProCheckoutAttempt.mockResolvedValue({
       userId: "user-1",
       checkoutKey: "attempt-legacy",
       billingOfferId: "offer_pro",
       stripeCheckoutSessionId: null,
-      paramsJson: JSON.stringify(legacyParams),
+      paramsJson: JSON.stringify(reorderedLegacyParams),
       expiresAt: new Date(Date.now() + 86_400_000),
     });
 
     await expect(createProCheckout()).rejects.toThrow("NEXT_REDIRECT");
 
-    expect(mocks.checkoutCreate).toHaveBeenCalledWith(legacyParams, {
+    expect(mocks.checkoutCreate).toHaveBeenCalledWith(reorderedLegacyParams, {
       idempotencyKey: "ai-pro-checkout:attempt-legacy",
     });
     expect(mocks.setProCheckoutAttemptParams).not.toHaveBeenCalled();
@@ -406,6 +421,40 @@ describe("AI checkout actions", () => {
     expect(mocks.checkoutRetrieve).toHaveBeenCalledWith("cs_discounted", {
       expand: ["line_items.data.price"],
     });
+  });
+
+  it("terminalizes a zero-cost top-up before creating a replacement", async () => {
+    mocks.getSubscriptionByUserId.mockResolvedValue({
+      status: "active",
+      planId: "pro",
+      billingOfferId: "offer_pro",
+      currentPeriodEnd: new Date(Date.now() + 60_000),
+    });
+    const zeroCostAttempt = {
+      ...mocks.topUpAttempt!,
+      stripeCheckoutSessionId: "cs_zero_cost",
+    };
+    const replacementAttempt = { ...mocks.topUpAttempt! };
+    mocks.getOrCreateTopUpCheckoutAttempt
+      .mockResolvedValueOnce(zeroCostAttempt)
+      .mockResolvedValueOnce(replacementAttempt);
+    mocks.checkoutRetrieve.mockResolvedValue(topUpCheckoutSession({
+      id: "cs_zero_cost",
+      status: "complete",
+      payment_status: "no_payment_required",
+      payment_intent: null,
+      amount_total: 0,
+      url: null,
+    }));
+
+    await expect(createCreditCheckout()).rejects.toThrow("NEXT_REDIRECT");
+
+    expect(mocks.expireTopUpCheckoutAttempt).toHaveBeenCalledWith({
+      attemptId: "topup-attempt-1",
+      ownerUserId: "user-1",
+      stripeCheckoutSessionId: "cs_zero_cost",
+    });
+    expect(mocks.checkoutCreate).toHaveBeenCalledTimes(1);
   });
 
   it("recovers a normal top-up after Stripe committed but the response was lost", async () => {

--- a/tests/contract/ai-checkout.test.ts
+++ b/tests/contract/ai-checkout.test.ts
@@ -96,6 +96,8 @@ function topUpCheckoutSession(
     mode: "payment",
     status: "open",
     customer: "cus_1",
+    allow_promotion_codes: true,
+    amount_subtotal: 1_000,
     amount_total: 1_000,
     currency: "usd",
     expires_at: Math.floor(Date.now() / 1_000) + 86_400,
@@ -192,6 +194,7 @@ describe("AI checkout actions", () => {
     const topUpParams = {
       customer: "cus_1",
       mode: "payment",
+      allow_promotion_codes: true,
       line_items: [{ price: "price_credits", quantity: 1 }],
       metadata: {
         beutlApplication: "beutl-web",
@@ -280,6 +283,7 @@ describe("AI checkout actions", () => {
     expect(mocks.checkoutCreate).toHaveBeenCalledWith(
       expect.objectContaining({
         mode: "subscription",
+        allow_promotion_codes: true,
         success_url:
           "https://beutl.example/dashboard/account/billing?checkout=success&session_id={CHECKOUT_SESSION_ID}",
         subscription_data: {
@@ -304,6 +308,47 @@ describe("AI checkout actions", () => {
     );
   });
 
+  it("replays pre-promotion Pro parameters with their original idempotency key", async () => {
+    mocks.getSubscriptionByUserId.mockResolvedValue(null);
+    const legacyParams = {
+      customer: "cus_1",
+      mode: "subscription",
+      line_items: [{ price: "price_pro", quantity: 1 }],
+      metadata: {
+        beutlApplication: "beutl-web",
+        beutlUserId: "user-1",
+        planId: "pro",
+        billingOfferId: "offer_pro",
+      },
+      subscription_data: {
+        metadata: {
+          beutlApplication: "beutl-web",
+          beutlUserId: "user-1",
+          planId: "pro",
+          billingOfferId: "offer_pro",
+        },
+      },
+      success_url:
+        "https://beutl.example/dashboard/account/billing?checkout=success&session_id={CHECKOUT_SESSION_ID}",
+      cancel_url: "https://beutl.example/dashboard/account/billing",
+    };
+    mocks.getOrCreateProCheckoutAttempt.mockResolvedValue({
+      userId: "user-1",
+      checkoutKey: "attempt-legacy",
+      billingOfferId: "offer_pro",
+      stripeCheckoutSessionId: null,
+      paramsJson: JSON.stringify(legacyParams),
+      expiresAt: new Date(Date.now() + 86_400_000),
+    });
+
+    await expect(createProCheckout()).rejects.toThrow("NEXT_REDIRECT");
+
+    expect(mocks.checkoutCreate).toHaveBeenCalledWith(legacyParams, {
+      idempotencyKey: "ai-pro-checkout:attempt-legacy",
+    });
+    expect(mocks.setProCheckoutAttemptParams).not.toHaveBeenCalled();
+  });
+
   it("copies the top-up amount to the Stripe PaymentIntent", async () => {
     mocks.getSubscriptionByUserId.mockResolvedValue({
       status: "active",
@@ -316,6 +361,7 @@ describe("AI checkout actions", () => {
     expect(mocks.checkoutCreate).toHaveBeenCalledWith(
       expect.objectContaining({
         mode: "payment",
+        allow_promotion_codes: true,
         payment_intent_data: {
           metadata: {
             beutlApplication: "beutl-web",
@@ -332,6 +378,34 @@ describe("AI checkout actions", () => {
         maxNetworkRetries: 2,
       },
     );
+    expect(JSON.parse(
+      mocks.getOrCreateTopUpCheckoutAttempt.mock.calls[0]![0].paramsJson,
+    )).toMatchObject({ allow_promotion_codes: true });
+  });
+
+  it("reuses a promotion-code discounted top-up Checkout", async () => {
+    mocks.getSubscriptionByUserId.mockResolvedValue({
+      status: "active",
+      planId: "pro",
+      billingOfferId: "offer_pro",
+      currentPeriodEnd: new Date(Date.now() + 60_000),
+    });
+    const boundAttempt = {
+      ...mocks.topUpAttempt!,
+      stripeCheckoutSessionId: "cs_discounted",
+    };
+    mocks.getOrCreateTopUpCheckoutAttempt.mockResolvedValue(boundAttempt);
+    mocks.checkoutRetrieve.mockResolvedValue(topUpCheckoutSession({
+      id: "cs_discounted",
+      amount_total: 800,
+    }));
+
+    await expect(createCreditCheckout()).rejects.toThrow("NEXT_REDIRECT");
+
+    expect(mocks.checkoutCreate).not.toHaveBeenCalled();
+    expect(mocks.checkoutRetrieve).toHaveBeenCalledWith("cs_discounted", {
+      expand: ["line_items.data.price"],
+    });
   });
 
   it("recovers a normal top-up after Stripe committed but the response was lost", async () => {

--- a/tests/contract/stripe-ai-webhook.test.ts
+++ b/tests/contract/stripe-ai-webhook.test.ts
@@ -430,6 +430,7 @@ describe("Stripe AI billing webhook", () => {
     mocks.retrievePaymentIntent.mockResolvedValue({
       id: "pi_1",
       customer: "cus_1",
+      amount: 1000,
       amount_received: 1000,
       currency: "usd",
       status: "succeeded",
@@ -541,6 +542,7 @@ describe("Stripe AI billing webhook", () => {
       stripeEvent("payment_intent.succeeded", {
         id: "pi_1",
         customer: "cus_1",
+        amount: 1000,
         amount_received: 1000,
         currency: "usd",
         status: "succeeded",

--- a/tests/contract/stripe-checkout-discounts.test.ts
+++ b/tests/contract/stripe-checkout-discounts.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import {
+  allowsStripePromotionCodes,
+  isValidStripeCheckoutAmount,
+  isValidStripeCheckoutSessionAmount,
+} from "@beutl/core";
+
+describe("Stripe Checkout promotion-code amounts", () => {
+  it("reads the durable Checkout parameter without trusting malformed JSON", () => {
+    expect(allowsStripePromotionCodes({ allow_promotion_codes: true })).toBe(true);
+    expect(allowsStripePromotionCodes('{"allow_promotion_codes":true}')).toBe(true);
+    expect(allowsStripePromotionCodes({ allow_promotion_codes: false })).toBe(false);
+    expect(allowsStripePromotionCodes("not-json")).toBe(false);
+  });
+
+  it("accepts a positive discount only when promotion codes were enabled", () => {
+    expect(isValidStripeCheckoutAmount(1_000, 1_000, false)).toBe(true);
+    expect(isValidStripeCheckoutAmount(800, 1_000, true)).toBe(true);
+    expect(isValidStripeCheckoutAmount(800, 1_000, false)).toBe(false);
+    expect(isValidStripeCheckoutAmount(0, 1_000, true)).toBe(false);
+    expect(isValidStripeCheckoutAmount(1_001, 1_000, true)).toBe(false);
+  });
+
+  it("requires the original subtotal to validate a discounted Session", () => {
+    expect(isValidStripeCheckoutSessionAmount(
+      { amountSubtotal: 1_000, amountTotal: 800 },
+      1_000,
+      true,
+    )).toBe(true);
+    expect(isValidStripeCheckoutSessionAmount(
+      { amountSubtotal: undefined, amountTotal: 800 },
+      1_000,
+      true,
+    )).toBe(false);
+    expect(isValidStripeCheckoutSessionAmount(
+      { amountSubtotal: undefined, amountTotal: 1_000 },
+      1_000,
+      false,
+    )).toBe(true);
+  });
+});

--- a/tests/contract/stripe-checkout-discounts.test.ts
+++ b/tests/contract/stripe-checkout-discounts.test.ts
@@ -3,6 +3,7 @@ import {
   allowsStripePromotionCodes,
   isValidStripeCheckoutAmount,
   isValidStripeCheckoutSessionAmount,
+  isZeroCostStripeCheckoutSessionAmount,
 } from "@beutl/core";
 
 describe("Stripe Checkout promotion-code amounts", () => {
@@ -37,5 +38,25 @@ describe("Stripe Checkout promotion-code amounts", () => {
       1_000,
       false,
     )).toBe(true);
+    expect(isValidStripeCheckoutSessionAmount(
+      { amountSubtotal: null, amountTotal: null },
+      1_000,
+      false,
+      true,
+    )).toBe(true);
+  });
+
+  it("recognizes only promotion-enabled zero-cost Sessions", () => {
+    const amounts = { amountSubtotal: 1_000, amountTotal: 0 };
+
+    expect(isZeroCostStripeCheckoutSessionAmount(amounts, 1_000, true))
+      .toBe(true);
+    expect(isZeroCostStripeCheckoutSessionAmount(amounts, 1_000, false))
+      .toBe(false);
+    expect(isZeroCostStripeCheckoutSessionAmount(
+      { amountSubtotal: undefined, amountTotal: 0 },
+      1_000,
+      true,
+    )).toBe(false);
   });
 });

--- a/tests/contract/top-up-fulfillment.test.ts
+++ b/tests/contract/top-up-fulfillment.test.ts
@@ -14,12 +14,16 @@ vi.mock("@beutl/db", () => ({
   requireTopUpRefund: mocks.requireTopUpRefund,
 }));
 
-import { fulfillOrRefundTopUpPayment } from "../../apps/web/src/lib/stripe/ai-billing";
+import {
+  fulfillOrRefundTopUpPayment,
+  topUpPaymentMatchesOffer,
+} from "../../apps/web/src/lib/stripe/ai-billing";
 
 const paymentIntent = {
   id: "pi_delayed",
   status: "succeeded",
   customer: "cus_1",
+  amount: 1_000,
   amount_received: 1_000,
   currency: "usd",
   metadata: {
@@ -36,6 +40,7 @@ const attempt = {
   ownerUserId: "user-1",
   stripeCustomerId: "cus_1",
   billingOfferId: "offer_top_up_v1",
+  paramsJson: JSON.stringify({ allow_promotion_codes: true }),
   billingOffer: {
     id: "offer_top_up_v1",
     kind: "top_up",
@@ -94,6 +99,48 @@ describe("durable top-up fulfillment", () => {
       fulfillOrRefundTopUpPayment(stripe, paymentIntent),
     ).resolves.toMatchObject({ status: "fulfilled", creditAmount: 500 });
     expect(createRefund).not.toHaveBeenCalled();
+  });
+
+  it("fulfills a discounted payment from a promotion-code Checkout", async () => {
+    const discountedPayment = {
+      ...paymentIntent,
+      amount: 800,
+      amount_received: 800,
+    };
+    mocks.fulfillTopUpCheckoutAttempt.mockResolvedValue({
+      status: "fulfilled",
+      userId: "user-1",
+      creditAmount: 500,
+    });
+    retrievePaymentIntent.mockResolvedValue(discountedPayment);
+
+    await expect(
+      fulfillOrRefundTopUpPayment(stripe, discountedPayment as never),
+    ).resolves.toMatchObject({ status: "fulfilled", creditAmount: 500 });
+    expect(mocks.fulfillTopUpCheckoutAttempt).toHaveBeenCalledWith(
+      expect.objectContaining({
+        stripePayment: { amount: 800, currency: "usd" },
+      }),
+    );
+  });
+
+  it("does not accept a discount for a legacy Checkout", () => {
+    const discountedPayment = {
+      ...paymentIntent,
+      amount: 800,
+      amount_received: 800,
+    };
+
+    expect(topUpPaymentMatchesOffer(
+      discountedPayment as never,
+      attempt.billingOffer as never,
+      false,
+    )).toBe(false);
+    expect(topUpPaymentMatchesOffer(
+      discountedPayment as never,
+      attempt.billingOffer as never,
+      true,
+    )).toBe(true);
   });
 
   it("waits for canonical recovery instead of refunding its in-flight payment", async () => {

--- a/tests/contract/top-up-refund-processing.test.ts
+++ b/tests/contract/top-up-refund-processing.test.ts
@@ -366,6 +366,62 @@ describe("durable top-up refund processing", () => {
     });
   });
 
+  it("closes an account-deletion zero-cost Checkout without a refund", async () => {
+    database.state.billingOffers.set("offer_top_up_v1", {
+      id: "offer_top_up_v1",
+      kind: "top_up",
+      stripePriceId: "price_top_up",
+      stripeProductId: "prod_top_up",
+      unitAmount: 1_000,
+      currency: "usd",
+      creditAmount: 500,
+      recurringInterval: null,
+      recurringIntervalCount: null,
+      checkoutEnabled: true,
+      createdAt: now,
+      updatedAt: now,
+    });
+    seedAttempt({
+      paramsJson: JSON.stringify({ allow_promotion_codes: true }),
+    });
+    checkoutRetrieve.mockResolvedValue({
+      id: "cs_1",
+      customer: "cus_1",
+      status: "complete",
+      payment_status: "no_payment_required",
+      payment_intent: null,
+      mode: "payment",
+      amount_subtotal: 1_000,
+      amount_total: 0,
+      currency: "usd",
+      metadata: {
+        beutlApplication: "beutl-web",
+        beutlUserId: "deleted-user",
+        topUpAttemptId: "attempt-1",
+        billingOfferId: "offer_top_up_v1",
+        creditAmount: "500",
+      },
+      line_items: {
+        data: [{ quantity: 1, price: { id: "price_top_up" } }],
+      },
+    });
+
+    await expect(processTopUpRefunds({ stripe, now })).resolves.toMatchObject({
+      claimed: 1,
+      noRefundRequired: 1,
+      interventionRequired: 0,
+      errors: 0,
+    });
+    expect(checkoutExpire).not.toHaveBeenCalled();
+    expect(paymentIntentRetrieve).not.toHaveBeenCalled();
+    expect(refundCreate).not.toHaveBeenCalled();
+    expect(database.state.topUpCheckoutAttempts.get("attempt-1")).toMatchObject({
+      status: "refund_not_required",
+      refundStatus: "not_required",
+      refundLeaseToken: null,
+    });
+  });
+
   it("resolves Checkout to PaymentIntent, creates one idempotent refund, and records canonical success", async () => {
     seedAttempt();
     checkoutRetrieve.mockResolvedValue({

--- a/tests/contract/topup-checkout-recovery-reconciler.test.ts
+++ b/tests/contract/topup-checkout-recovery-reconciler.test.ts
@@ -308,6 +308,48 @@ describe("top-up account-deletion recovery reconciliation", () => {
     expect(database.state.topUpCheckoutResolutions.size).toBe(0);
   });
 
+  it("terminalizes a recovered zero-cost Session without a PaymentIntent", async () => {
+    const database = createInMemoryPrisma();
+    setDbProvider(async () => database.prisma as any);
+    seedAttempt(database, {
+      ownerUserId: "active-user",
+      accountDeletionAt: null,
+      activeOwnerKey: "active-user",
+      checkoutKey: "ai-top-up-checkout:attempt-topup",
+      status: "open",
+      paramsJson: JSON.stringify({ allow_promotion_codes: true }),
+      refundNotBefore: null,
+    });
+    const completed = session("cs-zero-cost", "unused", {
+      payment_intent: null,
+      amount_total: 0,
+      metadata: {
+        ...session("unused", "unused").metadata,
+        beutlUserId: "active-user",
+        creditAmount: "500",
+      },
+    });
+    const retrievePaymentIntent = vi.fn();
+    const stripe: any = {
+      checkout: { sessions: {
+        list: vi.fn(async ({ status }: any) => ({
+          data: status === "complete" ? [completed] : [],
+          has_more: false,
+        })),
+        expire: vi.fn(),
+        retrieve: vi.fn(),
+      } },
+      paymentIntents: { retrieve: retrievePaymentIntent },
+      refunds: { list: vi.fn(), create: vi.fn() },
+    };
+
+    await reconcileStripeCheckoutCleanups(NOW, "sk_test", stripe);
+
+    expect(database.state.topUpCheckoutAttempts.get("attempt-topup"))
+      .toMatchObject({ status: "expired", activeOwnerKey: null });
+    expect(retrievePaymentIntent).not.toHaveBeenCalled();
+  });
+
   it("schedules only the remaining refund for a partially refunded normal Session", async () => {
     const database = createInMemoryPrisma();
     setDbProvider(async () => database.prisma as any);
@@ -548,6 +590,37 @@ describe("top-up account-deletion recovery reconciliation", () => {
       expect.objectContaining({
         stripePaymentIntentId: "pi-discount-b",
         amount: 800,
+      }),
+    ]);
+  });
+
+  it("hydrates legacy Sessions whose amount fields were not retained", async () => {
+    const database = createInMemoryPrisma();
+    setDbProvider(async () => database.prisma as any);
+    seedAttempt(database, { paramsJson: null });
+    const historical = [
+      session("cs-legacy-a", "pi-legacy-a", {
+        amount_subtotal: null,
+        amount_total: null,
+      }),
+      session("cs-legacy-b", "pi-legacy-b", {
+        amount_subtotal: null,
+        amount_total: null,
+      }),
+    ];
+    const stripe = stripeFor(
+      historical,
+      { "pi-legacy-a": 10, "pi-legacy-b": 20 },
+    );
+
+    await reconcileStripeCheckoutCleanups(NOW, "sk_test", stripe);
+
+    expect(database.state.topUpCheckoutResolutions.get("attempt-topup"))
+      .toMatchObject({ canonicalPaymentIntentId: "pi-legacy-a" });
+    expect([...database.state.topUpDuplicateRefundAttempts.values()]).toEqual([
+      expect.objectContaining({
+        stripePaymentIntentId: "pi-legacy-b",
+        amount: 1_000,
       }),
     ]);
   });

--- a/tests/contract/topup-checkout-recovery-reconciler.test.ts
+++ b/tests/contract/topup-checkout-recovery-reconciler.test.ts
@@ -350,6 +350,45 @@ describe("top-up account-deletion recovery reconciliation", () => {
     expect(retrievePaymentIntent).not.toHaveBeenCalled();
   });
 
+  it("marks a deletion-raced zero-cost Session as refund not required", async () => {
+    const database = createInMemoryPrisma();
+    setDbProvider(async () => database.prisma as any);
+    seedAttempt(database, {
+      paramsJson: JSON.stringify({ allow_promotion_codes: true }),
+    });
+    const completed = session("cs-zero-cost-deletion", "unused", {
+      payment_intent: null,
+      amount_total: 0,
+      metadata: {
+        ...session("unused", "unused").metadata,
+        creditAmount: "500",
+      },
+    });
+    const retrievePaymentIntent = vi.fn();
+    const stripe: any = {
+      checkout: { sessions: {
+        list: vi.fn(async ({ status }: any) => ({
+          data: status === "complete" ? [completed] : [],
+          has_more: false,
+        })),
+        expire: vi.fn(),
+        retrieve: vi.fn(),
+      } },
+      paymentIntents: { retrieve: retrievePaymentIntent },
+      refunds: { list: vi.fn(), create: vi.fn() },
+    };
+
+    await reconcileStripeCheckoutCleanups(NOW, "sk_test", stripe);
+
+    expect(database.state.topUpCheckoutAttempts.get("attempt-topup"))
+      .toMatchObject({
+        status: "refund_not_required",
+        stripeCheckoutSessionId: null,
+        activeOwnerKey: null,
+      });
+    expect(retrievePaymentIntent).not.toHaveBeenCalled();
+  });
+
   it("schedules only the remaining refund for a partially refunded normal Session", async () => {
     const database = createInMemoryPrisma();
     setDbProvider(async () => database.prisma as any);

--- a/tests/contract/topup-checkout-recovery-reconciler.test.ts
+++ b/tests/contract/topup-checkout-recovery-reconciler.test.ts
@@ -38,12 +38,17 @@ vi.mock("@beutl/db", async (importOriginal) => {
 
 const NOW = new Date("2026-08-25T00:00:00.000Z");
 
-function session(id: string, paymentIntentId: string): any {
+function session(
+  id: string,
+  paymentIntentId: string,
+  overrides: Record<string, unknown> = {},
+): any {
   return {
     id,
     mode: "payment",
     status: "complete",
     customer: "cus_topup",
+    amount_subtotal: 1000,
     amount_total: 1000,
     currency: "usd",
     payment_intent: paymentIntentId,
@@ -53,6 +58,7 @@ function session(id: string, paymentIntentId: string): any {
       topUpAttemptId: "attempt-topup",
       billingOfferId: "offer-topup",
     },
+    ...overrides,
   };
 }
 
@@ -110,7 +116,12 @@ function seedAttempt(database: ReturnType<typeof createInMemoryPrisma>, override
   return attempt;
 }
 
-function stripeFor(sessions: any[], chargeCreated: Record<string, number>, refunded = new Map<string, any[]>()) {
+function stripeFor(
+  sessions: any[],
+  chargeCreated: Record<string, number>,
+  refunded = new Map<string, any[]>(),
+  amount = 1000,
+) {
   const ownerUserId = sessions[0]?.metadata?.beutlUserId ?? "deleted-user";
   const refundList = vi.fn(async ({ payment_intent: paymentIntentId, starting_after }: any) => {
     const rows = refunded.get(paymentIntentId) ?? [];
@@ -133,8 +144,8 @@ function stripeFor(sessions: any[], chargeCreated: Record<string, number>, refun
       retrieve: vi.fn(async (id: string) => ({
         id,
         status: "succeeded",
-        amount: 1000,
-        amount_received: 1000,
+        amount,
+        amount_received: amount,
         currency: "usd",
         customer: "cus_topup",
         metadata: { topUpAttemptId: "attempt-topup", beutlUserId: ownerUserId, billingOfferId: "offer-topup", creditAmount: "500" },
@@ -510,6 +521,35 @@ describe("top-up account-deletion recovery reconciliation", () => {
     await reconcileStripeCheckoutCleanups(new Date(NOW.getTime() + 5 * 60_000), "sk_test", stripe);
     expect(database.state.topUpCheckoutAttempts.get("attempt-topup")).toMatchObject({ status: "refund_required", stripeCheckoutSessionId: "cs-a", recoveryLeaseToken: null });
     expect(database.state.topUpCheckoutResolutions.get("attempt-topup")).toMatchObject({ status: "resolved", canonicalSessionId: "cs-a" });
+  });
+
+  it("hydrates promotion-code discounted Sessions at the charged amount", async () => {
+    const database = createInMemoryPrisma();
+    setDbProvider(async () => database.prisma as any);
+    seedAttempt(database, {
+      paramsJson: JSON.stringify({ allow_promotion_codes: true }),
+    });
+    const discounted = [
+      session("cs-discount-a", "pi-discount-a", { amount_total: 800 }),
+      session("cs-discount-b", "pi-discount-b", { amount_total: 800 }),
+    ];
+    const stripe = stripeFor(
+      discounted,
+      { "pi-discount-a": 10, "pi-discount-b": 20 },
+      new Map(),
+      800,
+    );
+
+    await reconcileStripeCheckoutCleanups(NOW, "sk_test", stripe);
+
+    expect(database.state.topUpCheckoutResolutions.get("attempt-topup"))
+      .toMatchObject({ canonicalPaymentIntentId: "pi-discount-a" });
+    expect([...database.state.topUpDuplicateRefundAttempts.values()]).toEqual([
+      expect.objectContaining({
+        stripePaymentIntentId: "pi-discount-b",
+        amount: 800,
+      }),
+    ]);
   });
 
   it("prefers the attempt PaymentIntent as canonical even when another Charge is older", async () => {

--- a/tests/contract/topup-fulfillment-recovery-race.test.ts
+++ b/tests/contract/topup-fulfillment-recovery-race.test.ts
@@ -22,6 +22,7 @@ describe("top-up webhook versus multiple-Session recovery", () => {
       ownerUserId: "user-1",
       activeOwnerKey: "user-1",
       checkoutKey: "ai-top-up-checkout:attempt-1",
+      paramsJson: JSON.stringify({ allow_promotion_codes: true }),
       stripeCustomerId: "cus-1",
       billingOfferId: "offer-1",
       stripeCheckoutSessionId: null,
@@ -107,7 +108,7 @@ describe("top-up webhook versus multiple-Session recovery", () => {
     await expect(fulfillTopUpCheckoutAttempt({
       attemptId: "attempt-1",
       stripePaymentIntentId: "pi-canonical",
-      stripePayment: { amount: 1_000, currency: "usd" },
+      stripePayment: { amount: 800, currency: "usd" },
       stripeRefundState: { succeededAmount: 0, pendingAmount: 0 },
       now,
       prisma: tx as never,
@@ -129,7 +130,7 @@ describe("top-up webhook versus multiple-Session recovery", () => {
       canonicalPaymentIntentId: "pi-canonical",
       expectedPaymentIntents: [{
         paymentIntentId: "pi-duplicate",
-        amount: 1_000,
+        amount: 800,
         currency: "usd",
       }],
       prisma: tx as never,
@@ -153,7 +154,7 @@ describe("top-up webhook versus multiple-Session recovery", () => {
         sessionId: "cs-canonical",
         expiresAt: new Date(now.getTime() + 60_000),
         paymentIntentId: "pi-canonical",
-        stripePayment: { amount: 1_000, currency: "usd" },
+        stripePayment: { amount: 800, currency: "usd" },
       },
       prisma: tx as never,
     })).resolves.toBe(true);


### PR DESCRIPTION
## Description

- Enable customer-entered Stripe promotion codes for Pro and credit top-up Checkout Sessions.
- Validate discounted top-up totals against the persisted Checkout parameters and original Stripe Price across normal checkout, webhook fulfillment, and recovery paths.
- Preserve exact pre-promotion Pro Checkout parameters when replaying an existing idempotency key.
- Terminalize zero-cost top-ups without granting credits or requesting impossible refunds, including account-deletion recovery.
- Keep package-store Checkout excluded and document that top-up promotion codes must leave a positive amount to pay.

## Breaking changes

None.

## Fixed issues

None.

## Verification

- pnpm test (1,786 passed, 20 skipped)
- pnpm typecheck
- pnpm lint