### PR TITLE
fix: keep package deletion inside the transaction timeout

### DIFF
--- a/packages/db/src/file.ts
+++ b/packages/db/src/file.ts
@@ -278,6 +278,67 @@ export async function deleteUnreferencedFileWithStorageCleanup({
   return prisma ? run(prisma) : startRetryableTransaction(run);
 }
 
+/** Batch form of deleteUnreferencedFileWithStorageCleanup. The query count does
+ * not grow with the number of files, so a package that owns many release
+ * artifacts still finishes inside the interactive transaction timeout. Files
+ * still referenced elsewhere are retained, exactly as in the single form. */
+export async function deleteUnreferencedFilesWithStorageCleanup({
+  fileIds,
+  userId,
+  prisma,
+}: {
+  fileIds: string[];
+  userId: string;
+  prisma?: PrismaTransaction;
+}) {
+  const uniqueIds = [...new Set(fileIds)];
+  const run = async (tx: PrismaTransaction) => {
+    if (uniqueIds.length === 0) {
+      return { deleted: [] as string[], retained: [] as string[] };
+    }
+    const files = await tx.file.findMany({
+      where: { id: { in: uniqueIds }, userId, aiJobResult: null },
+      select: { id: true, objectKey: true, ...fileReferenceSelect },
+    });
+    if (files.length !== uniqueIds.length) {
+      const found = new Set(files.map((file) => file.id));
+      const missing = uniqueIds.find((id) => !found.has(id));
+      throw new Error(`Storage file ${missing} was not found`);
+    }
+    const retained = files.filter((file) => hasLiveFileReference(file));
+    const deletable = files.filter((file) => !hasLiveFileReference(file));
+    if (deletable.length === 0) {
+      return { deleted: [] as string[], retained: retained.map((file) => file.id) };
+    }
+
+    const objectKeys = deletable.map((file) => file.objectKey);
+    await tx.aiStorageCleanup.createMany({
+      data: objectKeys.map((objectKey) => ({
+        objectKey,
+        aiJobId: null,
+        leaseToken: null,
+        state: "writing",
+        notBefore: new Date(),
+      })),
+    });
+    const deleted = await tx.file.deleteMany({
+      where: { id: { in: deletable.map((file) => file.id) }, userId, aiJobResult: null },
+    });
+    if (deleted.count !== deletable.length) {
+      throw new Error("Storage files changed before deletion");
+    }
+    await tx.aiStorageCleanup.updateMany({
+      where: { objectKey: { in: objectKeys }, state: "writing", leaseToken: null },
+      data: { state: "cleanup", notBefore: new Date() },
+    });
+    return {
+      deleted: deletable.map((file) => file.id),
+      retained: retained.map((file) => file.id),
+    };
+  };
+  return prisma ? run(prisma) : startRetryableTransaction(run);
+}
+
 /** Atomically delete an exact user-selected set, or retain the whole set when
  * any row is dedicated, missing, or still referenced. */
 export async function deleteUserFilesWithStorageCleanup({

--- a/packages/db/src/file.ts
+++ b/packages/db/src/file.ts
@@ -300,17 +300,21 @@ export async function deleteUnreferencedFilesWithStorageCleanup({
       where: { id: { in: uniqueIds }, userId, aiJobResult: null },
       select: { id: true, objectKey: true, ...fileReferenceSelect },
     });
-    if (files.length !== uniqueIds.length) {
-      const found = new Set(files.map((file) => file.id));
-      const missing = uniqueIds.find((id) => !found.has(id));
-      throw new Error(`Storage file ${missing} was not found`);
+    // Classify in input order so callers never observe the database's row order.
+    const byId = new Map(files.map((file) => [file.id, file]));
+    const retained: string[] = [];
+    const deletable: { id: string; objectKey: string }[] = [];
+    for (const id of uniqueIds) {
+      const file = byId.get(id);
+      if (!file) throw new Error(`Storage file ${id} was not found`);
+      if (hasLiveFileReference(file)) retained.push(id);
+      else deletable.push({ id, objectKey: file.objectKey });
     }
-    const retained = files.filter((file) => hasLiveFileReference(file));
-    const deletable = files.filter((file) => !hasLiveFileReference(file));
     if (deletable.length === 0) {
-      return { deleted: [] as string[], retained: retained.map((file) => file.id) };
+      return { deleted: [] as string[], retained };
     }
 
+    const now = new Date();
     const objectKeys = deletable.map((file) => file.objectKey);
     await tx.aiStorageCleanup.createMany({
       data: objectKeys.map((objectKey) => ({
@@ -318,7 +322,7 @@ export async function deleteUnreferencedFilesWithStorageCleanup({
         aiJobId: null,
         leaseToken: null,
         state: "writing",
-        notBefore: new Date(),
+        notBefore: now,
       })),
     });
     const deleted = await tx.file.deleteMany({
@@ -329,12 +333,9 @@ export async function deleteUnreferencedFilesWithStorageCleanup({
     }
     await tx.aiStorageCleanup.updateMany({
       where: { objectKey: { in: objectKeys }, state: "writing", leaseToken: null },
-      data: { state: "cleanup", notBefore: new Date() },
+      data: { state: "cleanup", notBefore: now },
     });
-    return {
-      deleted: deletable.map((file) => file.id),
-      retained: retained.map((file) => file.id),
-    };
+    return { deleted: deletable.map((file) => file.id), retained };
   };
   return prisma ? run(prisma) : startRetryableTransaction(run);
 }

--- a/packages/db/src/package.ts
+++ b/packages/db/src/package.ts
@@ -3,7 +3,10 @@ import type { PaymentInterval } from "@prisma/client";
 import type { PrismaTransaction } from "./transaction";
 import { startRetryableTransaction } from "./transaction";
 import { preparePackageDeletionOutboxes } from "./package-checkout-attempt";
-import { deleteUnreferencedFileWithStorageCleanup } from "./file";
+import {
+  deleteUnreferencedFilesWithStorageCleanup,
+  deleteUnreferencedFileWithStorageCleanup,
+} from "./file";
 
 export async function findPackageIdById({
   id,
@@ -903,6 +906,10 @@ export async function deleteDevPackageScreenshotAndFile({
   return prisma ? run(prisma) : startRetryableTransaction(run);
 }
 
+// Package deletion cascades Release / PackageScreenshot rows and retires their
+// files in one transaction. Prisma's 5 s default is too tight behind Hyperdrive.
+const DEV_PACKAGE_DELETION_TRANSACTION = { maxWait: 5_000, timeout: 20_000 } as const;
+
 export async function deleteDevPackage({
   packageId,
   prisma,
@@ -934,16 +941,18 @@ export async function deleteDevPackage({
     }
     await preparePackageDeletionOutboxes({ packageId, prisma: tx });
     const deleted = await tx.package.delete({ where: { id: packageId } });
-    for (const fileId of ownedFileIds) {
-      await deleteUnreferencedFileWithStorageCleanup({
-        fileId,
-        userId: pkg.userId,
-        prisma: tx,
-      });
-    }
+    // One round trip per release or screenshot does not fit the interactive
+    // transaction timeout once a package has accumulated a few dozen files.
+    await deleteUnreferencedFilesWithStorageCleanup({
+      fileIds: [...ownedFileIds],
+      userId: pkg.userId,
+      prisma: tx,
+    });
     return deleted;
   };
-  return prisma ? await run(prisma) : await startRetryableTransaction(run);
+  return prisma
+    ? await run(prisma)
+    : await startRetryableTransaction(run, DEV_PACKAGE_DELETION_TRANSACTION);
 }
 
 export async function upsertPackagePricings({

--- a/tests/contract/storage-legacy-cleanup.test.ts
+++ b/tests/contract/storage-legacy-cleanup.test.ts
@@ -25,7 +25,9 @@ import {
   findStorageCleanupForMutation,
   freezeStorageUploadForAccountDeletion,
   deleteReleaseWithStorageCleanup,
+  deleteDevPackage,
   deleteDevPackageScreenshotAndFile,
+  deleteUnreferencedFilesWithStorageCleanup,
   deleteUnreferencedFileWithStorageCleanup,
   setDbProvider,
 } from "@beutl/db";
@@ -351,6 +353,149 @@ describe("legacy storage cleanup contracts", () => {
     expect(calls).toEqual([]);
   });
 
+  it("retires unreferenced package files in a fixed number of queries and keeps shared ones", async () => {
+    const calls: string[] = [];
+    let deletedIds: string[] = [];
+    let outboxKeys: string[] = [];
+    let promotedKeys: string[] = [];
+    const unreferenced = { Package: [], PackageScreenshot: [], Profile: [], Release: [], aiJobResult: null };
+    const tx = {
+      file: {
+        findMany: async () => {
+          calls.push("file-find");
+          return [
+            { id: "a", objectKey: "obj/a", ...unreferenced },
+            { id: "shared", objectKey: "obj/shared", ...unreferenced, Package: [{ id: "other-package" }] },
+            { id: "b", objectKey: "obj/b", ...unreferenced },
+          ];
+        },
+        deleteMany: async ({ where }: { where: { id: { in: string[] } } }) => {
+          calls.push("file-delete");
+          deletedIds = where.id.in;
+          return { count: where.id.in.length };
+        },
+      },
+      aiStorageCleanup: {
+        createMany: async ({ data }: { data: Array<{ objectKey: string; state: string }> }) => {
+          calls.push("outbox-create");
+          outboxKeys = data.map((row) => row.objectKey);
+          expect(data.every((row) => row.state === "writing")).toBe(true);
+          return { count: data.length };
+        },
+        updateMany: async ({ where }: { where: { objectKey: { in: string[] } } }) => {
+          calls.push("outbox-promote");
+          promotedKeys = where.objectKey.in;
+          return { count: where.objectKey.in.length };
+        },
+      },
+    } as never;
+
+    const result = await deleteUnreferencedFilesWithStorageCleanup({
+      fileIds: ["a", "shared", "b", "a"],
+      userId: "u",
+      prisma: tx,
+    });
+    expect(calls).toEqual(["file-find", "outbox-create", "file-delete", "outbox-promote"]);
+    expect(deletedIds).toEqual(["a", "b"]);
+    expect(outboxKeys).toEqual(["obj/a", "obj/b"]);
+    expect(promotedKeys).toEqual(["obj/a", "obj/b"]);
+    expect(result).toEqual({ deleted: ["a", "b"], retained: ["shared"] });
+  });
+
+  it("refuses a batch with a missing file and skips an empty batch", async () => {
+    const calls: string[] = [];
+    const tx = {
+      file: {
+        findMany: async () => {
+          calls.push("file-find");
+          return [{ id: "a", objectKey: "obj/a", Package: [], PackageScreenshot: [], Profile: [], Release: [], aiJobResult: null }];
+        },
+        deleteMany: async () => { calls.push("file-delete"); return { count: 1 }; },
+      },
+      aiStorageCleanup: {
+        createMany: async () => { calls.push("outbox-create"); return { count: 1 }; },
+        updateMany: async () => { calls.push("outbox-promote"); return { count: 1 }; },
+      },
+    } as never;
+
+    await expect(deleteUnreferencedFilesWithStorageCleanup({
+      fileIds: ["a", "gone"],
+      userId: "u",
+      prisma: tx,
+    })).rejects.toThrow("gone was not found");
+    expect(calls).toEqual(["file-find"]);
+
+    calls.length = 0;
+    await expect(deleteUnreferencedFilesWithStorageCleanup({
+      fileIds: [],
+      userId: "u",
+      prisma: tx,
+    })).resolves.toEqual({ deleted: [], retained: [] });
+    expect(calls).toEqual([]);
+  });
+
+  it("deletes a package with many releases without a query per file", async () => {
+    // Every query is a Hyperdrive round trip inside one interactive transaction,
+    // so the count must not scale with the number of releases or screenshots.
+    const queriesFor = async (releaseCount: number) => {
+      let queries = 0;
+      const releaseFiles = Array.from({ length: releaseCount }, (_, index) => ({
+        id: `release-${index}`,
+        userId: "u",
+      }));
+      const unreferenced = { Package: [], PackageScreenshot: [], Profile: [], Release: [], aiJobResult: null };
+      const handlers: Record<string, Record<string, (args: never) => Promise<unknown>>> = {
+        package: {
+          findUniqueOrThrow: async () => ({
+            userId: "u",
+            iconFile: { id: "icon", userId: "u" },
+            PackageScreenshot: [{ file: { id: "shot", userId: "u" } }],
+            Release: releaseFiles.map((file) => ({ file })),
+          }),
+          delete: async () => ({ id: "pkg" }),
+        },
+        packageCheckoutAttempt: {
+          findMany: async () => [],
+          updateMany: async () => ({ count: 0 }),
+        },
+        file: {
+          findMany: async () => [
+            { id: "icon", objectKey: "obj/icon", ...unreferenced },
+            { id: "shot", objectKey: "obj/shot", ...unreferenced },
+            ...releaseFiles.map((file) => ({ id: file.id, objectKey: `obj/${file.id}`, ...unreferenced })),
+          ],
+          deleteMany: async ({ where }: { where: { id: { in: string[] } } }) => ({ count: where.id.in.length }),
+        },
+        aiStorageCleanup: {
+          createMany: async ({ data }: { data: unknown[] }) => ({ count: data.length }),
+          updateMany: async ({ where }: { where: { objectKey: { in: string[] } } }) => ({ count: where.objectKey.in.length }),
+        },
+      };
+      const tx = new Proxy({}, {
+        get: (_target, model) => {
+          if (typeof model !== "string") return undefined;
+          return new Proxy({}, {
+            get: (_inner, method) => {
+              if (typeof method !== "string") return undefined;
+              return async (args: never) => {
+                queries++;
+                const handler = handlers[model]?.[method];
+                if (!handler) throw new Error(`unexpected query ${model}.${method}`);
+                return handler(args);
+              };
+            },
+          });
+        },
+      });
+      await deleteDevPackage({ packageId: "pkg", prisma: tx as never });
+      return queries;
+    };
+
+    const single = await queriesFor(1);
+    expect(await queriesFor(40)).toBe(single);
+    expect(single).toBeLessThanOrEqual(10);
+  });
+
   it("generic storage deletion refuses a legacy visible package artifact", async () => {
     const calls: string[] = [];
     let reads = 0;
@@ -575,7 +720,7 @@ describe("legacy storage cleanup contracts", () => {
       packageDb.indexOf("export async function upsertPackagePricings"),
     );
     expect(packageDelete.indexOf("tx.package.delete")).toBeLessThan(
-      packageDelete.indexOf("deleteUnreferencedFileWithStorageCleanup"),
+      packageDelete.indexOf("deleteUnreferencedFilesWithStorageCleanup"),
     );
 
     const packageAction = await readFile(

--- a/tests/contract/storage-legacy-cleanup.test.ts
+++ b/tests/contract/storage-legacy-cleanup.test.ts
@@ -357,16 +357,19 @@ describe("legacy storage cleanup contracts", () => {
     const calls: string[] = [];
     let deletedIds: string[] = [];
     let outboxKeys: string[] = [];
+    let outboxNotBefore: Date[] = [];
     let promotedKeys: string[] = [];
+    let promotedNotBefore: Date | undefined;
     const unreferenced = { Package: [], PackageScreenshot: [], Profile: [], Release: [], aiJobResult: null };
     const tx = {
       file: {
+        // Rows come back in an order unrelated to the request.
         findMany: async () => {
           calls.push("file-find");
           return [
-            { id: "a", objectKey: "obj/a", ...unreferenced },
-            { id: "shared", objectKey: "obj/shared", ...unreferenced, Package: [{ id: "other-package" }] },
             { id: "b", objectKey: "obj/b", ...unreferenced },
+            { id: "shared", objectKey: "obj/shared", ...unreferenced, Package: [{ id: "other-package" }] },
+            { id: "a", objectKey: "obj/a", ...unreferenced },
           ];
         },
         deleteMany: async ({ where }: { where: { id: { in: string[] } } }) => {
@@ -376,15 +379,17 @@ describe("legacy storage cleanup contracts", () => {
         },
       },
       aiStorageCleanup: {
-        createMany: async ({ data }: { data: Array<{ objectKey: string; state: string }> }) => {
+        createMany: async ({ data }: { data: Array<{ objectKey: string; state: string; notBefore: Date }> }) => {
           calls.push("outbox-create");
           outboxKeys = data.map((row) => row.objectKey);
+          outboxNotBefore = data.map((row) => row.notBefore);
           expect(data.every((row) => row.state === "writing")).toBe(true);
           return { count: data.length };
         },
-        updateMany: async ({ where }: { where: { objectKey: { in: string[] } } }) => {
+        updateMany: async ({ where, data }: { where: { objectKey: { in: string[] } }; data: { notBefore: Date } }) => {
           calls.push("outbox-promote");
           promotedKeys = where.objectKey.in;
+          promotedNotBefore = data.notBefore;
           return { count: where.objectKey.in.length };
         },
       },
@@ -400,6 +405,7 @@ describe("legacy storage cleanup contracts", () => {
     expect(outboxKeys).toEqual(["obj/a", "obj/b"]);
     expect(promotedKeys).toEqual(["obj/a", "obj/b"]);
     expect(result).toEqual({ deleted: ["a", "b"], retained: ["shared"] });
+    expect(new Set([...outboxNotBefore, promotedNotBefore]).size).toBe(1);
   });
 
   it("refuses a batch with a missing file and skips an empty batch", async () => {


### PR DESCRIPTION
## Description

- Deleting a package with many releases or screenshots failed with a 500. `deleteDevPackage` ran everything in one interactive transaction and retired each owned file through `deleteUnreferencedFileWithStorageCleanup`, which costs about seven round trips per file. Behind Hyperdrive that exceeds Prisma's 5 s default transaction timeout once a package owns a few dozen files; the failing request took 5.4 s of wall time.
- Add `deleteUnreferencedFilesWithStorageCleanup`, a batch form that looks up references, writes the cleanup outbox, deletes the File rows, and promotes the outbox in four queries regardless of file count. Files still referenced elsewhere are retained exactly as in the single-file form.
- `deleteDevPackage` now uses the batch form and runs with a 20 s transaction timeout, so the query count no longer grows with the number of releases.
- Contract tests cover the batch call order, refusal of a batch with a missing file, and that a package with 40 releases issues the same number of queries as one with a single release.

## Breaking changes

None.

## Fixed issues

- Deleting some extension packages from the developer dashboard returned a 500 on `POST /ja/dashboard/developer/projects/<name>`.