### PR TITLE
fix: rotate legacy checkouts to enable promotion codes

### DIFF
--- a/apps/web/src/app/[lang]/(dashboard)/dashboard/account/billing/actions.ts
+++ b/apps/web/src/app/[lang]/(dashboard)/dashboard/account/billing/actions.ts
@@ -127,6 +127,27 @@ function canonicalizeCheckoutParams(value: unknown): unknown {
   return value;
 }
 
+async function expireOpenCheckoutSession(
+  stripe: ReturnType<typeof createStripe>,
+  checkoutSession: Stripe.Checkout.Session,
+): Promise<Stripe.Checkout.Session> {
+  if (checkoutSession.status !== "open") {
+    return checkoutSession;
+  }
+  try {
+    return await stripe.checkout.sessions.expire(checkoutSession.id);
+  } catch (error) {
+    const resolved = await stripe.checkout.sessions.retrieve(
+      checkoutSession.id,
+      { expand: ["line_items.data.price"] },
+    );
+    if (resolved.status !== "complete" && resolved.status !== "expired") {
+      throw error;
+    }
+    return resolved;
+  }
+}
+
 function persistedProCheckoutParams(
   paramsJson: string,
   current: Stripe.Checkout.SessionCreateParams,
@@ -556,6 +577,9 @@ export async function createProCheckout(): Promise<void> {
       const authorizedOffer =
         attemptOffer?.kind === "pro" &&
         recognizedProPriceIds.has(attemptOffer.stripePriceId);
+      const promotionCodesEnabled = allowsStripePromotionCodes(
+        attempt.paramsJson,
+      );
       if (!isValidatedBoundSession(existingSession)) {
         if (
           existingSession.id === attempt.stripeCheckoutSessionId &&
@@ -575,7 +599,8 @@ export async function createProCheckout(): Promise<void> {
       if (
         authorizedOffer &&
         existingSession.status === "open" &&
-        existingSession.url
+        existingSession.url &&
+        promotionCodesEnabled
       ) {
         redirect(existingSession.url);
       }
@@ -615,6 +640,15 @@ export async function createProCheckout(): Promise<void> {
         finalSession = await stripe.checkout.sessions.retrieve(
           finalSession.id,
           { expand: ["line_items.data.price"] },
+        );
+      }
+      if (
+        authorizedOffer &&
+        finalSession.status === "complete" &&
+        isValidatedBoundSession(finalSession)
+      ) {
+        redirect(
+          `/dashboard/account/billing?checkout=success&session_id=${finalSession.id}`,
         );
       }
       if (finalSession.status === "complete") {
@@ -749,6 +783,29 @@ export async function createProCheckout(): Promise<void> {
         }
       }
       continue;
+    }
+
+    if (!allowsStripePromotionCodes(createParams)) {
+      const finalSession = await expireOpenCheckoutSession(
+        stripe,
+        checkoutSession,
+      );
+      if (finalSession.status === "complete") {
+        redirect(
+          `/dashboard/account/billing?checkout=success&session_id=${finalSession.id}`,
+        );
+      }
+      if (finalSession.status === "expired") {
+        await deleteBoundProCheckoutAttempt({
+          userId: session.user.id,
+          checkoutKey: attempt.checkoutKey,
+          stripeCheckoutSessionId: checkoutSession.id,
+        });
+        continue;
+      }
+      throw new Error(
+        `Pre-promotion Checkout Session ${checkoutSession.id} remains ${finalSession.status ?? "unknown"}`,
+      );
     }
 
     if (!checkoutSession.url) {
@@ -954,6 +1011,9 @@ export async function createCreditCheckout(): Promise<void> {
         attempt.stripeCheckoutSessionId,
         { expand: ["line_items.data.price"] },
       );
+      const promotionCodesEnabled = allowsStripePromotionCodes(
+        attempt.paramsJson,
+      );
       const sessionExpectation = {
         checkoutSession: existing,
         attemptId: attempt.id,
@@ -961,7 +1021,7 @@ export async function createCreditCheckout(): Promise<void> {
         offer,
         userId: authSession.user.id,
         requireLineItems: true,
-        promotionCodesEnabled: allowsStripePromotionCodes(attempt.paramsJson),
+        promotionCodesEnabled,
       };
       if (isCompletedZeroCostTopUpSession(sessionExpectation)) {
         const terminalized = await expireTopUpCheckoutAttempt({
@@ -978,6 +1038,38 @@ export async function createCreditCheckout(): Promise<void> {
       }
       if (!topUpSessionMatchesAttempt(sessionExpectation)) {
         throw new Error("Bound top-up Checkout failed canonical validation");
+      }
+      if (existing.status === "open" && !promotionCodesEnabled) {
+        const finalSession = await expireOpenCheckoutSession(stripe, existing);
+        if (finalSession.status === "complete") {
+          if (!topUpSessionMatchesAttempt({
+            ...sessionExpectation,
+            checkoutSession: finalSession,
+          })) {
+            throw new Error(
+              "Completed pre-promotion top-up Checkout failed canonical validation",
+            );
+          }
+          redirect(
+            `/dashboard/account/billing?checkout=success&session_id=${finalSession.id}`,
+          );
+        }
+        if (finalSession.status !== "expired") {
+          throw new Error(
+            `Pre-promotion top-up Checkout ${existing.id} remains ${finalSession.status ?? "unknown"}`,
+          );
+        }
+        const expired = await expireTopUpCheckoutAttempt({
+          attemptId: attempt.id,
+          ownerUserId: authSession.user.id,
+          stripeCheckoutSessionId: existing.id,
+        });
+        if (expired.count !== 1) {
+          throw new Error(
+            "Pre-promotion top-up Checkout changed during rotation",
+          );
+        }
+        continue;
       }
       if (existing.status === "expired") {
         const expired = await expireTopUpCheckoutAttempt({
@@ -1135,6 +1227,45 @@ export async function createCreditCheckout(): Promise<void> {
         }
       }
 
+      const promotionCodesEnabled = allowsStripePromotionCodes(params);
+      if (checkoutSession.status === "open" && !promotionCodesEnabled) {
+        const finalSession = await expireOpenCheckoutSession(
+          stripe,
+          checkoutSession,
+        );
+        if (finalSession.status === "expired") {
+          const expired = await expireTopUpCheckoutAttempt({
+            attemptId: claim.attempt.id,
+            ownerUserId: authSession.user.id,
+            stripeCheckoutSessionId: null,
+            leaseToken,
+          });
+          if (expired.count !== 1) {
+            throw new Error(
+              "Pre-promotion top-up Checkout rotation lease was lost",
+            );
+          }
+          continue;
+        }
+        if (
+          finalSession.status !== "complete" ||
+          !topUpSessionMatchesAttempt({
+            checkoutSession: finalSession,
+            attemptId: claim.attempt.id,
+            customerId: claim.attempt.stripeCustomerId,
+            offer,
+            userId: authSession.user.id,
+            requireLineItems: true,
+            promotionCodesEnabled,
+          })
+        ) {
+          throw new Error(
+            "Completed pre-promotion top-up Checkout failed canonical validation",
+          );
+        }
+        checkoutSession = finalSession;
+      }
+
       if (checkoutSession.status === "expired") {
         const expired = await expireTopUpCheckoutAttempt({
           attemptId: claim.attempt.id,
@@ -1160,6 +1291,11 @@ export async function createCreditCheckout(): Promise<void> {
       }
       if (checkoutSession.status === "open" && checkoutSession.url) {
         redirect(checkoutSession.url);
+      }
+      if (checkoutSession.status === "complete") {
+        redirect(
+          `/dashboard/account/billing?checkout=success&session_id=${checkoutSession.id}`,
+        );
       }
       redirect("/dashboard/account/billing");
     } catch (error) {

--- a/apps/web/src/app/[lang]/(dashboard)/dashboard/account/billing/actions.ts
+++ b/apps/web/src/app/[lang]/(dashboard)/dashboard/account/billing/actions.ts
@@ -134,13 +134,19 @@ async function expireOpenCheckoutSession(
   if (checkoutSession.status !== "open") {
     return checkoutSession;
   }
+  const retrieveExpanded = () =>
+    stripe.checkout.sessions.retrieve(checkoutSession.id, {
+      expand: ["line_items.data.price"],
+    });
   try {
-    return await stripe.checkout.sessions.expire(checkoutSession.id);
+    const resolved = await stripe.checkout.sessions.expire(checkoutSession.id);
+    // Stripe normally returns an expired Session here. Defensively hydrate a
+    // completed result before callers perform exact line-item validation.
+    return resolved.status === "complete"
+      ? await retrieveExpanded()
+      : resolved;
   } catch (error) {
-    const resolved = await stripe.checkout.sessions.retrieve(
-      checkoutSession.id,
-      { expand: ["line_items.data.price"] },
-    );
+    const resolved = await retrieveExpanded();
     if (resolved.status !== "complete" && resolved.status !== "expired") {
       throw error;
     }

--- a/tests/contract/ai-checkout.test.ts
+++ b/tests/contract/ai-checkout.test.ts
@@ -308,7 +308,7 @@ describe("AI checkout actions", () => {
     );
   });
 
-  it("replays pre-promotion Pro parameters with their original idempotency key", async () => {
+  it("resolves a pre-promotion Pro replay before rotating to a new Checkout", async () => {
     mocks.getSubscriptionByUserId.mockResolvedValue(null);
     const legacyParams = {
       customer: "cus_1",
@@ -347,21 +347,45 @@ describe("AI checkout actions", () => {
       mode: legacyParams.mode,
       customer: legacyParams.customer,
     };
-    mocks.getOrCreateProCheckoutAttempt.mockResolvedValue({
-      userId: "user-1",
-      checkoutKey: "attempt-legacy",
-      billingOfferId: "offer_pro",
-      stripeCheckoutSessionId: null,
-      paramsJson: JSON.stringify(reorderedLegacyParams),
-      expiresAt: new Date(Date.now() + 86_400_000),
-    });
+    mocks.getOrCreateProCheckoutAttempt
+      .mockResolvedValueOnce({
+        userId: "user-1",
+        checkoutKey: "attempt-legacy",
+        billingOfferId: "offer_pro",
+        stripeCheckoutSessionId: null,
+        paramsJson: JSON.stringify(reorderedLegacyParams),
+        expiresAt: new Date(Date.now() + 86_400_000),
+      })
+      .mockResolvedValueOnce({
+        userId: "user-1",
+        checkoutKey: "attempt-current",
+        billingOfferId: "offer_pro",
+        stripeCheckoutSessionId: null,
+        paramsJson: null,
+        expiresAt: new Date(Date.now() + 86_400_000),
+      });
 
     await expect(createProCheckout()).rejects.toThrow("NEXT_REDIRECT");
 
-    expect(mocks.checkoutCreate).toHaveBeenCalledWith(reorderedLegacyParams, {
-      idempotencyKey: "ai-pro-checkout:attempt-legacy",
+    expect(mocks.checkoutCreate).toHaveBeenNthCalledWith(
+      1,
+      reorderedLegacyParams,
+      { idempotencyKey: "ai-pro-checkout:attempt-legacy" },
+    );
+    expect(mocks.checkoutExpire).toHaveBeenCalledWith("cs_1");
+    expect(mocks.deleteBoundProCheckoutAttempt).toHaveBeenCalledWith({
+      userId: "user-1",
+      checkoutKey: "attempt-legacy",
+      stripeCheckoutSessionId: "cs_1",
     });
-    expect(mocks.setProCheckoutAttemptParams).not.toHaveBeenCalled();
+    expect(mocks.checkoutCreate).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ allow_promotion_codes: true }),
+      { idempotencyKey: "ai-pro-checkout:attempt-current" },
+    );
+    expect(mocks.setProCheckoutAttemptParams).toHaveBeenCalledWith(
+      expect.objectContaining({ checkoutKey: "attempt-current" }),
+    );
   });
 
   it("copies the top-up amount to the Stripe PaymentIntent", async () => {
@@ -421,6 +445,171 @@ describe("AI checkout actions", () => {
     expect(mocks.checkoutRetrieve).toHaveBeenCalledWith("cs_discounted", {
       expand: ["line_items.data.price"],
     });
+  });
+
+  it("expires a bound pre-promotion top-up Checkout before creating a replacement", async () => {
+    mocks.getSubscriptionByUserId.mockResolvedValue({
+      status: "active",
+      planId: "pro",
+      billingOfferId: "offer_pro",
+      currentPeriodEnd: new Date(Date.now() + 60_000),
+    });
+    const legacyParams = JSON.parse(
+      mocks.topUpAttempt!.paramsJson as string,
+    );
+    delete legacyParams.allow_promotion_codes;
+    const legacyAttempt = {
+      ...mocks.topUpAttempt!,
+      stripeCheckoutSessionId: "cs_topup_pre_promotion",
+      paramsJson: JSON.stringify(legacyParams),
+    };
+    mocks.getOrCreateTopUpCheckoutAttempt.mockResolvedValueOnce(legacyAttempt);
+    mocks.checkoutRetrieve.mockResolvedValue(
+      topUpCheckoutSession({
+        id: "cs_topup_pre_promotion",
+        allow_promotion_codes: false,
+      }),
+    );
+    mocks.checkoutExpire.mockResolvedValue(
+      topUpCheckoutSession({
+        id: "cs_topup_pre_promotion",
+        status: "expired",
+        url: null,
+        allow_promotion_codes: false,
+      }),
+    );
+
+    await expect(createCreditCheckout()).rejects.toThrow("NEXT_REDIRECT");
+
+    expect(mocks.checkoutExpire).toHaveBeenCalledWith(
+      "cs_topup_pre_promotion",
+    );
+    expect(mocks.expireTopUpCheckoutAttempt).toHaveBeenCalledWith({
+      attemptId: "topup-attempt-1",
+      ownerUserId: "user-1",
+      stripeCheckoutSessionId: "cs_topup_pre_promotion",
+    });
+    expect(mocks.checkoutCreate).toHaveBeenCalledTimes(1);
+    expect(mocks.checkoutCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ allow_promotion_codes: true }),
+      expect.any(Object),
+    );
+  });
+
+  it("keeps a pre-promotion top-up Checkout that completes during expiry", async () => {
+    mocks.getSubscriptionByUserId.mockResolvedValue({
+      status: "active",
+      planId: "pro",
+      billingOfferId: "offer_pro",
+      currentPeriodEnd: new Date(Date.now() + 60_000),
+    });
+    const legacyParams = JSON.parse(
+      mocks.topUpAttempt!.paramsJson as string,
+    );
+    delete legacyParams.allow_promotion_codes;
+    const legacyAttempt = {
+      ...mocks.topUpAttempt!,
+      stripeCheckoutSessionId: "cs_topup_pre_promotion_race",
+      paramsJson: JSON.stringify(legacyParams),
+    };
+    mocks.getOrCreateTopUpCheckoutAttempt.mockResolvedValue(legacyAttempt);
+    const openSession = topUpCheckoutSession({
+      id: "cs_topup_pre_promotion_race",
+      allow_promotion_codes: false,
+    });
+    mocks.checkoutRetrieve
+      .mockResolvedValueOnce(openSession)
+      .mockResolvedValueOnce({
+        ...openSession,
+        status: "complete",
+        url: null,
+      });
+    mocks.checkoutExpire.mockRejectedValue(
+      new Error("Checkout Session already completed"),
+    );
+
+    await expect(createCreditCheckout()).rejects.toThrow("NEXT_REDIRECT");
+
+    expect(mocks.checkoutRetrieve).toHaveBeenCalledTimes(2);
+    expect(mocks.expireTopUpCheckoutAttempt).not.toHaveBeenCalled();
+    expect(mocks.checkoutCreate).not.toHaveBeenCalled();
+  });
+
+  it("resolves an unbound pre-promotion top-up replay before rotating", async () => {
+    mocks.getSubscriptionByUserId.mockResolvedValue({
+      status: "active",
+      planId: "pro",
+      billingOfferId: "offer_pro",
+      currentPeriodEnd: new Date(Date.now() + 60_000),
+    });
+    const legacyParams = JSON.parse(
+      mocks.topUpAttempt!.paramsJson as string,
+    );
+    delete legacyParams.allow_promotion_codes;
+    const legacyAttempt = {
+      ...mocks.topUpAttempt!,
+      stripeCheckoutSessionId: null,
+      paramsJson: JSON.stringify(legacyParams),
+    };
+    const currentParams = structuredClone(
+      JSON.parse(mocks.topUpAttempt!.paramsJson as string),
+    );
+    currentParams.metadata.topUpAttemptId = "topup-attempt-2";
+    currentParams.payment_intent_data.metadata.topUpAttemptId =
+      "topup-attempt-2";
+    const currentAttempt = {
+      ...mocks.topUpAttempt!,
+      id: "topup-attempt-2",
+      checkoutKey: "ai-top-up-checkout:topup-attempt-2",
+      stripeCheckoutSessionId: null,
+      paramsJson: JSON.stringify(currentParams),
+    };
+    mocks.getOrCreateTopUpCheckoutAttempt
+      .mockResolvedValueOnce(legacyAttempt)
+      .mockResolvedValueOnce(currentAttempt);
+    mocks.claimTopUpCheckoutCreation
+      .mockResolvedValueOnce({ status: "claimed", attempt: legacyAttempt })
+      .mockResolvedValueOnce({ status: "claimed", attempt: currentAttempt });
+    mocks.checkoutCreate
+      .mockResolvedValueOnce(
+        topUpCheckoutSession({ allow_promotion_codes: false }),
+      )
+      .mockResolvedValueOnce(
+        topUpCheckoutSession({
+          id: "cs_topup_current",
+          metadata: currentParams.metadata,
+        }),
+      );
+    mocks.checkoutExpire.mockResolvedValue(
+      topUpCheckoutSession({
+        status: "expired",
+        url: null,
+        allow_promotion_codes: false,
+      }),
+    );
+
+    await expect(createCreditCheckout()).rejects.toThrow("NEXT_REDIRECT");
+
+    expect(mocks.checkoutCreate).toHaveBeenNthCalledWith(
+      1,
+      legacyParams,
+      expect.objectContaining({
+        idempotencyKey: "ai-top-up-checkout:topup-attempt-1",
+      }),
+    );
+    expect(mocks.expireTopUpCheckoutAttempt).toHaveBeenCalledWith({
+      attemptId: "topup-attempt-1",
+      ownerUserId: "user-1",
+      stripeCheckoutSessionId: null,
+      leaseToken: expect.any(String),
+    });
+    expect(mocks.checkoutCreate).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ allow_promotion_codes: true }),
+      expect.objectContaining({
+        idempotencyKey: "ai-top-up-checkout:topup-attempt-2",
+      }),
+    );
   });
 
   it("terminalizes a zero-cost top-up before creating a replacement", async () => {
@@ -671,6 +860,111 @@ describe("AI checkout actions", () => {
     ]);
   });
 
+  it("expires a bound pre-promotion Pro Checkout before creating a replacement", async () => {
+    mocks.getSubscriptionByUserId.mockResolvedValue(null);
+    const legacySession = {
+      id: "cs_pre_promotion",
+      customer: "cus_1",
+      mode: "subscription",
+      status: "open",
+      url: "https://checkout.stripe.com/pre-promotion",
+      metadata: {
+        beutlApplication: "beutl-web",
+        beutlUserId: "user-1",
+        planId: "pro",
+        billingOfferId: "offer_pro",
+      },
+      line_items: {
+        data: [{ quantity: 1, price: { id: "price_pro" } }],
+      },
+    };
+    mocks.getOrCreateProCheckoutAttempt
+      .mockResolvedValueOnce({
+        userId: "user-1",
+        checkoutKey: "attempt-pre-promotion",
+        billingOfferId: "offer_pro",
+        stripeCheckoutSessionId: legacySession.id,
+        paramsJson: JSON.stringify({ mode: "subscription" }),
+        expiresAt: new Date(Date.now() + 86_400_000),
+      })
+      .mockResolvedValueOnce({
+        userId: "user-1",
+        checkoutKey: "attempt-current",
+        billingOfferId: "offer_pro",
+        stripeCheckoutSessionId: null,
+        paramsJson: null,
+        expiresAt: new Date(Date.now() + 86_400_000),
+      });
+    mocks.checkoutRetrieve.mockResolvedValue(legacySession);
+    mocks.checkoutExpire.mockResolvedValue({
+      ...legacySession,
+      status: "expired",
+      url: null,
+    });
+
+    await expect(createProCheckout()).rejects.toThrow("NEXT_REDIRECT");
+
+    expect(mocks.checkoutExpire).toHaveBeenCalledWith(legacySession.id);
+    expect(mocks.deleteBoundProCheckoutAttempt).toHaveBeenCalledWith({
+      userId: "user-1",
+      checkoutKey: "attempt-pre-promotion",
+      stripeCheckoutSessionId: legacySession.id,
+    });
+    expect(mocks.checkoutCreate).toHaveBeenCalledTimes(1);
+    expect(mocks.checkoutCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ allow_promotion_codes: true }),
+      expect.objectContaining({
+        idempotencyKey: "ai-pro-checkout:attempt-current",
+      }),
+    );
+  });
+
+  it("keeps a pre-promotion Pro Checkout that completes during expiry", async () => {
+    mocks.getSubscriptionByUserId.mockResolvedValue(null);
+    const legacySession = {
+      id: "cs_pre_promotion_race",
+      customer: "cus_1",
+      mode: "subscription",
+      status: "open",
+      url: "https://checkout.stripe.com/pre-promotion-race",
+      metadata: {
+        beutlApplication: "beutl-web",
+        beutlUserId: "user-1",
+        planId: "pro",
+        billingOfferId: "offer_pro",
+      },
+      line_items: {
+        data: [{ quantity: 1, price: { id: "price_pro" } }],
+      },
+    };
+    mocks.getOrCreateProCheckoutAttempt.mockResolvedValue({
+      userId: "user-1",
+      checkoutKey: "attempt-pre-promotion-race",
+      billingOfferId: "offer_pro",
+      stripeCheckoutSessionId: legacySession.id,
+      paramsJson: JSON.stringify({ mode: "subscription" }),
+      expiresAt: new Date(Date.now() + 86_400_000),
+    });
+    mocks.checkoutRetrieve
+      .mockResolvedValueOnce(legacySession)
+      .mockResolvedValueOnce({
+        ...legacySession,
+        status: "complete",
+        url: null,
+      });
+    mocks.checkoutExpire.mockRejectedValue(
+      new Error("Checkout Session already completed"),
+    );
+
+    await expect(createProCheckout()).rejects.toThrow("NEXT_REDIRECT");
+
+    expect(mocks.checkoutRetrieve).toHaveBeenCalledTimes(2);
+    expect(mocks.deleteBoundProCheckoutAttempt).not.toHaveBeenCalled();
+    expect(mocks.checkoutCreate).not.toHaveBeenCalled();
+    expect(mocks.scheduleBillingRefundAttempt).not.toHaveBeenCalled();
+    expect(mocks.subscriptionCancel).not.toHaveBeenCalled();
+  });
+
   it("reuses an open Checkout bound to an explicitly authorized historical offer", async () => {
     process.env.STRIPE_PRO_PRICE_ID = "price_pro_v2";
     process.env.STRIPE_PRO_HISTORICAL_OFFERS = "price_old:prod_old";
@@ -688,6 +982,7 @@ describe("AI checkout actions", () => {
       checkoutKey: "attempt-old",
       billingOfferId: "offer_old",
       stripeCheckoutSessionId: "cs_old",
+      paramsJson: JSON.stringify({ allow_promotion_codes: true }),
       expiresAt: new Date(Date.now() + 86_400_000),
     });
     mocks.checkoutRetrieve.mockResolvedValue({
@@ -723,6 +1018,7 @@ describe("AI checkout actions", () => {
       checkoutKey: "attempt-expired-cache",
       billingOfferId: "offer_pro",
       stripeCheckoutSessionId: "cs_still_open",
+      paramsJson: JSON.stringify({ allow_promotion_codes: true }),
       expiresAt: new Date(Date.now() - 1),
     });
     mocks.checkoutRetrieve.mockResolvedValue({

--- a/tests/contract/ai-checkout.test.ts
+++ b/tests/contract/ai-checkout.test.ts
@@ -496,7 +496,12 @@ describe("AI checkout actions", () => {
     );
   });
 
-  it("keeps a pre-promotion top-up Checkout that completes during expiry", async () => {
+  it.each([
+    { outcome: "returns completion", expireReturnsCompletion: true },
+    { outcome: "rejects after completion", expireReturnsCompletion: false },
+  ])("keeps a pre-promotion top-up Checkout when expiry $outcome", async ({
+    expireReturnsCompletion,
+  }) => {
     mocks.getSubscriptionByUserId.mockResolvedValue({
       status: "active",
       planId: "pro",
@@ -524,9 +529,16 @@ describe("AI checkout actions", () => {
         status: "complete",
         url: null,
       });
-    mocks.checkoutExpire.mockRejectedValue(
-      new Error("Checkout Session already completed"),
-    );
+    if (expireReturnsCompletion) {
+      mocks.checkoutExpire.mockResolvedValue({
+        id: "cs_topup_pre_promotion_race",
+        status: "complete",
+      });
+    } else {
+      mocks.checkoutExpire.mockRejectedValue(
+        new Error("Checkout Session already completed"),
+      );
+    }
 
     await expect(createCreditCheckout()).rejects.toThrow("NEXT_REDIRECT");
 


### PR DESCRIPTION
## Description

Expire and rotate open Pro and credit top-up Checkout Sessions that were created before promotion codes were enabled. If payment completes while expiration is attempted, preserve the completed payment and continue through the normal success reconciliation path.

Adds regression coverage for bound Sessions and response-loss recovery paths. Verified with `pnpm test` (1,799 passed, 20 skipped), `pnpm typecheck`, and `pnpm lint`.

## Breaking changes

None.

## Fixed issues

- Promotion code entry is missing when a pre-feature Checkout Session is reused.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved checkout recovery for older sessions created before promotion codes were supported.
  - Expired legacy open sessions are now safely replaced with current checkout sessions.
  - Completed checkouts remain valid during session-expiration races.
  - Improved recovery for Pro plan purchases and credit top-ups, including clearer handling of expired or otherwise unavailable sessions.
  - Promotion-code eligibility is now consistently preserved when creating replacement checkout sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
