### PR TITLE
docs: reorganize README and deployment guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,182 +1,89 @@
 # beutl-web
 
-Beutl's marketplace web application for browsing packages, managing developer projects, user accounts, releases, checkout, and public API endpoints.
+The monorepo behind Beutl's marketplace, account and developer dashboards,
+checkout flows, admin console, and desktop-facing APIs.
 
-## Monorepo structure
+The Web and admin applications use Next.js App Router. Desktop APIs use Hono,
+with Prisma and CockroachDB for persistence. Production workloads run on
+Cloudflare Workers.
 
-```
-apps/web/            # Next.js Web アプリ (@beutl/web) → beutl-web Worker
-apps/admin/          # 管理画面 Next.js アプリ (@beutl/admin) → beutl-admin Worker
-packages/api/        # デスクトップ API (v1/v2/v3, Hono) → beutl-web-api Worker
-packages/db/         # データアクセス層 (@beutl/db)
-packages/i18n/       # i18n (静的 resource map) (@beutl/i18n)
-packages/core/       # 純粋ロジック (@beutl/core)
-packages/ui/         # 共有 UI コンポーネント (shadcn/ui, @beutl/ui)
-tests/contract/      # 外部契約のゴールデンテスト (Vitest)
-```
+## Repository layout
 
-## Technology
+| Path | Package | Purpose |
+| --- | --- | --- |
+| `apps/web` | `@beutl/web` | Public site, account and developer dashboards, authentication, and checkout |
+| `apps/admin` | `@beutl/admin` | Administrative console |
+| `packages/api` | `@beutl/api` | Hono APIs for desktop clients (`v1`, `v2`, and `v3`) |
+| `packages/core` | `@beutl/core` | Framework-independent domain logic |
+| `packages/db` | `@beutl/db` | Prisma client and data-access helpers |
+| `packages/email` | `@beutl/email` | Server-only email delivery |
+| `packages/i18n` | `@beutl/i18n` | Translations and locale resolution |
+| `packages/next` | `@beutl/next` | Shared Next.js server helpers |
+| `packages/ui` | `@beutl/ui` | Shared UI components |
+| `tests/contract` | — | Golden and external-contract tests |
+| `tests/integration` | — | Tests that use CockroachDB or live provider data when enabled |
 
-- Next.js App Router
-- Prisma with PostgreSQL-compatible database access (CockroachDB)
-- Better Auth for authentication
-- Stripe checkout and webhooks
-- Cloudflare Workers deployment (OpenNext Cloudflare for Web, wrangler for API)
-- pnpm workspaces
+## Getting started
 
-## Development
-
-Use the Node major declared in `.nvmrc`, then install dependencies and start the local server:
+Use the Node.js version in [`.nvmrc`](.nvmrc) and the pnpm version declared in
+[`package.json`](package.json). Corepack can activate that pnpm version.
 
 ```bash
+corepack enable
 pnpm install
+cp apps/web/.env.sample apps/web/.env.local
 pnpm dev
 ```
 
-Run linting with:
+Fill in the values needed for the flow you are developing. The public Web app
+runs at `http://localhost:3000`.
+
+To run the admin console at `http://localhost:3001`:
 
 ```bash
-pnpm lint
+cp apps/admin/.env.sample apps/admin/.env.local
+pnpm dev:admin
 ```
 
-Run contract tests (external API golden tests):
+Local environment files and Wrangler `.dev.vars` files are ignored by Git and
+must not be committed.
 
-```bash
-pnpm test
-```
+## Common commands
+
+| Command | Purpose |
+| --- | --- |
+| `pnpm dev` | Start the public Web app |
+| `pnpm dev:admin` | Start the admin console |
+| `pnpm build` | Build both Next.js apps and type-check the desktop API |
+| `pnpm lint` | Lint both Next.js apps |
+| `pnpm typecheck` | Type-check every workspace that defines a type-check script |
+| `pnpm test` | Run the Vitest contract and integration suites |
+| `pnpm test:watch` | Run Vitest in watch mode |
+| `pnpm preview` | Build and preview the public Cloudflare Worker locally |
+
+CockroachDB integration tests require `TEST_DATABASE_URL`. The live OpenRouter
+pricing test is opt-in through `TEST_OPENROUTER_PRICING=1`; these tests are
+skipped when their respective variables are absent.
 
 ## Deployment
 
-Three Workers are deployed (see `docs/adr/0002-api-worker-split.md` for the path split):
+Production is split across three Cloudflare Workers. The longest matching
+Cloudflare route sends desktop API traffic to the dedicated API Worker.
 
-- `beutl-web` (Web): `beutl.beditor.net/*` (except API paths)
-- `beutl-web-api` (desktop API): `beutl.beditor.net/api/v{1,2,3}/*`
-- `beutl-admin` (admin console): `admin.beutl.beditor.net/*`
+| Worker | Routes | Command |
+| --- | --- | --- |
+| `beutl-web` | `beutl.beditor.net/*`, except the desktop API routes | `pnpm deploy:web` |
+| `beutl-web-api` | `beutl.beditor.net/api/v{1,2,3}/*` | `pnpm deploy:api` |
+| `beutl-admin` | `admin.beutl.beditor.net/*` | `pnpm deploy:admin` |
 
-```bash
-pnpm run deploy:web   # Web Worker (OpenNext build + deploy)
-pnpm run deploy:api   # API Worker (wrangler deploy)
-pnpm run deploy:admin # Admin Worker (OpenNext build + deploy)
-```
+Before deploying, read [Deployment configuration](docs/deployment.md) for
+cross-Worker secrets, admin session sharing, Paid AI settings, and required
+Stripe webhook events. The route split and its rollback procedure are recorded
+in [ADR 0002](docs/adr/0002-api-worker-split.md).
 
-Cloudflare bindings are declared in `apps/web/wrangler.jsonc`, `packages/api/wrangler.jsonc`
-and `apps/admin/wrangler.jsonc`; local environment placeholders are documented in
-`apps/web/.env.sample` and `apps/admin/.env.sample`.
-`JWT_SECRET` / `JWT_ISSUER` / `JWT_AUDIENCE` must match between the Web and API Workers
-(CI deploys from GitHub Secrets).
+## Documentation
 
-The admin console can share the better-auth session with the Web app via
-`crossSubDomainCookies`, which is enabled only when `BETTER_AUTH_COOKIE_DOMAIN` is set.
-Set it to the narrowest domain that covers both Workers (`beutl.beditor.net` in
-production); `admin.beutl.beditor.net` is a subdomain of it. Do not use the root domain
-`beditor.net`, which would send the session cookie to every unrelated host under it.
-Leaving it unset (the default, including local development) keeps each Worker on a
-host-only session cookie and disables session sharing. The admin Worker needs the same
-`BETTER_AUTH_SECRET` and OAuth client IDs (Google/GitHub) as the Web app; OAuth
-redirect URIs for `admin.beutl.beditor.net` must be registered on the provider side.
-Access is restricted to the user IDs in `ADMIN_USER_IDS`.
-
-Note: adding a `Domain` attribute to previously host-only cookies creates a separate
-cookie entry in the browser. Both may be sent together during rollout, so existing
-session cookies should be explicitly expired when enabling this.
-
-### Paid AI configuration
-
-The Web Worker requires `STRIPE_PRO_PRICE_ID` for the monthly Pro subscription,
-`STRIPE_CREDIT_PRICE_ID` for the one-time 500-unit top-up, and an explicit
-`STRIPE_BILLING_PORTAL_CONFIGURATION_ID` whose configuration disables
-subscription price switching and cancels at period end. Rotated Pro offers must
-be listed as immutable `priceId:productId` pairs in
-`STRIPE_PRO_HISTORICAL_OFFERS`; they are never learned from a customer-edited
-subscription. The API Worker
-requires `OPENROUTER_WEBHOOK_SECRET` as a Cloudflare secret so ambiguous video
-submissions can be reconciled through signed provider callbacks. It also
-requires `OPENROUTER_API_KEY` as a Wrangler secret. Provider calls default to a
-120-second deadline, configurable with `OPENROUTER_REQUEST_TIMEOUT_MS`.
-
-The API Worker also requires `STRIPE_SECRET_KEY`. Its scheduled run reconciles
-the refunds owed for top-ups and for Pro billing, and both reconcilers need a
-Stripe client; without the secret the cron fails and compensating refunds stop
-being issued. It is the same secret the Web Worker uses.
-
-An operation can offer several models, each with its own usage-unit price, and
-the caller picks one per request — `model` on the v3 request bodies, a field on
-the dashboard forms. Omitting it runs the operation's default. An unknown or
-disabled model is refused rather than replaced by the default, since that would
-charge the default's price for a model nobody asked for. The models on offer are
-registered per operation from the admin console (`/admin/ai`) and stored in the
-`AiOperationModel` table; an operation with none registered runs on the single
-model and price the console holds in `AiSetting`, which is also where the
-monthly allowance granted to each Pro subscription lives. Each value resolves
-from the database or the built-in default (500 units per period for the
-allowance). Every change is written to the audit log in the same transaction.
-
-Clients learn the models from `GET /api/v3/ai/capabilities`, which names them
-and orders them by relative expense (`costTier`: `low` / `medium` / `high`)
-without stating any price; `GET /api/v3/user/entitlements` says which of them
-the account can currently afford in `modelAvailability`. Prices themselves never
-leave the server.
-API keys and other secrets are deliberately **not** configurable this way and
-stay in Wrangler secrets. A price change applies only to operations started
-afterwards: each job records the price reserved at its start and is refunded at
-that same price. An allowance change likewise applies to operations started
-afterwards; usage already consumed in the current period is left untouched.
-
-The settings page shows what each price and the allowance actually amount to,
-so they are not set blind: how far the allowance goes for each operation, what
-one usage unit is worth in money (per allowance unit and per purchased unit),
-and an estimated provider cost with its resulting cost ratio.
-
-Prices are read from Stripe directly, so the page is accurate before the first
-sale — `BillingOffer` only holds terms a checkout has already been created
-against. The admin Worker needs `STRIPE_SECRET_KEY`, `STRIPE_PRO_PRICE_ID`, and
-`STRIPE_CREDIT_PRICE_ID` for this; **use a Stripe restricted key limited to
-`prices: read`**, since the admin console has no reason to be able to move
-money. Without them the page falls back to the recorded offer and says so, and
-when Stripe and the stored offer disagree it flags that too (purchases still
-settle against the stored terms).
-
-Pro and credit top-up Checkout Sessions let customers enter active Stripe
-promotion codes. Create and constrain those codes in the Stripe Dashboard; the
-package store does not accept them. A top-up promotion must leave a positive
-amount to pay because credit fulfillment is tied to its successful
-PaymentIntent, so do not make a 100%-off code eligible for the top-up Price.
-
-Costs come from OpenRouter's public price endpoints, which need no API key, so
-the admin Worker holds no provider credentials. They
-are estimates from a published rate card, not recorded spend: where a rate is
-quoted per token rather than per image or per second, the assumption used to
-bridge it is stated on screen, and anything whose unit cannot be determined is
-reported as unknown rather than shown as free.
-
-`/admin/ai/usage` reports jobs and usage units over a selected window, the
-balances every account currently holds, the heaviest consumers, and how much of
-the allowance subscribers actually consume (median, 90th percentile, and the
-share who exhaust it). That distribution reads the current billing period only,
-and rows whose period has already ended are excluded, because the usage counter
-is not cleared until the account next runs a job. Individual
-balances are corrected from the user detail page (`/admin/users/<id>`): an
-administrator can grant or revoke additional credits and set the usage consumed
-in the current period. A grant settles outstanding credit debt first, a revoke
-never exceeds the current balance, and the monthly counter can only be changed
-while the user has an active Pro plan, because the allowance belongs to a
-billing period. Each adjustment writes both a `CreditTransaction` row
-(`admin_credit_adjustment` / `admin_usage_adjustment`) and an audit log entry in
-the same transaction.
-
-The Stripe webhook endpoint must receive these paid-AI lifecycle events:
-
-- `customer.subscription.created`, `customer.subscription.updated`, and
-  `customer.subscription.deleted`
-- `invoice.paid` and `payment_intent.succeeded`
-- `charge.refunded`, `refund.created`, `refund.updated`, and `refund.failed`
-- `charge.dispute.created`, `charge.dispute.updated`,
-  `charge.dispute.closed`, `charge.dispute.funds_withdrawn`, and
-  `charge.dispute.funds_reinstated`
-
-Successful transcription and translation response payloads are stored as
-private AI job outputs for 30 days. The authenticated job detail and history
-endpoints return their content URLs, allowing the desktop app to recover a paid
-result after a lost HTTP response. Subtitle timing context is retained in the
-private translation result but stripped before the text is sent to the AI
-provider.
+- [Deployment configuration](docs/deployment.md)
+- [ADR 0001: v1 account is the authentication backbone](docs/adr/0001-v1-account-is-the-auth-backbone.md)
+- [ADR 0002: desktop API Worker split](docs/adr/0002-api-worker-split.md)
+- [Stripe AI billing migration safety](docs/stripe-ai-billing-migration.md)

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,161 @@
+# Deployment configuration
+
+This document records configuration and operational requirements shared by the
+three Cloudflare Workers. Worker routes and deploy commands are listed in the
+root [README](../README.md#deployment).
+
+## Configuration sources
+
+Cloudflare bindings are declared alongside each deployable application:
+
+- Web: [`apps/web/wrangler.jsonc`](../apps/web/wrangler.jsonc)
+- Desktop API: [`packages/api/wrangler.jsonc`](../packages/api/wrangler.jsonc)
+- Admin: [`apps/admin/wrangler.jsonc`](../apps/admin/wrangler.jsonc)
+
+Local environment placeholders are documented in
+[`apps/web/.env.sample`](../apps/web/.env.sample) and
+[`apps/admin/.env.sample`](../apps/admin/.env.sample). Store production secrets
+in Cloudflare and local Worker secrets in ignored `.dev.vars` files; never
+commit secret values.
+
+`JWT_SECRET`, `JWT_ISSUER`, and `JWT_AUDIENCE` must match between the Web and
+desktop API Workers. The Web Worker issues the JWTs that the API Worker
+validates.
+
+## Admin authentication and session sharing
+
+The admin console can share the Better Auth session with the Web app through
+`crossSubDomainCookies`. Session sharing is enabled only when
+`BETTER_AUTH_COOKIE_DOMAIN` is set.
+
+- Leave `BETTER_AUTH_COOKIE_DOMAIN` unset during local development. Each
+  Worker then uses a host-only session cookie and does not share sessions.
+- In production, set it to the narrowest domain covering both Workers:
+  `beutl.beditor.net`.
+- Do not use `beditor.net`. That would send the session cookie to unrelated
+  hosts below the root domain.
+- Configure the same `BETTER_AUTH_SECRET` and Google/GitHub OAuth client IDs on
+  the Web and admin Workers.
+- Register OAuth redirect URIs for `admin.beutl.beditor.net` with each provider.
+- Restrict admin access with the comma-separated user IDs in `ADMIN_USER_IDS`.
+
+Adding a `Domain` attribute does not replace an existing host-only cookie; the
+browser can send both entries during rollout. Explicitly expire existing
+host-only session cookies when enabling session sharing.
+
+## Paid AI
+
+### Worker settings
+
+The Web Worker requires:
+
+- `STRIPE_SECRET_KEY`
+- `STRIPE_PRO_PRICE_ID` for the monthly Pro subscription
+- `STRIPE_CREDIT_PRICE_ID` for the one-time 500-unit top-up
+- `STRIPE_BILLING_PORTAL_CONFIGURATION_ID`, pointing to an active portal
+  configuration that disables price switching and cancels at period end
+- `STRIPE_PRO_HISTORICAL_OFFERS`, containing immutable `priceId:productId`
+  pairs for rotated Pro offers
+
+Historical offers are explicit rather than learned from a customer-edited
+subscription.
+
+The desktop API Worker requires:
+
+- `OPENROUTER_API_KEY`
+- `OPENROUTER_WEBHOOK_SECRET`, used to verify callbacks that reconcile
+  ambiguous video submissions
+- `STRIPE_SECRET_KEY`, used by scheduled top-up and Pro refund reconciliation
+- `OPENROUTER_REQUEST_TIMEOUT_MS` when overriding the default 120-second
+  provider deadline
+
+Without `STRIPE_SECRET_KEY`, the API Worker's scheduled billing reconcilers
+fail and compensating refunds stop being issued. Use the same Stripe secret as
+the Web Worker.
+
+The admin Worker can read current prices from Stripe before the first sale.
+Configure `STRIPE_PRO_PRICE_ID`, `STRIPE_CREDIT_PRICE_ID`, and a restricted
+`STRIPE_SECRET_KEY` that grants only `prices: read`. The admin console has no
+reason to hold a key capable of moving money. When these settings are absent,
+the console falls back to a recorded `BillingOffer` when available and marks
+the fallback; it also flags disagreements between Stripe and stored terms.
+Purchases continue to settle against the stored terms.
+
+### Models, prices, and allowances
+
+An operation can offer several models, each with its own usage-unit price. The
+caller selects one through `model` in a v3 request or the corresponding
+dashboard field. Omitting the field selects the operation's default. Unknown
+or disabled models are rejected instead of silently replaced, preventing a
+caller from being charged for a model it did not request.
+
+Administrators register models per operation at `/admin/ai`. They are stored
+in `AiOperationModel`. An operation with no registered models uses the single
+model and price in `AiSetting`; the monthly Pro allowance is configured there
+as well. Values resolve from the database or their built-in defaults, including
+the default allowance of 500 units per period. Each settings change and account
+adjustment is written to the audit log in the same transaction as the change.
+
+Clients discover models through `GET /api/v3/ai/capabilities`. It exposes model
+names and relative expense (`costTier`: `low`, `medium`, or `high`) without
+prices. `GET /api/v3/user/entitlements` exposes affordability through
+`modelAvailability`. Prices and secret values never leave the server.
+
+Price and allowance changes affect only operations started afterwards. Each
+job records the price reserved at its start and uses that same price for a
+refund. Changing the allowance does not alter usage already consumed in the
+current billing period.
+
+### Admin reporting and adjustments
+
+The AI settings page shows:
+
+- how many runs of each operation an allowance buys;
+- the monetary value of one unit for allowances and purchased credits; and
+- estimated provider cost and the resulting cost ratio.
+
+Provider costs come from OpenRouter's public price endpoints and require no
+provider credential on the admin Worker. They are rate-card estimates, not
+recorded spend. When a token rate must be converted to another unit, the UI
+states the assumption. An indeterminate unit is reported as unknown rather
+than free.
+
+`/admin/ai/usage` reports jobs and units for a selected window, current account
+balances, heavy consumers, and allowance consumption statistics. The
+distribution uses only current billing periods because an expired period's
+counter is not cleared until the account next runs a job.
+
+Administrators can grant or revoke purchased credits and correct current-period
+usage from `/admin/users/<id>`. A grant settles credit debt first, a revoke
+cannot exceed the current balance, and monthly usage can be changed only for an
+active Pro plan. Each adjustment writes a `CreditTransaction`
+(`admin_credit_adjustment` or `admin_usage_adjustment`) and an audit log entry
+in the same transaction.
+
+### Promotion codes
+
+Pro and credit top-up Checkout Sessions accept active Stripe promotion codes.
+Create and constrain them in the Stripe Dashboard; package-store checkout does
+not accept them. A top-up promotion must leave a positive amount payable because
+credit fulfillment depends on a successful PaymentIntent. Do not make a
+100%-off promotion eligible for the top-up Price.
+
+### Stripe webhook events
+
+The Stripe webhook endpoint must receive these Paid AI lifecycle events:
+
+- `customer.subscription.created`, `customer.subscription.updated`, and
+  `customer.subscription.deleted`
+- `invoice.paid` and `payment_intent.succeeded`
+- `charge.refunded`, `refund.created`, `refund.updated`, and `refund.failed`
+- `charge.dispute.created`, `charge.dispute.updated`,
+  `charge.dispute.closed`, `charge.dispute.funds_withdrawn`, and
+  `charge.dispute.funds_reinstated`
+
+### Result retention
+
+Successful transcription and translation payloads are stored as private AI
+job outputs for 30 days. Authenticated job-detail and history endpoints return
+their content URLs so the desktop app can recover a paid result after a lost
+HTTP response. Private translation results retain subtitle timing context, but
+that context is removed before text is sent to the AI provider.


### PR DESCRIPTION
## Description

- Rework the README around repository layout, onboarding, common commands, deployment topology, and documentation links.
- Move admin authentication and Paid AI operational guidance into `docs/deployment.md` without dropping deployment requirements.
- Remove the outdated deployment CI claim and document opt-in integration test prerequisites.
- Validate whitespace and all relative Markdown link targets.

## Breaking changes

None.

## Fixed issues

None.