### PR TITLE
fix: prevent AI screen provider and transaction failures

### DIFF
--- a/apps/web/src/app/[lang]/(dashboard)/dashboard/ai/page.tsx
+++ b/apps/web/src/app/[lang]/(dashboard)/dashboard/ai/page.tsx
@@ -1,4 +1,5 @@
 import { getTranslation } from "@beutl/i18n";
+import { loadAiVideoModelCapabilities } from "@beutl/api";
 import { authOrSignIn } from "@/lib/auth-guard";
 import { AiFeatureLinks } from "./feature-links";
 import { countActiveAiJobs, getAiScreenState } from "./queries";
@@ -11,7 +12,9 @@ export default async function Page(props: {
   const { lang } = await props.params;
   const session = await authOrSignIn();
   const { t } = await getTranslation(lang);
-  const { access, balance } = await getAiScreenState(session.user.id);
+  const { access, balance } = await getAiScreenState(session.user.id, {
+    videoCapabilities: loadAiVideoModelCapabilities(),
+  });
   const activeJobCount = access.canUseAi
     ? await countActiveAiJobs(session.user.id)
     : 0;

--- a/apps/web/src/app/[lang]/(dashboard)/dashboard/ai/queries.ts
+++ b/apps/web/src/app/[lang]/(dashboard)/dashboard/ai/queries.ts
@@ -1,18 +1,28 @@
 import "server-only";
 import { getEntitlements, loadAiModelCatalog } from "@beutl/api";
-import { listAiJobsByUserId } from "@beutl/db";
+import { getDb, listAiJobsByUserId } from "@beutl/db";
 import type { AiAccess, AiBalance } from "./shared";
 
 // Every AI screen needs the same two things from the server: whether the plan
 // allows the operation at all, and whether the balance still covers it. Both
 // come out of one entitlements read.
-export async function getAiScreenState(userId: string): Promise<{
-  access: AiAccess;
-  balance: AiBalance;
-}> {
+export async function getAiScreenState(
+  userId: string,
+  { videoCapabilities = new Map() }: {
+    videoCapabilities?:
+      | ReadonlyMap<string, { durations: readonly number[] }>
+      | PromiseLike<ReadonlyMap<string, { durations: readonly number[] }>>;
+  } = {},
+): Promise<{ access: AiAccess; balance: AiBalance }> {
+  const prisma = await getDb();
+  const catalogPromise = loadAiModelCatalog({ prisma });
   const [entitlements, catalog] = await Promise.all([
-    getEntitlements(userId),
-    loadAiModelCatalog(),
+    getEntitlements(userId, {
+      catalog: catalogPromise,
+      prisma,
+      videoCapabilities,
+    }),
+    catalogPromise,
   ]);
   return {
     access: {

--- a/apps/web/src/app/[lang]/(dashboard)/dashboard/ai/video/page.tsx
+++ b/apps/web/src/app/[lang]/(dashboard)/dashboard/ai/video/page.tsx
@@ -13,9 +13,15 @@ export default async function Page(props: {
   const { lang } = await props.params;
   const session = await authOrSignIn();
   const { t } = await getTranslation(lang);
+  // Both consumers need the same provider snapshot. Keep this promise scoped
+  // to the render: module-global in-flight I/O cannot safely cross Cloudflare
+  // Worker request contexts.
+  const capabilitiesPromise = loadAiVideoModelCapabilities();
   const [{ access, balance }, capabilities] = await Promise.all([
-    getAiScreenState(session.user.id),
-    loadAiVideoModelCapabilities(),
+    getAiScreenState(session.user.id, {
+      videoCapabilities: capabilitiesPromise,
+    }),
+    capabilitiesPromise,
   ]);
 
   // Which parameters a video may carry differs per model, so the screen offers

--- a/packages/api/src/ai/entitlements.ts
+++ b/packages/api/src/ai/entitlements.ts
@@ -297,30 +297,38 @@ export async function getEntitlementSummary(
 export async function getEntitlements(
   userId: string,
   options: {
-    videoCapabilities?: ReadonlyMap<
-      string,
-      { durations: readonly number[] }
-    >;
+    // A Server Component also needs this catalog's display metadata. Accept its
+    // in-flight read so entitlement availability and the form share one query
+    // without serializing the rest of the snapshot behind it.
+    catalog?: AiModelCatalog | PromiseLike<AiModelCatalog>;
+    prisma?: PrismaTransaction;
+    videoCapabilities?:
+      | ReadonlyMap<string, { durations: readonly number[] }>
+      | PromiseLike<ReadonlyMap<string, { durations: readonly number[] }>>;
   } = {},
 ): Promise<EntitlementsResponse> {
-  const videoCapabilities = options.videoCapabilities ??
-    await loadAiVideoModelCapabilities();
-  return await startRetryableTransaction(async (prisma) => {
-    const [{ summary, balance }, catalog] = await Promise.all([
-      loadEntitlementSnapshot(userId, prisma),
-      loadAiModelCatalog({ prisma }),
-    ]);
+  // This is an advisory presentation snapshot. Every paid operation repeats
+  // the entitlement and balance checks in the transaction that reserves its
+  // usage, so an interactive transaction here adds a connection-start deadline
+  // without making the later authorization decision atomic. This is the same
+  // boundary as getEntitlementSummary(), with the catalog joined for the model
+  // availability shown by AI screens and clients.
+  const prisma = options.prisma ?? await getDb();
+  const [{ summary, balance }, catalog, videoCapabilities] = await Promise.all([
+    loadEntitlementSnapshot(userId, prisma),
+    options.catalog ?? loadAiModelCatalog({ prisma }),
+    options.videoCapabilities ?? loadAiVideoModelCapabilities(),
+  ]);
 
-    return {
-      ...summary,
-      ...toAiOperationAvailability(
-        balance,
-        summary.canUseAi,
-        catalog,
-        videoCapabilities,
-      ),
-    };
-  });
+  return {
+    ...summary,
+    ...toAiOperationAvailability(
+      balance,
+      summary.canUseAi,
+      catalog,
+      videoCapabilities,
+    ),
+  };
 }
 
 export async function canStartAiOperation(

--- a/packages/api/src/ai/image-model-capabilities.ts
+++ b/packages/api/src/ai/image-model-capabilities.ts
@@ -274,7 +274,7 @@ async function loadOne(
   } catch (error) {
     // An outage in the capability lookup must not take image generation
     // offline: callers read a missing entry as "no restriction known".
-    console.error(
+    console.warn(
       "Failed to read OpenRouter image model capabilities",
       modelId,
       toAiProviderError(error, "OpenRouter image model endpoints failed")

--- a/packages/api/src/ai/video-model-capabilities.ts
+++ b/packages/api/src/ai/video-model-capabilities.ts
@@ -118,7 +118,13 @@ export async function loadAiVideoModelCapabilities(
       models.map((model) => [model.id, toCapabilities(model)]),
     );
   } catch (error) {
-    console.error("Failed to read OpenRouter video model capabilities", error);
+    // This lookup deliberately fails open, so report a degraded optional read
+    // as a warning rather than turning a successfully rendered page into an
+    // error event. Keep only the normalized message instead of serializing an
+    // SDK error and its worker stack as the log message.
+    console.warn("Failed to read OpenRouter video model capabilities", {
+      message: error instanceof Error ? error.message : String(error),
+    });
     capabilities = new Map();
     ttl = FAILURE_CACHE_TTL_MS;
   }

--- a/tests/contract/ai-entitlements.test.ts
+++ b/tests/contract/ai-entitlements.test.ts
@@ -5,7 +5,11 @@ import {
   upsertAiOperationModel,
   upsertSubscription,
 } from "@beutl/db";
-import { getEntitlements, getEntitlementSummary } from "@beutl/api";
+import {
+  getEntitlements,
+  getEntitlementSummary,
+  loadAiModelCatalog,
+} from "@beutl/api";
 import { createInMemoryPrisma } from "../stubs/in-memory-prisma";
 
 const USER_ID = "entitlements-user";
@@ -93,6 +97,23 @@ describe("AI entitlements", () => {
     expect(transaction).not.toHaveBeenCalled();
   });
 
+  it("does not use an interactive transaction for full AI presentation", async () => {
+    await activatePro();
+    const transaction = vi
+      .spyOn(prisma, "$transaction")
+      .mockRejectedValue(
+        Object.assign(new Error("Unable to start a transaction in time"), {
+          code: "P2028",
+        }),
+      );
+
+    const entitlements = await readEntitlements();
+
+    expect(entitlements.canUseAi).toBe(true);
+    expect(entitlements.modelAvailability["video.generate"]).toBeDefined();
+    expect(transaction).not.toHaveBeenCalled();
+  });
+
   it("uses an explicitly supplied client without resolving the provider", async () => {
     await activatePro();
     setDbProvider(async () => {
@@ -104,6 +125,37 @@ describe("AI entitlements", () => {
     });
 
     expect(summary.canUseAi).toBe(true);
+  });
+
+  it("uses an explicitly supplied client for full AI presentation", async () => {
+    await activatePro();
+    setDbProvider(async () => {
+      throw new Error("the configured provider must not be used");
+    });
+
+    const entitlements = await getEntitlements(USER_ID, {
+      prisma: prisma as never,
+      videoCapabilities,
+    });
+
+    expect(entitlements.canUseAi).toBe(true);
+  });
+
+  it("reuses a Server Component's in-flight model catalog", async () => {
+    await activatePro();
+    const catalog = await loadAiModelCatalog({ prisma: prisma as never });
+    const catalogRead = vi
+      .spyOn(prisma.aiOperationModel, "findMany")
+      .mockRejectedValue(new Error("model catalog must not be loaded twice"));
+
+    const entitlements = await getEntitlements(USER_ID, {
+      catalog: Promise.resolve(catalog),
+      prisma: prisma as never,
+      videoCapabilities: Promise.resolve(videoCapabilities),
+    });
+
+    expect(entitlements.canUseAi).toBe(true);
+    expect(catalogRead).not.toHaveBeenCalled();
   });
 
   it("keeps summary fields identical to the full entitlement response", async () => {

--- a/tests/contract/ai-image-model-capabilities.test.ts
+++ b/tests/contract/ai-image-model-capabilities.test.ts
@@ -213,7 +213,8 @@ describe("what an image model accepts", () => {
 
   it("imposes nothing when the provider cannot be reached", async () => {
     listModelEndpoints.mockRejectedValue(new Error("provider is down"));
-    vi.spyOn(console, "error").mockImplementation(() => {});
+    const errorLog = vi.spyOn(console, "error").mockImplementation(() => {});
+    const warningLog = vi.spyOn(console, "warn").mockImplementation(() => {});
 
     // An outage in the lookup must not take image generation offline.
     await expect(loadAiImageModelCapabilities(["a/model"])).resolves.toEqual(
@@ -222,6 +223,14 @@ describe("what an image model accepts", () => {
     expect(
       unsupportedImageRequestReason(undefined, { aspectRatio: "16:9" }),
     ).toBeNull();
+    expect(errorLog).not.toHaveBeenCalled();
+    expect(warningLog).toHaveBeenCalledWith(
+      "Failed to read OpenRouter image model capabilities",
+      "a/model",
+      "OpenRouter image model endpoints failed: provider is down",
+    );
+    errorLog.mockRestore();
+    warningLog.mockRestore();
   });
 });
 

--- a/tests/contract/ai-video-model-capabilities.test.ts
+++ b/tests/contract/ai-video-model-capabilities.test.ts
@@ -101,7 +101,8 @@ describe("what a video model accepts", () => {
 
   it("imposes nothing when the provider cannot be reached", async () => {
     listVideoModels.mockRejectedValue(new Error("provider is down"));
-    vi.spyOn(console, "error").mockImplementation(() => {});
+    const errorLog = vi.spyOn(console, "error").mockImplementation(() => {});
+    const warningLog = vi.spyOn(console, "warn").mockImplementation(() => {});
 
     // An outage in the capability list must not take video generation offline:
     // callers read a missing entry as "no restriction known".
@@ -110,6 +111,13 @@ describe("what a video model accepts", () => {
       resolution: "1080p",
       durationSeconds: 4,
     })).toBeNull();
+    expect(errorLog).not.toHaveBeenCalled();
+    expect(warningLog).toHaveBeenCalledWith(
+      "Failed to read OpenRouter video model capabilities",
+      { message: "provider is down" },
+    );
+    errorLog.mockRestore();
+    warningLog.mockRestore();
   });
 });
 

--- a/tests/contract/dashboard-ai-queries.test.ts
+++ b/tests/contract/dashboard-ai-queries.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const getEntitlements = vi.hoisted(() => vi.fn());
+const loadAiModelCatalog = vi.hoisted(() => vi.fn());
+const getDb = vi.hoisted(() => vi.fn());
+const listAiJobsByUserId = vi.hoisted(() => vi.fn());
+
+vi.mock("@beutl/api", () => ({
+  getEntitlements,
+  loadAiModelCatalog,
+}));
+vi.mock("@beutl/db", () => ({ getDb, listAiJobsByUserId }));
+
+import { getAiScreenState } from "../../apps/web/src/app/[lang]/(dashboard)/dashboard/ai/queries";
+
+describe("AI screen state", () => {
+  const prisma = {};
+
+  beforeEach(() => {
+    getEntitlements.mockReset();
+    loadAiModelCatalog.mockReset();
+    getDb.mockReset();
+    getDb.mockResolvedValue(prisma);
+    getEntitlements.mockResolvedValue({
+      canUseAi: true,
+      availability: {},
+      modelAvailability: {},
+      balance: {
+        monthlyUsage: {
+          usedPercent: 0,
+          remainingPercent: 100,
+          isExhausted: false,
+        },
+        additionalCredits: 0,
+        hasAdditionalCreditDebt: false,
+      },
+      currentPeriodEnd: null,
+      cancelAtPeriodEnd: false,
+    });
+    loadAiModelCatalog.mockResolvedValue({
+      operations: () => [],
+      list: () => [],
+    });
+  });
+
+  it("keeps non-video screens independent of video capability discovery", async () => {
+    await getAiScreenState("user-1");
+
+    expect(getEntitlements).toHaveBeenCalledWith("user-1", {
+      catalog: expect.any(Promise),
+      prisma,
+      videoCapabilities: expect.any(Map),
+    });
+    const options = getEntitlements.mock.calls[0]?.[1];
+    expect(options.videoCapabilities).toEqual(new Map());
+    expect(options.catalog).toBe(loadAiModelCatalog.mock.results[0]?.value);
+    expect(loadAiModelCatalog).toHaveBeenCalledWith({ prisma });
+    expect(getDb).toHaveBeenCalledOnce();
+    expect(loadAiModelCatalog).toHaveBeenCalledOnce();
+  });
+
+  it("shares the caller's request-scoped video capability read", async () => {
+    const videoCapabilities = Promise.resolve(new Map([
+      ["video/model", { durations: [4, 6] }],
+    ]));
+
+    await getAiScreenState("user-1", { videoCapabilities });
+
+    expect(getEntitlements).toHaveBeenCalledWith("user-1", {
+      catalog: expect.any(Promise),
+      prisma,
+      videoCapabilities,
+    });
+    expect(getDb).toHaveBeenCalledOnce();
+    expect(loadAiModelCatalog).toHaveBeenCalledOnce();
+  });
+});

--- a/tests/contract/web-request-scope.test.ts
+++ b/tests/contract/web-request-scope.test.ts
@@ -84,4 +84,22 @@ describe("server-render database resources", () => {
       );
     }
   });
+
+  it("shares video capability I/O only inside one Server Component render", () => {
+    const videoPage = source(
+      "apps/web/src/app/[lang]/(dashboard)/dashboard/ai/video/page.tsx",
+    );
+    const capabilities = source(
+      "packages/api/src/ai/video-model-capabilities.ts",
+    );
+
+    expect(videoPage.match(/loadAiVideoModelCapabilities\(\)/g)).toHaveLength(1);
+    expect(videoPage).toContain(
+      "const capabilitiesPromise = loadAiVideoModelCapabilities();",
+    );
+    expect(videoPage).toContain("videoCapabilities: capabilitiesPromise");
+    expect(capabilities).not.toMatch(
+      /inflight.*Promise<Map<string, AiVideoModelCapabilities>>/,
+    );
+  });
 });


### PR DESCRIPTION
## Description

- Avoid interactive transactions for presentation-only AI entitlement reads.
- Reuse the request-scoped Prisma client and model catalog.
- Fetch video capabilities only on screens that need them and share the read within a render.
- Log fail-open OpenRouter capability failures as warnings with a normalized cause.
- Add regression coverage for the affected AI screen paths.

## Breaking changes

None.

## Fixed issues

- Prevent transient OpenRouter video capability failures from producing error-level page logs.
- Prevent Prisma transaction startup failures while loading AI entitlement screens.
- Remove duplicate video capability requests from the video page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * AI dashboard and video views now use a consistent snapshot of available video model capabilities.
  * AI entitlement checks reuse shared model and database data for more efficient loading.
  * Capability lookup failures continue gracefully with clearer warning logs.

* **Tests**
  * Added coverage for entitlement loading, dashboard state, request-scoped capability reuse, and provider outage handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->