### PR TITLE
feat: support S3 compatible storage alongside R2

### DIFF
--- a/apps/admin/.env.sample
+++ b/apps/admin/.env.sample
@@ -42,3 +42,5 @@ BEUTL_S3_ACCESS_KEY_ID=""
 BEUTL_S3_SECRET_ACCESS_KEY=""
 BEUTL_S3_SESSION_TOKEN=""
 BEUTL_S3_FORCE_PATH_STYLE=""
+# "true" permits an http:// endpoint (local MinIO only; credentials travel in clear).
+BEUTL_S3_ALLOW_INSECURE_HTTP=""

--- a/apps/admin/.env.sample
+++ b/apps/admin/.env.sample
@@ -30,3 +30,15 @@ ADMIN_USER_IDS=""
 STRIPE_SECRET_KEY=""
 STRIPE_PRO_PRICE_ID=""
 STRIPE_CREDIT_PRICE_ID=""
+
+# Object storage, same values as the Web and desktop API Workers. /admin/storage
+# shows where each file lives and moves files between the configured stores.
+# "r2" (default) uses the BEUTL_R2_BUCKET binding; "s3" uses the values below.
+BEUTL_STORAGE_PROVIDER=""
+BEUTL_S3_ENDPOINT=""
+BEUTL_S3_BUCKET=""
+BEUTL_S3_REGION=""
+BEUTL_S3_ACCESS_KEY_ID=""
+BEUTL_S3_SECRET_ACCESS_KEY=""
+BEUTL_S3_SESSION_TOKEN=""
+BEUTL_S3_FORCE_PATH_STYLE=""

--- a/apps/admin/src/app/[lang]/admin/storage/actions.ts
+++ b/apps/admin/src/app/[lang]/admin/storage/actions.ts
@@ -88,6 +88,8 @@ export async function moveFileToProvider(
         stores,
         expectedSize: Number(file.size),
         contentType: file.mimeType,
+        // A file deleted while its copy was in flight must not come back.
+        stillWanted: async () => (await findFileForAdminById({ id: file.id })) !== null,
       });
       if (outcome.kind === "moved") {
         await recordMove({ operatorUserId: session.user.id, file, outcome });
@@ -172,6 +174,7 @@ export async function moveFilesBatch(
         },
         onObjectChanged: (file, outcome) =>
           recordMove({ operatorUserId: session.user.id, file, outcome }),
+        stillWanted: async (file) => (await findFileForAdminById({ id: file.id })) !== null,
       });
       return { success: true, data: outcome };
     } catch (error) {

--- a/apps/admin/src/app/[lang]/admin/storage/actions.ts
+++ b/apps/admin/src/app/[lang]/admin/storage/actions.ts
@@ -1,0 +1,178 @@
+"use server";
+
+import { addAuditLog, auditLogActions } from "@beutl/next/audit-log";
+import type { ActionResult } from "@beutl/core";
+import { getTranslation } from "@beutl/i18n";
+import { findFileForAdminById, listFilesForAdminAfter } from "@beutl/db";
+import {
+  moveStorageObject,
+  moveStorageObjectsBatch,
+  StorageMoveError,
+  type MoveBatchOutcome,
+  type MovableFile,
+  type StorageProvider,
+} from "@beutl/api";
+import { adminAction } from "@/lib/auth-guard";
+import {
+  decodeFileCursor,
+  encodeFileCursor,
+  getStorageStores,
+  isStorageProvider,
+} from "@/lib/storage";
+
+// 1 回の一括実行の上限。応答が Cloudflare の待ち時間に収まるよう、移動する本数と
+// 走査する行数と経過時間の 3 つで区切る。
+const BATCH_PAGE_SIZE = 25;
+const BATCH_MAX_MOVES = 20;
+const BATCH_MAX_SCANNED = 250;
+const BATCH_MILLISECONDS = 20_000;
+
+function describeError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+async function recordMove({
+  operatorUserId,
+  file,
+  from,
+  to,
+  size,
+  sourceRemoved,
+}: {
+  operatorUserId: string;
+  file: { id: string; objectKey: string };
+  from: StorageProvider;
+  to: StorageProvider;
+  size: number;
+  sourceRemoved: boolean;
+}): Promise<void> {
+  try {
+    await addAuditLog({
+      userId: operatorUserId,
+      action: auditLogActions.admin.storageObjectMoved,
+      details: `fileId: ${file.id}, objectKey: ${file.objectKey}, from: ${from}, to: ${to}, size: ${size}${sourceRemoved ? "" : ", sourceRemoved: false"}`,
+    });
+  } catch (error) {
+    // The object has moved either way; a lost audit row must not undo that.
+    console.error("Failed to record a storage object move", file.id, error);
+  }
+}
+
+export async function moveFileToProvider(
+  lang: string,
+  input: unknown,
+): Promise<ActionResult> {
+  const { t } = await getTranslation(lang);
+  return await adminAction(async (session) => {
+    if (!input || typeof input !== "object") {
+      return { success: false, message: t("admin:storage.messages.invalidInput") };
+    }
+    const { fileId, to } = input as Record<string, unknown>;
+    if (typeof fileId !== "string" || !isStorageProvider(to)) {
+      return { success: false, message: t("admin:storage.messages.invalidInput") };
+    }
+    const { stores } = await getStorageStores();
+    if (!stores.some((store) => store.provider === to)) {
+      return { success: false, message: t("admin:storage.messages.notConfigured") };
+    }
+    const file = await findFileForAdminById({ id: fileId });
+    if (!file) return { success: false, message: t("admin:storage.noResults") };
+
+    const providerName = (provider: StorageProvider) =>
+      t(`admin:storage.providers.${provider}`);
+    try {
+      const outcome = await moveStorageObject({
+        objectKey: file.objectKey,
+        to,
+        stores,
+        expectedSize: Number(file.size),
+        contentType: file.mimeType,
+      });
+      if (outcome.kind === "moved") {
+        await recordMove({ operatorUserId: session.user.id, file, ...outcome });
+        return {
+          success: true,
+          message: t(
+            outcome.sourceRemoved
+              ? "admin:storage.messages.moved"
+              : "admin:storage.messages.movedSourceLeft",
+            { name: file.name, from: providerName(outcome.from), to: providerName(to) },
+          ),
+        };
+      }
+      if (outcome.kind === "already-there") {
+        return {
+          success: true,
+          message: t("admin:storage.messages.alreadyThere", {
+            name: file.name,
+            to: providerName(to),
+          }),
+        };
+      }
+      return { success: false, message: t("admin:storage.messages.missing", { name: file.name }) };
+    } catch (error) {
+      console.error("Failed to move a storage object", file.id, error);
+      return {
+        success: false,
+        message: error instanceof StorageMoveError
+          ? error.message
+          : t("admin:storage.messages.failed"),
+      };
+    }
+  });
+}
+
+export async function moveFilesBatch(
+  lang: string,
+  input: unknown,
+): Promise<ActionResult<MoveBatchOutcome>> {
+  const { t } = await getTranslation(lang);
+  return await adminAction(async (session) => {
+    if (!input || typeof input !== "object") {
+      return { success: false, message: t("admin:storage.messages.invalidInput") };
+    }
+    const { to, cursor } = input as Record<string, unknown>;
+    const start = decodeFileCursor(cursor);
+    if (!isStorageProvider(to) || start === null) {
+      return { success: false, message: t("admin:storage.messages.invalidInput") };
+    }
+    const { stores } = await getStorageStores();
+    if (!stores.some((store) => store.provider === to)) {
+      return { success: false, message: t("admin:storage.messages.notConfigured") };
+    }
+
+    try {
+      const outcome = await moveStorageObjectsBatch({
+        to,
+        stores,
+        cursor: start ? encodeFileCursor(start) : undefined,
+        limits: {
+          moves: BATCH_MAX_MOVES,
+          scanned: BATCH_MAX_SCANNED,
+          milliseconds: BATCH_MILLISECONDS,
+        },
+        nextPage: async (position): Promise<MovableFile[]> => {
+          const after = decodeFileCursor(position);
+          const rows = await listFilesForAdminAfter({
+            after: after ?? undefined,
+            limit: BATCH_PAGE_SIZE,
+          });
+          return rows.map((row) => ({
+            id: row.id,
+            name: row.name,
+            objectKey: row.objectKey,
+            size: Number(row.size),
+            mimeType: row.mimeType,
+            cursor: encodeFileCursor(row),
+          }));
+        },
+        onMoved: (file, result) =>
+          recordMove({ operatorUserId: session.user.id, file, ...result }),
+      });
+      return { success: true, data: outcome };
+    } catch (error) {
+      console.error("Failed to move storage objects in bulk", error);
+      return { success: false, message: describeError(error) };
+    }
+  });
+}

--- a/apps/admin/src/app/[lang]/admin/storage/actions.ts
+++ b/apps/admin/src/app/[lang]/admin/storage/actions.ts
@@ -3,7 +3,11 @@
 import { addAuditLog, auditLogActions } from "@beutl/next/audit-log";
 import type { ActionResult } from "@beutl/core";
 import { getTranslation } from "@beutl/i18n";
-import { findFileForAdminById, listFilesForAdminAfter } from "@beutl/db";
+import {
+  claimFileForStorageMove,
+  findFileForAdminById,
+  listFilesForAdminAfter,
+} from "@beutl/db";
 import {
   moveStorageObject,
   moveStorageObjectsBatch,
@@ -88,8 +92,9 @@ export async function moveFileToProvider(
         stores,
         expectedSize: Number(file.size),
         contentType: file.mimeType,
-        // A file deleted while its copy was in flight must not come back.
-        stillWanted: async () => (await findFileForAdminById({ id: file.id })) !== null,
+        // One move at a time per file, across isolates; a file deleted while
+        // its copy was in flight must not come back.
+        claim: () => claimFileForStorageMove({ id: file.id, expectedUpdatedAt: file.updatedAt }),
       });
       if (outcome.kind === "moved") {
         await recordMove({ operatorUserId: session.user.id, file, outcome });
@@ -169,12 +174,13 @@ export async function moveFilesBatch(
             objectKey: row.objectKey,
             size: Number(row.size),
             mimeType: row.mimeType,
+            updatedAt: row.updatedAt,
             cursor: encodeFileCursor(row),
           }));
         },
         onObjectChanged: (file, outcome) =>
           recordMove({ operatorUserId: session.user.id, file, outcome }),
-        stillWanted: async (file) => (await findFileForAdminById({ id: file.id })) !== null,
+        claim: (file) => claimFileForStorageMove({ id: file.id, expectedUpdatedAt: file.updatedAt }),
       });
       return { success: true, data: outcome };
     } catch (error) {

--- a/apps/admin/src/app/[lang]/admin/storage/actions.ts
+++ b/apps/admin/src/app/[lang]/admin/storage/actions.ts
@@ -3,11 +3,7 @@
 import { addAuditLog, auditLogActions } from "@beutl/next/audit-log";
 import type { ActionResult } from "@beutl/core";
 import { getTranslation } from "@beutl/i18n";
-import {
-  claimFileForStorageMove,
-  findFileForAdminById,
-  listFilesForAdminAfter,
-} from "@beutl/db";
+import { findFileForAdminById, listFilesForAdminAfter } from "@beutl/db";
 import {
   moveStorageObject,
   moveStorageObjectsBatch,
@@ -21,6 +17,7 @@ import { adminAction } from "@/lib/auth-guard";
 import {
   decodeFileCursor,
   encodeFileCursor,
+  fileStorageMoveLease,
   getStorageStores,
   isStorageProvider,
 } from "@/lib/storage";
@@ -94,7 +91,7 @@ export async function moveFileToProvider(
         contentType: file.mimeType,
         // One move at a time per file, across isolates; a file deleted while
         // its copy was in flight must not come back.
-        claim: () => claimFileForStorageMove({ id: file.id, expectedUpdatedAt: file.updatedAt }),
+        lease: fileStorageMoveLease(file),
       });
       if (outcome.kind === "moved") {
         await recordMove({ operatorUserId: session.user.id, file, outcome });
@@ -174,13 +171,12 @@ export async function moveFilesBatch(
             objectKey: row.objectKey,
             size: Number(row.size),
             mimeType: row.mimeType,
-            updatedAt: row.updatedAt,
             cursor: encodeFileCursor(row),
           }));
         },
         onObjectChanged: (file, outcome) =>
           recordMove({ operatorUserId: session.user.id, file, outcome }),
-        claim: (file) => claimFileForStorageMove({ id: file.id, expectedUpdatedAt: file.updatedAt }),
+        lease: fileStorageMoveLease,
       });
       return { success: true, data: outcome };
     } catch (error) {

--- a/apps/admin/src/app/[lang]/admin/storage/actions.ts
+++ b/apps/admin/src/app/[lang]/admin/storage/actions.ts
@@ -9,6 +9,7 @@ import {
   moveStorageObjectsBatch,
   StorageMoveError,
   type MoveBatchOutcome,
+  type MoveOutcome,
   type MovableFile,
   type StorageProvider,
 } from "@beutl/api";
@@ -31,26 +32,26 @@ function describeError(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
 
+// Every outcome that deleted a copy is recorded, including the removal of a
+// leftover copy when the object was already at the destination.
 async function recordMove({
   operatorUserId,
   file,
-  from,
-  to,
-  size,
-  sourceRemoved,
+  outcome,
 }: {
   operatorUserId: string;
   file: { id: string; objectKey: string };
-  from: StorageProvider;
-  to: StorageProvider;
-  size: number;
-  sourceRemoved: boolean;
+  outcome: Extract<MoveOutcome, { kind: "moved" | "already-there" }>;
 }): Promise<void> {
+  const details =
+    outcome.kind === "moved"
+      ? `fileId: ${file.id}, objectKey: ${file.objectKey}, from: ${outcome.from}, to: ${outcome.to}, size: ${outcome.size}${outcome.sourceRemoved ? "" : ", sourceRemoved: false"}`
+      : `fileId: ${file.id}, objectKey: ${file.objectKey}, to: ${outcome.to}, leftoverRemovedFrom: ${outcome.removedFrom.join("+")}`;
   try {
     await addAuditLog({
       userId: operatorUserId,
       action: auditLogActions.admin.storageObjectMoved,
-      details: `fileId: ${file.id}, objectKey: ${file.objectKey}, from: ${from}, to: ${to}, size: ${size}${sourceRemoved ? "" : ", sourceRemoved: false"}`,
+      details,
     });
   } catch (error) {
     // The object has moved either way; a lost audit row must not undo that.
@@ -89,7 +90,7 @@ export async function moveFileToProvider(
         contentType: file.mimeType,
       });
       if (outcome.kind === "moved") {
-        await recordMove({ operatorUserId: session.user.id, file, ...outcome });
+        await recordMove({ operatorUserId: session.user.id, file, outcome });
         return {
           success: true,
           message: t(
@@ -101,6 +102,9 @@ export async function moveFileToProvider(
         };
       }
       if (outcome.kind === "already-there") {
+        if (outcome.removedFrom.length > 0) {
+          await recordMove({ operatorUserId: session.user.id, file, outcome });
+        }
         return {
           success: true,
           message: t("admin:storage.messages.alreadyThere", {
@@ -166,8 +170,8 @@ export async function moveFilesBatch(
             cursor: encodeFileCursor(row),
           }));
         },
-        onMoved: (file, result) =>
-          recordMove({ operatorUserId: session.user.id, file, ...result }),
+        onObjectChanged: (file, outcome) =>
+          recordMove({ operatorUserId: session.user.id, file, outcome }),
       });
       return { success: true, data: outcome };
     } catch (error) {

--- a/apps/admin/src/app/[lang]/admin/storage/components.tsx
+++ b/apps/admin/src/app/[lang]/admin/storage/components.tsx
@@ -1,0 +1,302 @@
+"use client";
+
+import type { MoveBatchOutcome, StorageProvider } from "@beutl/api";
+import { useTranslation } from "@beutl/ui/i18n-client";
+import { Button } from "@beutl/ui/ui/button";
+import { Checkbox } from "@beutl/ui/ui/checkbox";
+import { Input } from "@beutl/ui/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@beutl/ui/ui/select";
+import { Search } from "lucide-react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { useEffect, useRef, useState, useTransition } from "react";
+import { moveFileToProvider, moveFilesBatch } from "./actions";
+
+function localizedActionMessage(
+  message: string | undefined,
+  fallback: string,
+  unauthenticated: string,
+  forbidden: string,
+): string {
+  if (message === "Unauthenticated") return unauthenticated;
+  if (message === "Forbidden") return forbidden;
+  return message ?? fallback;
+}
+
+export function StorageSearchForm({
+  lang,
+  query,
+  order,
+}: {
+  lang: string;
+  query?: string;
+  order: "asc" | "desc";
+}) {
+  const { t } = useTranslation(lang);
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const [value, setValue] = useState(query || "");
+
+  // 戻る/進むで URL が変わったときに入力欄が古いまま残らないようにする。
+  useEffect(() => {
+    setValue(query || "");
+  }, [query]);
+
+  const navigate = (next: { q?: string; order?: "asc" | "desc" }) => {
+    const params = new URLSearchParams(searchParams?.toString() ?? "");
+    const q = next.q ?? value;
+    if (q) params.set("q", q);
+    else params.delete("q");
+    params.set("order", next.order ?? order);
+    params.delete("page");
+    router.push(`/${lang}/admin/storage?${params.toString()}`);
+  };
+
+  return (
+    <form
+      onSubmit={(event) => {
+        event.preventDefault();
+        navigate({});
+      }}
+      className="flex flex-wrap gap-2"
+    >
+      <Input
+        type="search"
+        value={value}
+        onChange={(event) => setValue(event.target.value)}
+        placeholder={t("admin:storage.search.placeholder")}
+        aria-label={t("admin:storage.search.placeholder")}
+        className="max-w-sm"
+      />
+      <Button type="submit" variant="outline">
+        <Search className="mr-2 h-4 w-4" />
+        {t("admin:storage.search.submit")}
+      </Button>
+      <Select value={order} onValueChange={(next) => navigate({ order: next === "desc" ? "desc" : "asc" })}>
+        <SelectTrigger className="w-40" aria-label={t("admin:storage.search.order")}>
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="asc">{t("admin:storage.search.oldestFirst")}</SelectItem>
+          <SelectItem value="desc">{t("admin:storage.search.newestFirst")}</SelectItem>
+        </SelectContent>
+      </Select>
+    </form>
+  );
+}
+
+export function MoveFileButton({
+  lang,
+  fileId,
+  to,
+}: {
+  lang: string;
+  fileId: string;
+  to: StorageProvider;
+}) {
+  const { t } = useTranslation(lang);
+  const router = useRouter();
+  const [pending, startTransition] = useTransition();
+  const [message, setMessage] = useState<string | null>(null);
+
+  const run = () =>
+    startTransition(async () => {
+      setMessage(null);
+      const result = await moveFileToProvider(lang, { fileId, to });
+      setMessage(
+        localizedActionMessage(
+          result.message,
+          t("admin:storage.messages.failed"),
+          t("admin:storage.messages.unauthenticated"),
+          t("admin:storage.messages.forbidden"),
+        ),
+      );
+      if (result.success) router.refresh();
+    });
+
+  return (
+    <div className="flex flex-col items-end gap-1">
+      <Button size="sm" variant="outline" disabled={pending} onClick={run}>
+        {pending
+          ? t("admin:storage.moving")
+          : t("admin:storage.moveTo", { provider: t(`admin:storage.providers.${to}`) })}
+      </Button>
+      {message && <p className="max-w-xs text-right text-xs text-muted-foreground">{message}</p>}
+    </div>
+  );
+}
+
+type BatchTotals = Pick<MoveBatchOutcome, "scanned" | "moved" | "alreadyThere" | "missing" | "failed">;
+
+const emptyTotals = (): BatchTotals => ({
+  scanned: 0,
+  moved: 0,
+  alreadyThere: 0,
+  missing: 0,
+  failed: [],
+});
+
+export function StorageBatchPanel({
+  lang,
+  destinations,
+  defaultTo,
+}: {
+  lang: string;
+  destinations: { provider: StorageProvider; label: string }[];
+  defaultTo: StorageProvider;
+}) {
+  const { t } = useTranslation(lang);
+  const router = useRouter();
+  const [to, setTo] = useState<StorageProvider>(defaultTo);
+  const [keepRunning, setKeepRunning] = useState(true);
+  const [pending, startTransition] = useTransition();
+  const [totals, setTotals] = useState<BatchTotals>(emptyTotals);
+  const [cursor, setCursor] = useState<string | undefined>(undefined);
+  const [state, setState] = useState<"idle" | "done" | "paused">("idle");
+  const [message, setMessage] = useState<string | null>(null);
+  const stopRequested = useRef(false);
+
+  const reset = () => {
+    setTotals(emptyTotals());
+    setCursor(undefined);
+    setState("idle");
+    setMessage(null);
+  };
+
+  const run = () =>
+    startTransition(async () => {
+      stopRequested.current = false;
+      setMessage(null);
+      let position = cursor;
+      for (;;) {
+        const result = await moveFilesBatch(lang, { to, cursor: position });
+        if (!result.success || !result.data) {
+          setMessage(
+            localizedActionMessage(
+              result.message,
+              t("admin:storage.messages.failed"),
+              t("admin:storage.messages.unauthenticated"),
+              t("admin:storage.messages.forbidden"),
+            ),
+          );
+          setState("paused");
+          break;
+        }
+        const batch = result.data;
+        setTotals((previous) => ({
+          scanned: previous.scanned + batch.scanned,
+          moved: previous.moved + batch.moved,
+          alreadyThere: previous.alreadyThere + batch.alreadyThere,
+          missing: previous.missing + batch.missing,
+          failed: [...previous.failed, ...batch.failed],
+        }));
+        position = batch.nextCursor;
+        setCursor(position);
+        if (batch.done) {
+          setState("done");
+          break;
+        }
+        if (!keepRunning || stopRequested.current) {
+          setState("paused");
+          break;
+        }
+      }
+      router.refresh();
+    });
+
+  return (
+    <section className="flex flex-col gap-3 rounded-lg border p-4">
+      <div>
+        <h2 className="font-semibold">{t("admin:storage.batch.heading")}</h2>
+        <p className="mt-1 text-sm text-muted-foreground">{t("admin:storage.batch.description")}</p>
+      </div>
+      <div className="flex flex-wrap items-center gap-3">
+        <label className="flex items-center gap-2 text-sm">
+          {t("admin:storage.batch.destination")}
+          <Select
+            value={to}
+            onValueChange={(next) => {
+              setTo(next as StorageProvider);
+              reset();
+            }}
+            disabled={pending}
+          >
+            <SelectTrigger className="w-64" aria-label={t("admin:storage.batch.destination")}>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {destinations.map((destination) => (
+                <SelectItem key={destination.provider} value={destination.provider}>
+                  {destination.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </label>
+        <label className="flex items-center gap-2 text-sm">
+          <Checkbox
+            checked={keepRunning}
+            onCheckedChange={(checked) => setKeepRunning(checked === true)}
+            disabled={pending}
+          />
+          {t("admin:storage.batch.keepRunning")}
+        </label>
+      </div>
+      <div className="flex flex-wrap items-center gap-2">
+        <Button onClick={run} disabled={pending || state === "done"}>
+          {pending ? t("admin:storage.batch.running") : t("admin:storage.batch.run")}
+        </Button>
+        {pending && keepRunning && (
+          <Button
+            variant="outline"
+            onClick={() => {
+              stopRequested.current = true;
+            }}
+          >
+            {t("admin:storage.batch.stop")}
+          </Button>
+        )}
+        {!pending && (cursor !== undefined || state !== "idle") && (
+          <Button variant="ghost" onClick={reset}>
+            {t("admin:storage.batch.reset")}
+          </Button>
+        )}
+      </div>
+      {(totals.scanned > 0 || state !== "idle") && (
+        <p className="text-sm">
+          {t("admin:storage.batch.progress", {
+            scanned: totals.scanned,
+            moved: totals.moved,
+            alreadyThere: totals.alreadyThere,
+            missing: totals.missing,
+            failed: totals.failed.length,
+          })}
+        </p>
+      )}
+      {state === "done" && (
+        <p className="text-sm text-muted-foreground">{t("admin:storage.batch.done")}</p>
+      )}
+      {state === "paused" && !message && (
+        <p className="text-sm text-muted-foreground">{t("admin:storage.batch.paused")}</p>
+      )}
+      {message && <p className="text-sm text-destructive">{message}</p>}
+      {totals.failed.length > 0 && (
+        <div className="text-sm">
+          <p className="font-medium">{t("admin:storage.batch.failures")}</p>
+          <ul className="mt-1 list-disc pl-5 text-muted-foreground">
+            {totals.failed.map((failure) => (
+              <li key={`${failure.id}:${failure.error}`}>
+                <span className="text-foreground">{failure.name}</span>: {failure.error}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/apps/admin/src/app/[lang]/admin/storage/components.tsx
+++ b/apps/admin/src/app/[lang]/admin/storage/components.tsx
@@ -195,10 +195,18 @@ export function StorageBatchPanel({
           missing: previous.missing + batch.missing,
           failed: [...previous.failed, ...batch.failed],
         }));
+        const advanced = batch.scanned > 0 && batch.nextCursor !== position;
         position = batch.nextCursor;
         setCursor(position);
         if (batch.done) {
           setState("done");
+          break;
+        }
+        if (!advanced) {
+          // A run that settled nothing would be sent again with the same
+          // cursor; stop rather than keep a slow store busy.
+          setMessage(t("admin:storage.batch.noProgress"));
+          setState("paused");
           break;
         }
         if (!keepRunning || stopRequested.current) {

--- a/apps/admin/src/app/[lang]/admin/storage/page.tsx
+++ b/apps/admin/src/app/[lang]/admin/storage/page.tsx
@@ -1,0 +1,217 @@
+import { listFilesForAdmin, type AdminFileOrder } from "@beutl/db";
+import { formatBytes } from "@beutl/core";
+import { getTranslation } from "@beutl/i18n";
+import type { StorageStores } from "@beutl/api";
+import { Badge } from "@beutl/ui/ui/badge";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@beutl/ui/ui/table";
+import Link from "next/link";
+import { requireAdmin } from "@/lib/auth-guard";
+import { formatTimestamp } from "@/lib/format";
+import { fetchPaginated, parsePageParam } from "@/lib/pagination";
+import { firstSearchParam } from "@/lib/search-params";
+import { getStorageStores, locateFiles, type FileLocation } from "@/lib/storage";
+import { Pagination } from "@/components/admin/pagination";
+import { MoveFileButton, StorageBatchPanel, StorageSearchForm } from "./components";
+
+const PAGE_SIZE = 20;
+
+// The location column is read from the stores on every render; never cache it.
+export const dynamic = "force-dynamic";
+
+function LocationCell({
+  location,
+  t,
+}: {
+  location: FileLocation | undefined;
+  t: (key: string, options?: Record<string, unknown>) => string;
+}) {
+  if (!location) return null;
+  if (location.kind === "error") {
+    return (
+      <span className="text-xs text-destructive">
+        {t("admin:storage.location.unknown", { error: location.error })}
+      </span>
+    );
+  }
+  if (location.locations.length === 0) {
+    return <Badge variant="destructive">{t("admin:storage.location.missing")}</Badge>;
+  }
+  return (
+    <div className="flex flex-wrap gap-1">
+      {location.locations.map((entry) => (
+        <Badge key={entry.provider} variant="secondary">
+          {t(`admin:storage.providers.${entry.provider}`)}
+        </Badge>
+      ))}
+    </div>
+  );
+}
+
+export default async function Page(props: {
+  params: Promise<{ lang: string }>;
+  searchParams: Promise<{
+    q?: string | string[];
+    page?: string | string[];
+    order?: string | string[];
+  }>;
+}) {
+  await requireAdmin();
+  const { lang } = await props.params;
+  const searchParams = await props.searchParams;
+  const q = firstSearchParam(searchParams.q);
+  const order: AdminFileOrder =
+    firstSearchParam(searchParams.order) === "desc" ? "desc" : "asc";
+  const { t } = await getTranslation(lang);
+
+  let stores: StorageStores | null = null;
+  let configError: string | null = null;
+  try {
+    stores = await getStorageStores();
+  } catch (error) {
+    configError = error instanceof Error ? error.message : String(error);
+  }
+
+  const { result, currentPage, totalPages } = await fetchPaginated(
+    (pageNumber) =>
+      listFilesForAdmin({ query: q, page: pageNumber, pageSize: PAGE_SIZE, order }),
+    parsePageParam(searchParams.page),
+    PAGE_SIZE,
+  );
+  const locations = stores
+    ? await locateFiles(result.items, stores.stores)
+    : new Map<string, FileLocation>();
+  const [primary, fallback] = stores?.stores ?? [];
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div>
+        <h1 className="text-2xl font-bold">{t("admin:storage.title")}</h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          {t("admin:storage.description")}
+        </p>
+      </div>
+
+      {configError ? (
+        <p className="rounded-lg border border-destructive p-4 text-sm text-destructive">
+          {t("admin:storage.stores.configError", { error: configError })}
+        </p>
+      ) : (
+        <section className="grid gap-4 sm:grid-cols-2">
+          <div className="rounded-lg border bg-card p-4 text-card-foreground">
+            <p className="text-xs text-muted-foreground">{t("admin:storage.stores.primary")}</p>
+            <p className="mt-1 font-medium">{primary?.label ?? t("admin:storage.stores.none")}</p>
+          </div>
+          <div className="rounded-lg border bg-card p-4 text-card-foreground">
+            <p className="text-xs text-muted-foreground">{t("admin:storage.stores.fallback")}</p>
+            <p className="mt-1 font-medium">{fallback?.label ?? t("admin:storage.stores.none")}</p>
+          </div>
+        </section>
+      )}
+
+      {stores && stores.stores.length > 1 && (
+        <StorageBatchPanel
+          lang={lang}
+          destinations={stores.stores.map((store) => ({
+            provider: store.provider,
+            label: store.label,
+          }))}
+          defaultTo={stores.primary}
+        />
+      )}
+
+      <StorageSearchForm lang={lang} query={q} order={order} />
+
+      {result.items.length === 0 ? (
+        <p className="text-sm text-muted-foreground">{t("admin:storage.noResults")}</p>
+      ) : (
+        <>
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>{t("admin:storage.columns.name")}</TableHead>
+                <TableHead>{t("admin:storage.columns.owner")}</TableHead>
+                <TableHead className="text-right">{t("admin:storage.columns.size")}</TableHead>
+                <TableHead>{t("admin:storage.columns.createdAt")}</TableHead>
+                <TableHead>{t("admin:storage.columns.location")}</TableHead>
+                <TableHead className="text-right">{t("admin:storage.columns.actions")}</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {result.items.map((file) => {
+                const location = locations.get(file.objectKey);
+                const present = new Set(
+                  location?.kind === "located"
+                    ? location.locations.map((entry) => entry.provider)
+                    : [],
+                );
+                // A file that is nowhere has nothing to move; one found in
+                // both stores can be consolidated into either.
+                const targets =
+                  location?.kind === "located" && present.size > 0
+                    ? (stores?.stores ?? []).filter(
+                        (store) => !(present.size === 1 && present.has(store.provider)),
+                      )
+                    : [];
+                return (
+                  <TableRow key={file.id}>
+                    <TableCell className="max-w-xs">
+                      <div className="truncate font-medium" title={file.name}>{file.name}</div>
+                      <div className="truncate text-xs text-muted-foreground" title={file.objectKey}>
+                        {file.objectKey}
+                      </div>
+                    </TableCell>
+                    <TableCell>
+                      <Link
+                        href={`/${lang}/admin/users/${file.user.id}`}
+                        className="hover:underline"
+                      >
+                        {file.user.email}
+                      </Link>
+                    </TableCell>
+                    <TableCell className="text-right tabular-nums">
+                      {formatBytes(Number(file.size))}
+                    </TableCell>
+                    <TableCell className="text-muted-foreground">
+                      {formatTimestamp(file.createdAt, lang)}
+                    </TableCell>
+                    <TableCell>
+                      <LocationCell location={location} t={t} />
+                    </TableCell>
+                    <TableCell className="text-right">
+                      <div className="flex justify-end gap-2">
+                        {targets.map((store) => (
+                          <MoveFileButton
+                            key={store.provider}
+                            lang={lang}
+                            fileId={file.id}
+                            to={store.provider}
+                          />
+                        ))}
+                      </div>
+                    </TableCell>
+                  </TableRow>
+                );
+              })}
+            </TableBody>
+          </Table>
+
+          <Pagination
+            basePath={`/${lang}/admin/storage`}
+            params={{ q, order }}
+            currentPage={currentPage}
+            totalPages={totalPages}
+            previousLabel={t("admin:common.previousPage")}
+            nextLabel={t("admin:common.nextPage")}
+          />
+        </>
+      )}
+    </div>
+  );
+}

--- a/apps/admin/src/components/admin/admin-nav.tsx
+++ b/apps/admin/src/components/admin/admin-nav.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useTranslation } from "@beutl/ui/i18n-client";
-import { LayoutDashboard, Users, MessageSquare, ScrollText, LogOut, Sparkles } from "lucide-react";
+import { HardDrive, LayoutDashboard, Users, MessageSquare, ScrollText, LogOut, Sparkles } from "lucide-react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { cn } from "@beutl/core";
@@ -22,6 +22,7 @@ export function AdminNav({ lang }: { lang: string }) {
     { slug: "users", href: `/${lang}/admin/users`, label: t("admin:nav.users"), icon: Users },
     { slug: "feedback", href: `/${lang}/admin/feedback`, label: t("admin:nav.feedback"), icon: MessageSquare },
     { slug: "ai", href: `/${lang}/admin/ai`, label: t("admin:nav.ai"), icon: Sparkles },
+    { slug: "storage", href: `/${lang}/admin/storage`, label: t("admin:nav.storage"), icon: HardDrive },
     { slug: "audit-log", href: `/${lang}/admin/audit-log`, label: t("admin:nav.auditLog"), icon: ScrollText },
   ] as const;
 

--- a/apps/admin/src/lib/auth-guard.ts
+++ b/apps/admin/src/lib/auth-guard.ts
@@ -29,7 +29,7 @@ const getSession = cache(async () => {
 // 認証だけを見る関数を外に出すのは管理者判定込みの adminAction / requireAdmin だけ。
 // Generic in what the action returns so a read-only lookup can hand back the
 // data it found; the union keeps the refusals, which carry no payload.
-export async function adminAction<T extends ActionResult>(
+export async function adminAction<T extends ActionResult<unknown>>(
   fnc: (session: SafeSession) => Promise<T>,
 ): Promise<T | ActionResult> {
   const result = await getSession();

--- a/apps/admin/src/lib/storage.ts
+++ b/apps/admin/src/lib/storage.ts
@@ -4,10 +4,17 @@ import {
   resolveStorageStores,
   STORAGE_PROVIDERS,
   type ObjectLocation,
+  type StorageMoveLease,
   type StorageProvider,
   type StorageStore,
   type StorageStores,
 } from "@beutl/api";
+import {
+  acquireFileStorageMoveLease,
+  existsFileById,
+  registerAiStorageCleanup,
+  releaseFileStorageMoveLease,
+} from "@beutl/db";
 import { getCloudflareContext } from "@opennextjs/cloudflare";
 
 // 管理画面は Web と同じストレージ設定 (BEUTL_R2_BUCKET / BEUTL_S3_*) を持つ。
@@ -56,6 +63,33 @@ export async function locateFiles(
     Array.from({ length: Math.min(LOCATE_CONCURRENCY, queue.length) }, worker),
   );
   return result;
+}
+
+// 移動 1 件が持つ File 行のリース。isolate を跨いだ同時移動を排他し、移動中に
+// ファイルが消されていたら、その鍵のオブジェクト削除を耐久的な後始末に載せる
+// (行の削除が両ストアを掃除した後に着地したコピーを、後から確実に消すため)。
+export function fileStorageMoveLease(file: { id: string; objectKey: string }): StorageMoveLease {
+  const leaseToken = crypto.randomUUID();
+  return {
+    acquire: () => acquireFileStorageMoveLease({ id: file.id, leaseToken }),
+    async stillExists() {
+      if (await existsFileById({ id: file.id })) return true;
+      await registerAiStorageCleanup({
+        objectKey: file.objectKey,
+        aiJobId: null,
+        state: "cleanup",
+        notBefore: new Date(),
+      }).catch((error) => {
+        console.error("Failed to queue cleanup for a copy of a deleted file", file.objectKey, error);
+      });
+      return false;
+    },
+    async release() {
+      await releaseFileStorageMoveLease({ id: file.id, leaseToken }).catch((error) => {
+        console.error("Failed to release a storage move lease; it expires on its own", file.id, error);
+      });
+    },
+  };
 }
 
 // 一括移動の走査位置。(createdAt, id) をクライアントが持ち回れる文字列にする。

--- a/apps/admin/src/lib/storage.ts
+++ b/apps/admin/src/lib/storage.ts
@@ -14,6 +14,7 @@ import {
   existsFileById,
   registerAiStorageCleanup,
   releaseFileStorageMoveLease,
+  renewFileStorageMoveLease,
 } from "@beutl/db";
 import { getCloudflareContext } from "@opennextjs/cloudflare";
 
@@ -74,6 +75,7 @@ export function fileStorageMoveLease(file: { id: string; objectKey: string }): S
   const leaseToken = crypto.randomUUID();
   return {
     acquire: () => acquireFileStorageMoveLease({ id: file.id, leaseToken }),
+    confirm: () => renewFileStorageMoveLease({ id: file.id, leaseToken }),
     async stillExists() {
       if (await existsFileById({ id: file.id })) return true;
       // The file's own cleanup row may be leased by the sweeper right now;

--- a/apps/admin/src/lib/storage.ts
+++ b/apps/admin/src/lib/storage.ts
@@ -33,6 +33,8 @@ export type FileLocation =
   | { kind: "error"; error: string };
 
 const LOCATE_CONCURRENCY = 8;
+const CLEANUP_INTENT_ATTEMPTS = 3;
+const CLEANUP_INTENT_RETRY_MILLISECONDS = 500;
 
 // 一覧の各行について、どのストアに実体があるかを HEAD で確かめる。
 // 1 ページ分 (数十件) を、外部ストアへ同時に投げ過ぎない程度に並列化する。
@@ -74,15 +76,27 @@ export function fileStorageMoveLease(file: { id: string; objectKey: string }): S
     acquire: () => acquireFileStorageMoveLease({ id: file.id, leaseToken }),
     async stillExists() {
       if (await existsFileById({ id: file.id })) return true;
-      await registerAiStorageCleanup({
-        objectKey: file.objectKey,
-        aiJobId: null,
-        state: "cleanup",
-        notBefore: new Date(),
-      }).catch((error) => {
-        console.error("Failed to queue cleanup for a copy of a deleted file", file.objectKey, error);
-      });
-      return false;
+      // The file's own cleanup row may be leased by the sweeper right now;
+      // wait it out briefly. Returning false without a recorded intent would
+      // let the mover treat a one-shot delete as durable.
+      let lastError: unknown;
+      for (let attempt = 0; attempt < CLEANUP_INTENT_ATTEMPTS; attempt++) {
+        try {
+          await registerAiStorageCleanup({
+            objectKey: file.objectKey,
+            aiJobId: null,
+            state: "cleanup",
+            notBefore: new Date(),
+          });
+          return false;
+        } catch (error) {
+          lastError = error;
+          await new Promise((resolve) => setTimeout(resolve, CLEANUP_INTENT_RETRY_MILLISECONDS * (attempt + 1)));
+        }
+      }
+      throw new Error(
+        `Could not queue cleanup for ${file.objectKey} after its file was deleted: ${lastError instanceof Error ? lastError.message : String(lastError)}`,
+      );
     },
     async release() {
       await releaseFileStorageMoveLease({ id: file.id, leaseToken }).catch((error) => {

--- a/apps/admin/src/lib/storage.ts
+++ b/apps/admin/src/lib/storage.ts
@@ -1,0 +1,84 @@
+import "server-only";
+import {
+  locateStorageObject,
+  resolveStorageStores,
+  STORAGE_PROVIDERS,
+  type ObjectLocation,
+  type StorageProvider,
+  type StorageStore,
+  type StorageStores,
+} from "@beutl/api";
+import { getCloudflareContext } from "@opennextjs/cloudflare";
+
+// 管理画面は Web と同じストレージ設定 (BEUTL_R2_BUCKET / BEUTL_S3_*) を持つ。
+// getCloudflareContext はリクエストコンテキストでのみ使えるため、呼び出し時に引く。
+export async function getStorageStores(): Promise<StorageStores> {
+  const { env } = await getCloudflareContext({ async: true });
+  return resolveStorageStores(env);
+}
+
+export function isStorageProvider(value: unknown): value is StorageProvider {
+  return (STORAGE_PROVIDERS as readonly unknown[]).includes(value);
+}
+
+export type FileLocation =
+  | { kind: "located"; locations: ObjectLocation[] }
+  | { kind: "error"; error: string };
+
+const LOCATE_CONCURRENCY = 8;
+
+// 一覧の各行について、どのストアに実体があるかを HEAD で確かめる。
+// 1 ページ分 (数十件) を、外部ストアへ同時に投げ過ぎない程度に並列化する。
+export async function locateFiles(
+  files: readonly { objectKey: string }[],
+  stores: readonly StorageStore[],
+): Promise<Map<string, FileLocation>> {
+  const result = new Map<string, FileLocation>();
+  const queue = [...new Set(files.map((file) => file.objectKey))];
+  const worker = async () => {
+    for (;;) {
+      const objectKey = queue.shift();
+      if (objectKey === undefined) return;
+      try {
+        result.set(objectKey, {
+          kind: "located",
+          locations: await locateStorageObject(objectKey, stores),
+        });
+      } catch (error) {
+        result.set(objectKey, {
+          kind: "error",
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+  };
+  await Promise.all(
+    Array.from({ length: Math.min(LOCATE_CONCURRENCY, queue.length) }, worker),
+  );
+  return result;
+}
+
+// 一括移動の走査位置。(createdAt, id) をクライアントが持ち回れる文字列にする。
+export function encodeFileCursor(position: { createdAt: Date; id: string }): string {
+  return Buffer.from(`${position.createdAt.toISOString()}\n${position.id}`, "utf8")
+    .toString("base64url");
+}
+
+export function decodeFileCursor(
+  value: unknown,
+): { createdAt: Date; id: string } | null | undefined {
+  if (value === undefined || value === null || value === "") return undefined;
+  if (typeof value !== "string") return null;
+  let decoded: string;
+  try {
+    decoded = Buffer.from(value, "base64url").toString("utf8");
+  } catch {
+    return null;
+  }
+  const separator = decoded.indexOf("\n");
+  if (separator === -1) return null;
+  const createdAt = new Date(decoded.slice(0, separator));
+  const id = decoded.slice(separator + 1);
+  if (!Number.isFinite(createdAt.getTime()) || id.length === 0) return null;
+  return { createdAt, id };
+}

--- a/apps/admin/worker-configuration.d.ts
+++ b/apps/admin/worker-configuration.d.ts
@@ -1,6 +1,7 @@
 /* eslint-disable */
 interface CloudflareEnv {
 	NEXT_INC_CACHE_R2_BUCKET: R2Bucket;
+	BEUTL_R2_BUCKET: R2Bucket;
 	WORKER_SELF_REFERENCE: Fetcher /* beutl-admin */;
 	BEUTL_DATABASE_HYPERDRIVE: Hyperdrive;
 	ASSETS: Fetcher;

--- a/apps/admin/wrangler.jsonc
+++ b/apps/admin/wrangler.jsonc
@@ -33,6 +33,13 @@
       // (パス名キーのインクリメンタルキャッシュがドメイン跨ぎで衝突し、
       // 誤ったコンテンツを配信するのを防ぐ)。
       "bucket_name": "beutl-admin-inc-cache"
+    },
+    {
+      // MUST MATCH beutl-web / beutl-web-api. /admin/storage がファイルの所在を
+      // 確認し、ストア間で移動するのに使う。BEUTL_STORAGE_PROVIDER と BEUTL_S3_*
+      // も両 Worker と同じ値にする。See docs/deployment.md#object-storage.
+      "binding": "BEUTL_R2_BUCKET",
+      "bucket_name": "beutl-dev"
     }
   ],
   "hyperdrive": [

--- a/apps/web/.env.sample
+++ b/apps/web/.env.sample
@@ -61,3 +61,21 @@ NODE_ENV=""
 
 # Admin user IDs (comma-separated UUIDs)
 ADMIN_USER_IDS=""
+
+# Object storage. "r2" (default) uses the BEUTL_R2_BUCKET binding from
+# wrangler.jsonc; "s3" talks to any S3 compatible service with the values below.
+# The Web and desktop API Workers must point at the same bucket. Only new
+# objects go to the selected provider: when the other one is configured too,
+# objects missing from the primary are read from it (docs/deployment.md).
+BEUTL_STORAGE_PROVIDER=""
+# e.g. https://s3.example.com or https://<account>.r2.cloudflarestorage.com
+BEUTL_S3_ENDPOINT=""
+BEUTL_S3_BUCKET=""
+# Signing region. R2 and MinIO accept "auto" (default); AWS S3 needs the real one.
+BEUTL_S3_REGION=""
+BEUTL_S3_ACCESS_KEY_ID=""
+BEUTL_S3_SECRET_ACCESS_KEY=""
+BEUTL_S3_SESSION_TOKEN=""
+# "true" (default) requests https://endpoint/bucket/key; "false" uses
+# https://bucket.endpoint/key.
+BEUTL_S3_FORCE_PATH_STYLE=""

--- a/apps/web/.env.sample
+++ b/apps/web/.env.sample
@@ -79,3 +79,5 @@ BEUTL_S3_SESSION_TOKEN=""
 # "true" (default) requests https://endpoint/bucket/key; "false" uses
 # https://bucket.endpoint/key.
 BEUTL_S3_FORCE_PATH_STYLE=""
+# "true" permits an http:// endpoint (local MinIO only; credentials travel in clear).
+BEUTL_S3_ALLOW_INSECURE_HTTP=""

--- a/apps/web/prisma/migrations/20260909010000_add_file_storage_move_lease/migration.sql
+++ b/apps/web/prisma/migrations/20260909010000_add_file_storage_move_lease/migration.sql
@@ -1,0 +1,8 @@
+-- 管理画面がストア間 (R2 / S3) でオブジェクトを移す間だけ File 行に持つリース。
+-- isolate を跨いで同じファイルの移動が同時に走り、互いのコピーを消し合わないよう
+-- にする。期限切れのリースは取り直せる。Cockroach のローリングデプロイに備えて
+-- 前進のみ・再実行可能に書き、schema_locked を前後で外し直す。
+ALTER TABLE "File" SET (schema_locked = false);
+ALTER TABLE "File" ADD COLUMN IF NOT EXISTS "storageMoveLeaseToken" STRING;
+ALTER TABLE "File" ADD COLUMN IF NOT EXISTS "storageMoveLeaseUntil" TIMESTAMP(3);
+ALTER TABLE "File" SET (schema_locked = true);

--- a/apps/web/prisma/migrations/20260909010000_add_file_storage_move_lease/migration.sql
+++ b/apps/web/prisma/migrations/20260909010000_add_file_storage_move_lease/migration.sql
@@ -5,4 +5,9 @@
 ALTER TABLE "File" SET (schema_locked = false);
 ALTER TABLE "File" ADD COLUMN IF NOT EXISTS "storageMoveLeaseToken" STRING;
 ALTER TABLE "File" ADD COLUMN IF NOT EXISTS "storageMoveLeaseUntil" TIMESTAMP(3);
+
+-- 一括移動は (createdAt, id) のカーソルで File を古い順に歩く。索引が無いと
+-- ページごとに全体の並べ替えが走り、件数に対して二乗で遅くなる。
+CREATE INDEX IF NOT EXISTS "File_createdAt_id_idx" ON "File"("createdAt", "id");
+
 ALTER TABLE "File" SET (schema_locked = true);

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -191,6 +191,10 @@ model File {
   // 中身ごと消すときはアプリ側がストレージの後始末付きで先に消す。
   folderId          String?
   folder            StorageFolder?      @relation(fields: [folderId], references: [id], onDelete: SetNull)
+  // 管理画面がストア間でオブジェクトを移す間だけ持つリース。isolate を跨いで
+  // 同じファイルの移動が同時に走らないようにする。期限切れは取り直せる。
+  storageMoveLeaseToken String?
+  storageMoveLeaseUntil DateTime?
 
   @@index([userId])
   @@index([folderId])

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -198,6 +198,8 @@ model File {
 
   @@index([userId])
   @@index([folderId])
+  // 管理画面の一括移動が (createdAt, id) のカーソルで全件を歩くための索引。
+  @@index([createdAt, id])
 }
 
 // ストレージ画面でユーザーがファイルを整理するためのフォルダー。ツリーは親への

--- a/apps/web/src/app/api/contents/[fileId]/route.ts
+++ b/apps/web/src/app/api/contents/[fileId]/route.ts
@@ -4,7 +4,7 @@ import {
   findFileForContentAccess,
 } from "@beutl/db";
 import { tryGetUserIdFromHeaders } from "@beutl/api";
-import { getCloudflareContext } from "@opennextjs/cloudflare";
+import { getR2Bucket } from "@beutl/api/ai/r2-provider";
 import { NextResponse, type NextRequest } from "next/server";
 import { auth } from "@/lib/better-auth";
 import {
@@ -52,7 +52,10 @@ export async function GET(
   });
 
   if (access.outcome === "allowed") {
-    const bucket = getCloudflareContext().env.BEUTL_R2_BUCKET;
+    const bucket = getR2Bucket();
+    if (!bucket.get) {
+      throw new Error("The configured storage bucket cannot read objects");
+    }
     const object = await bucket.get(file.objectKey);
     if (!object) {
       return NextResponse.json(
@@ -67,9 +70,15 @@ export async function GET(
     }
 
     const deliveryHeaders = contentDeliveryHeaders(file.mimeType);
-    return new NextResponse(object.body, {
+    const body = object.body ?? (object.arrayBuffer ? await object.arrayBuffer() : null);
+    if (body === null) {
+      throw new Error(`Storage object ${file.objectKey} cannot be read`);
+    }
+    return new NextResponse(body, {
       headers: {
-        "Content-Length": object.size.toString(),
+        ...(typeof object.size === "number"
+          ? { "Content-Length": object.size.toString() }
+          : {}),
         ...deliveryHeaders,
         "Content-Disposition": contentDisposition(
           deliveryHeaders["Content-Disposition"],

--- a/apps/web/src/lib/storage-upload-server.ts
+++ b/apps/web/src/lib/storage-upload-server.ts
@@ -473,11 +473,11 @@ export async function uploadPart({
     upload.objectKey,
     upload.uploadId,
   );
-  // Handed on exactly as it arrived. The bucket takes a stream only when it can
-  // know its length, which the request body carries and a stream wrapped around
-  // it would not — reading the part into memory to give it one would defeat the
-  // point of splitting the file up at all.
-  const part = await multipart.uploadPart(partNumber, body);
+  // Handed on exactly as it arrived, with the length the request declared. The
+  // bucket takes a stream only when it can know its length — reading the part
+  // into memory to give it one would defeat the point of splitting the file
+  // up at all.
+  const part = await multipart.uploadPart(partNumber, body, { contentLength });
   return { ok: true, etag: part.etag };
 }
 

--- a/apps/web/src/lib/storage.ts
+++ b/apps/web/src/lib/storage.ts
@@ -15,6 +15,7 @@ import {
   renewDedicatedStorageReservation,
   retrieveFilesByUserId,
 } from "@beutl/db";
+import { getR2Bucket } from "@beutl/api/ai/r2-provider";
 import { getCloudflareContext } from "@opennextjs/cloudflare";
 
 const DEDICATED_STORAGE_WRITE_DEADLINE_MILLISECONDS = 30 * 1000;
@@ -77,7 +78,7 @@ export async function deleteStorageFile({
   // remote delete after the transaction is known to have committed.
   if (prisma) return record;
 
-  const bucket = getCloudflareContext().env.BEUTL_R2_BUCKET;
+  const bucket = getR2Bucket();
   try {
     if (!bucket.delete) throw new Error("The configured bucket cannot delete objects");
     await bucket.delete(record.objectKey);
@@ -137,7 +138,7 @@ export async function createStorageFile({
   const array = await file.arrayBuffer();
   const objectKey = crypto.randomUUID();
   await registerAiStorageCleanup({ objectKey, aiJobId: null, state: "writing", notBefore: new Date(Date.now() + 15 * 60_000) });
-  const bucket = getCloudflareContext().env.BEUTL_R2_BUCKET;
+  const bucket = getR2Bucket();
   // The File record below is what callers commit against, so the object has to exist
   // first — an unawaited write can reject, or outlive the request, after they succeed.
   await bucket.put(objectKey, array);
@@ -223,7 +224,7 @@ export async function createDedicatedStorageFile({
     }).catch(() => undefined);
     throw error;
   }
-  const bucket = getCloudflareContext().env.BEUTL_R2_BUCKET;
+  const bucket = getR2Bucket();
   let hashHex: string;
   try {
     const hashBuffer = await crypto.subtle.digest("SHA-256", array);

--- a/apps/web/src/prisma.ts
+++ b/apps/web/src/prisma.ts
@@ -3,6 +3,7 @@ import { PrismaPg } from "@prisma/adapter-pg";
 import { getCloudflareContext } from "@opennextjs/cloudflare";
 import { setDbProvider } from "@beutl/db";
 import { setR2BucketProvider } from "@beutl/api/ai/r2-provider";
+import { resolveStorageBucket } from "@beutl/api/storage/bucket-from-env";
 import { after } from "next/server";
 import { cache } from "react";
 
@@ -32,14 +33,9 @@ const getPrismaClient = cache(createPrismaClient);
 
 setDbProvider(getPrismaClient);
 
-// AI 出力の保存先 (R2) を @beutl/api のストレージ層に登録する。
-// getCloudflareContext はリクエストコンテキストでのみ利用可能なため遅延実行する。
-setR2BucketProvider(() => {
-  const { env } = getCloudflareContext();
-  if (!env.BEUTL_R2_BUCKET) {
-    throw new Error("BEUTL_R2_BUCKET binding not found");
-  }
-  return env.BEUTL_R2_BUCKET;
-});
+// ファイルと AI 出力の保存先 (R2 か S3 互換ストレージ) を @beutl/api の
+// ストレージ層に登録する。getCloudflareContext はリクエストコンテキストでのみ
+// 利用可能なため遅延実行する。
+setR2BucketProvider(() => resolveStorageBucket(getCloudflareContext().env));
 
 export type { PrismaClient };

--- a/apps/web/wrangler.jsonc
+++ b/apps/web/wrangler.jsonc
@@ -42,6 +42,10 @@
       "binding": "NEXT_INC_CACHE_R2_BUCKET",
       "bucket_name": "beutl-web-inc-cache",
     },
+    // MUST MATCH beutl-web-api (packages/api/wrangler.jsonc).
+    // BEUTL_STORAGE_PROVIDER=s3 (vars) + BEUTL_S3_* (vars/secrets) sends new
+    // objects to S3 compatible storage; keep this binding so objects already in
+    // R2 stay readable. See docs/deployment.md#object-storage.
     {
       "binding": "BEUTL_R2_BUCKET",
       "bucket_name": "beutl-dev",

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -68,6 +68,12 @@ services that copy its behaviour) answers a GET or HEAD of a missing key with
 adapter treats only `404` as "not here", so without that permission an object
 that lives in the other store is reported as an error rather than read from it.
 
+Use a bucket without versioning. A delete on a versioned bucket only writes a
+delete marker, while the cleanup outboxes and the storage console take a
+successful delete as the object being gone; the noncurrent versions would
+then stay stored and billed with nothing tracking them. If versioning cannot
+be turned off, add a lifecycle rule that expires noncurrent versions promptly.
+
 Uploads stream each part straight from the browser request to the service with
 an unsigned payload (`x-amz-content-sha256: UNSIGNED-PAYLOAD`). This has been
 verified against MinIO, and R2 and AWS S3 document support for it; check
@@ -91,15 +97,17 @@ objects across and remove the other provider's configuration once the
 transition is over. `/admin/storage` in the admin console lists files with the
 store each object was found in, moves a single file, and moves files in bulk
 from the oldest onwards; each bulk run is bounded and resumes from where the
-previous one stopped. A move copies the object, checks the copy's size against
-the File record, and only then deletes the source; each moved file is written
-to the audit log. A half-configured provider is an error rather than a
+previous one stopped. A move holds a lease on the File record for its
+duration (the same file cannot be moved from two places at once), copies the
+object, checks the copy's size against the File record, and only then
+deletes the source; each moved file is written to the audit log. A half-configured provider is an error rather than a
 skipped fallback, so a stale `BEUTL_S3_*` value must be removed completely.
 
 Multipart uploads in flight at the moment of the switch belong to the old
 store. Their completion and abort are retried against it when the primary
 does not know the upload id, but a part cannot be resent, so a browser that
-was mid-upload fails that part and starts the upload again on the primary.
+was mid-upload sees that upload fail and the user has to start it again;
+the new upload then goes to the primary.
 
 ## Admin authentication and session sharing
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -22,6 +22,76 @@ commit secret values.
 desktop API Workers. The Web Worker issues the JWTs that the API Worker
 validates.
 
+## Object storage
+
+User files and AI outputs live in one object store that the Web Worker and the
+desktop API Worker share. Both Workers must be configured for the same bucket:
+the Web Worker writes uploads that the API Worker's scheduled reconcilers
+inspect and clean up, and either Worker may serve or delete an object the
+other one wrote. The admin Worker takes the same configuration so that
+`/admin/storage` can show where each file's object lives and move it.
+
+`BEUTL_STORAGE_PROVIDER` selects the implementation:
+
+| Value | Storage | Configuration |
+| --- | --- | --- |
+| `r2` (default when unset) | Cloudflare R2 through the `BEUTL_R2_BUCKET` binding | `r2_buckets` in each `wrangler.jsonc` |
+| `s3` | Any S3 compatible service over signed HTTPS | `BEUTL_S3_*` vars and secrets below |
+
+### S3 compatible storage
+
+Set `BEUTL_STORAGE_PROVIDER=s3` on both Workers together with:
+
+- `BEUTL_S3_ENDPOINT`: the service URL, for example `https://s3.example.com`,
+  `https://<account>.r2.cloudflarestorage.com`, or an endpoint with a path
+  prefix. Workers fetch with `global_fetch_strictly_public`, so the endpoint
+  must be publicly reachable.
+- `BEUTL_S3_BUCKET`: the bucket name.
+- `BEUTL_S3_ACCESS_KEY_ID` and `BEUTL_S3_SECRET_ACCESS_KEY`: store both with
+  `wrangler secret put`. `BEUTL_S3_SESSION_TOKEN` is optional for temporary
+  credentials.
+- `BEUTL_S3_REGION`: the signing region. It defaults to `auto`, which R2 and
+  MinIO accept; AWS S3, Backblaze B2, and Wasabi need their real region.
+- `BEUTL_S3_FORCE_PATH_STYLE`: `true` (default) requests
+  `https://endpoint/bucket/key`; `false` requests `https://bucket.endpoint/key`.
+
+The credential needs `GetObject`, `PutObject`, `DeleteObject`, and the
+multipart upload permissions (`CreateMultipartUpload`, `UploadPart`,
+`CompleteMultipartUpload`, `AbortMultipartUpload`) on the bucket. Objects are
+addressed by key only; no bucket listing is performed.
+
+Uploads stream each part straight from the browser request to the service with
+an unsigned payload (`x-amz-content-sha256: UNSIGNED-PAYLOAD`), which every
+common S3 compatible service accepts over HTTPS. Configure the bucket to abort
+incomplete multipart uploads after 7 days, matching the R2 lifecycle rule that
+`pnpm verify:r2-lifecycle` checks, so that an upload id whose owner never
+returned is not paid for indefinitely.
+
+### Switching providers
+
+`BEUTL_STORAGE_PROVIDER` only decides where new objects are written. When the
+other provider is configured as well (the `BEUTL_R2_BUCKET` binding for R2,
+the `BEUTL_S3_*` values for S3), an object the primary does not hold is read
+from the other store, and a delete is issued to both. Objects stored before
+the switch therefore stay reachable without being copied: to move new uploads
+to S3 while existing files keep coming from R2, set `BEUTL_STORAGE_PROVIDER=s3`
+and leave the R2 binding in place. The same rule covers moving back.
+
+A read that misses the primary costs one extra request, so move the old
+objects across and remove the other provider's configuration once the
+transition is over. `/admin/storage` in the admin console lists files with the
+store each object was found in, moves a single file, and moves files in bulk
+from the oldest onwards; each bulk run is bounded and resumes from where the
+previous one stopped. A move copies the object, checks the copy's size against
+the File record, and only then deletes the source; each moved file is written
+to the audit log. A half-configured provider is an error rather than a
+skipped fallback, so a stale `BEUTL_S3_*` value must be removed completely.
+
+Multipart uploads in flight at the moment of the switch belong to the old
+store. Their completion and abort are retried against it when the primary
+does not know the upload id, but a part cannot be resent, so a browser that
+was mid-upload fails that part and starts the upload again on the primary.
+
 ## Admin authentication and session sharing
 
 The admin console can share the Better Auth session with the Web app through

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -61,8 +61,12 @@ admin) together with:
 
 The credential needs `GetObject`, `PutObject`, `DeleteObject`, and the
 multipart upload permissions (`CreateMultipartUpload`, `UploadPart`,
-`CompleteMultipartUpload`, `AbortMultipartUpload`) on the bucket. Objects are
-addressed by key only; no bucket listing is performed.
+`CompleteMultipartUpload`, `AbortMultipartUpload`) on the objects, plus
+`ListBucket` on the bucket itself. Nothing lists the bucket, but AWS S3 (and
+services that copy its behaviour) answers a GET or HEAD of a missing key with
+`403 AccessDenied` instead of `404` when the principal lacks `ListBucket`; the
+adapter treats only `404` as "not here", so without that permission an object
+that lives in the other store is reported as an error rather than read from it.
 
 Uploads stream each part straight from the browser request to the service with
 an unsigned payload (`x-amz-content-sha256: UNSIGNED-PAYLOAD`). This has been

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -40,20 +40,24 @@ other one wrote. The admin Worker takes the same configuration so that
 
 ### S3 compatible storage
 
-Set `BEUTL_STORAGE_PROVIDER=s3` on both Workers together with:
+Set `BEUTL_STORAGE_PROVIDER=s3` on all three Workers (Web, desktop API, and
+admin) together with:
 
 - `BEUTL_S3_ENDPOINT`: the service URL, for example `https://s3.example.com`,
   `https://<account>.r2.cloudflarestorage.com`, or an endpoint with a path
   prefix. Workers fetch with `global_fetch_strictly_public`, so the endpoint
   must be publicly reachable.
 - `BEUTL_S3_BUCKET`: the bucket name.
-- `BEUTL_S3_ACCESS_KEY_ID` and `BEUTL_S3_SECRET_ACCESS_KEY`: store both with
-  `wrangler secret put`. `BEUTL_S3_SESSION_TOKEN` is optional for temporary
-  credentials.
+- `BEUTL_S3_ACCESS_KEY_ID`, `BEUTL_S3_SECRET_ACCESS_KEY`, and, for temporary
+  credentials, `BEUTL_S3_SESSION_TOKEN`: all three are credentials and must be
+  stored with `wrangler secret put`, never as `vars`.
 - `BEUTL_S3_REGION`: the signing region. It defaults to `auto`, which R2 and
   MinIO accept; AWS S3, Backblaze B2, and Wasabi need their real region.
 - `BEUTL_S3_FORCE_PATH_STYLE`: `true` (default) requests
   `https://endpoint/bucket/key`; `false` requests `https://bucket.endpoint/key`.
+- `BEUTL_S3_ALLOW_INSECURE_HTTP`: an `http://` endpoint is refused unless this
+  is `true`. Signed requests carry the credentials and the object data, so
+  this is for a local MinIO during development only.
 
 The credential needs `GetObject`, `PutObject`, `DeleteObject`, and the
 multipart upload permissions (`CreateMultipartUpload`, `UploadPart`,
@@ -61,8 +65,9 @@ multipart upload permissions (`CreateMultipartUpload`, `UploadPart`,
 addressed by key only; no bucket listing is performed.
 
 Uploads stream each part straight from the browser request to the service with
-an unsigned payload (`x-amz-content-sha256: UNSIGNED-PAYLOAD`), which every
-common S3 compatible service accepts over HTTPS. Configure the bucket to abort
+an unsigned payload (`x-amz-content-sha256: UNSIGNED-PAYLOAD`). This has been
+verified against MinIO, and R2 and AWS S3 document support for it; check
+another provider accepts it before relying on it. Configure the bucket to abort
 incomplete multipart uploads after 7 days, matching the R2 lifecycle rule that
 `pnpm verify:r2-lifecycle` checks, so that an upload id whose owner never
 returned is not paid for indefinitely.

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -10,7 +10,9 @@
     "./ai/image-model-capabilities": "./src/ai/image-model-capabilities.ts",
     "./ai/model-catalog": "./src/ai/model-catalog.ts",
     "./ai/video-model-capabilities": "./src/ai/video-model-capabilities.ts",
-    "./ai/r2-provider": "./src/ai/r2-provider.ts"
+    "./ai/r2-provider": "./src/ai/r2-provider.ts",
+    "./storage/bucket-from-env": "./src/storage/bucket-from-env.ts",
+    "./storage/s3-compatible-bucket": "./src/storage/s3-compatible-bucket.ts"
   },
   "dependencies": {
     "@beutl/core": "workspace:*",
@@ -20,6 +22,7 @@
     "@openrouter/sdk": "^1.2.42",
     "@prisma/adapter-pg": "^7.9.1",
     "@prisma/client": "^7.9.1",
+    "aws4fetch": "^1.0.20",
     "country-to-currency": "^2.0.2",
     "hono": "^4.13.0",
     "music-metadata": "^11.14.0",

--- a/packages/api/src/ai/r2-provider.ts
+++ b/packages/api/src/ai/r2-provider.ts
@@ -1,13 +1,24 @@
-// R2 bucket injection point shared by the standalone Worker and OpenNext.
+// Storage bucket injection point shared by the standalone Worker and OpenNext.
+// The shape is the R2 binding's; storage/s3-compatible-bucket.ts adapts S3
+// compatible services to it, and storage/bucket-from-env.ts picks which one
+// the configuration names.
 // Keep this module dependency-free: instrumentation imports it during Worker
 // startup, before any API route or AI provider implementation is needed.
 const GLOBAL_KEY = "__BEUTL_R2_BUCKET_PROVIDER__";
+
+/**
+ * A stream body must reach the service with a known length: S3 compatible
+ * services reject chunked uploads, and R2 refuses a stream of unknown length.
+ * workerd carries the length of an incoming request body along; anywhere
+ * else, pass `contentLength` with the stream.
+ */
+export type StorageStreamOptions = { contentLength?: number };
 
 export type R2BucketLike = {
   put(
     key: string,
     value: ArrayBuffer | ReadableStream | string,
-    options?: { httpMetadata?: { contentType?: string } },
+    options?: { httpMetadata?: { contentType?: string } } & StorageStreamOptions,
   ): Promise<unknown>;
   get?(key: string): Promise<{
     body?: ReadableStream<Uint8Array>;
@@ -27,6 +38,7 @@ export type R2BucketLike = {
     uploadPart(
       partNumber: number,
       value: ReadableStream<Uint8Array>,
+      options?: StorageStreamOptions,
     ): Promise<{ partNumber: number; etag: string }>;
     complete(
       parts: { partNumber: number; etag: string }[],

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -50,6 +50,7 @@ export type {
   MoveBatchOutcome,
   MoveOutcome,
   ObjectLocation,
+  StorageMoveLease,
 } from "./storage/move-object";
 export { createLayeredBucket } from "./storage/layered-bucket";
 export type { StorageStreamOptions } from "./ai/r2-provider";

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -29,6 +29,35 @@ export {
   isTerminalMultipartAbortError,
   reconcileStorageMultipartCleanups,
 } from "./storage-uploads";
+export {
+  configuredStorageProviders,
+  createStorageBucket,
+  createStorageStores,
+  resolveStorageBucket,
+  resolveStorageStores,
+  storageProviderOf,
+  STORAGE_PROVIDERS,
+} from "./storage/bucket-from-env";
+export type { StorageProvider, StorageStore, StorageStores } from "./storage/bucket-from-env";
+export {
+  locateStorageObject,
+  moveStorageObject,
+  moveStorageObjectsBatch,
+  StorageMoveError,
+} from "./storage/move-object";
+export type {
+  MovableFile,
+  MoveBatchOutcome,
+  MoveOutcome,
+  ObjectLocation,
+} from "./storage/move-object";
+export { createLayeredBucket } from "./storage/layered-bucket";
+export type { StorageStreamOptions } from "./ai/r2-provider";
+export {
+  createS3CompatibleBucket,
+  S3StorageError,
+} from "./storage/s3-compatible-bucket";
+export type { S3CompatibleBucketOptions } from "./storage/s3-compatible-bucket";
 export { closeStripeCustomerForAdminAccountDeletion } from "./account-deletion-stripe";
 export {
   discoverPackageCheckoutAttempt,

--- a/packages/api/src/storage-uploads.ts
+++ b/packages/api/src/storage-uploads.ts
@@ -24,6 +24,9 @@ import {
   STORAGE_QUOTA_BYTES,
 } from "@beutl/core";
 import { getR2Bucket } from "./ai/storage";
+import { isTerminalMultipartAbortError } from "./storage/multipart-errors";
+
+export { isTerminalMultipartAbortError } from "./storage/multipart-errors";
 
 // Giving up on uploads nobody finished.
 //
@@ -47,16 +50,6 @@ const ABANDON_AFTER_MILLISECONDS = 24 * 60 * 60 * 1000;
 const TOMBSTONE_GRACE_MILLISECONDS = 15 * 60 * 1000;
 const STORAGE_UPLOAD_CLEANUP_LEASE_MILLISECONDS = 5 * 60 * 1000;
 const MAX_PER_RUN = 100;
-
-export function isTerminalMultipartAbortError(error: unknown): boolean {
-  if (typeof error !== "object" || error === null) return false;
-  const record = error as Record<string, unknown>;
-  const code = String(record.code ?? record.name ?? "").toLowerCase();
-  if (code === "nosuchupload") return true;
-  return /(?:\(\s*10024\s*\)|\b10024)\s*$/u.test(
-    String(record.message ?? error),
-  );
-}
 
 export async function reconcileStorageMultipartCleanups(
   now: Date = new Date(),

--- a/packages/api/src/storage/bucket-from-env.ts
+++ b/packages/api/src/storage/bucket-from-env.ts
@@ -1,0 +1,172 @@
+// 環境変数からオブジェクトストレージの実装を選ぶ。既定は Cloudflare R2 の
+// バインディング (BEUTL_R2_BUCKET)。BEUTL_STORAGE_PROVIDER=s3 なら S3 互換
+// ストレージへ SigV4 署名付き HTTP でアクセスする。Web (OpenNext) と API
+// Worker の両方がここを通るので、設定の読み方はこの 1 か所に閉じる。
+import type { R2BucketLike } from "../ai/r2-provider";
+import { createLayeredBucket } from "./layered-bucket";
+import { createS3CompatibleBucket } from "./s3-compatible-bucket";
+
+export const STORAGE_PROVIDERS = ["r2", "s3"] as const;
+export type StorageProvider = (typeof STORAGE_PROVIDERS)[number];
+
+/** One configured store: the provider name, its bucket, and a label an
+ * administrator can recognise it by (never a credential). */
+export type StorageStore = {
+  provider: StorageProvider;
+  bucket: R2BucketLike;
+  label: string;
+};
+
+export type StorageStores = {
+  /** Where new objects are written. */
+  primary: StorageProvider;
+  /** Every configured store, primary first. */
+  stores: StorageStore[];
+};
+
+const STORAGE_PROVIDER_KEY = "BEUTL_STORAGE_PROVIDER";
+const R2_BINDING_KEY = "BEUTL_R2_BUCKET";
+const S3_KEYS = {
+  endpoint: "BEUTL_S3_ENDPOINT",
+  bucket: "BEUTL_S3_BUCKET",
+  region: "BEUTL_S3_REGION",
+  accessKeyId: "BEUTL_S3_ACCESS_KEY_ID",
+  secretAccessKey: "BEUTL_S3_SECRET_ACCESS_KEY",
+  sessionToken: "BEUTL_S3_SESSION_TOKEN",
+  forcePathStyle: "BEUTL_S3_FORCE_PATH_STYLE",
+} as const;
+
+// Worker の vars/secrets は env に、`next dev` の .env は process.env にしか
+// 無いので両方を見る。env が優先。
+function readString(env: object, key: string): string | undefined {
+  const bound = (env as Record<string, unknown>)[key];
+  const value = typeof bound === "string" ? bound : process.env[key];
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function requireString(env: object, key: string): string {
+  const value = readString(env, key);
+  if (value === undefined) {
+    throw new Error(`${key} is required for S3 compatible storage`);
+  }
+  return value;
+}
+
+function readBoolean(env: object, key: string, fallback: boolean): boolean {
+  const value = readString(env, key)?.toLowerCase();
+  if (value === undefined) return fallback;
+  if (value === "true" || value === "1" || value === "yes") return true;
+  if (value === "false" || value === "0" || value === "no") return false;
+  throw new Error(`${key} must be true or false, received "${value}"`);
+}
+
+export function storageProviderOf(env: object): StorageProvider {
+  const value = readString(env, STORAGE_PROVIDER_KEY)?.toLowerCase() ?? "r2";
+  if ((STORAGE_PROVIDERS as readonly string[]).includes(value)) {
+    return value as StorageProvider;
+  }
+  throw new Error(
+    `${STORAGE_PROVIDER_KEY} must be one of ${STORAGE_PROVIDERS.join(", ")}, received "${value}"`,
+  );
+}
+
+function r2Binding(env: object): R2BucketLike | undefined {
+  const binding = (env as Record<string, unknown>)[R2_BINDING_KEY];
+  return binding && typeof binding === "object" ? (binding as R2BucketLike) : undefined;
+}
+
+function s3Configured(env: object): boolean {
+  return Object.values(S3_KEYS).some((key) => readString(env, key) !== undefined);
+}
+
+function s3Bucket(env: object): R2BucketLike {
+  return createS3CompatibleBucket({
+    endpoint: requireString(env, S3_KEYS.endpoint),
+    bucket: requireString(env, S3_KEYS.bucket),
+    region: readString(env, S3_KEYS.region),
+    accessKeyId: requireString(env, S3_KEYS.accessKeyId),
+    secretAccessKey: requireString(env, S3_KEYS.secretAccessKey),
+    sessionToken: readString(env, S3_KEYS.sessionToken),
+    forcePathStyle: readBoolean(env, S3_KEYS.forcePathStyle, true),
+  });
+}
+
+/** Which providers the configuration describes, primary first. */
+export function configuredStorageProviders(env: object): StorageProvider[] {
+  const primary = storageProviderOf(env);
+  const other: StorageProvider = primary === "r2" ? "s3" : "r2";
+  const otherConfigured = other === "r2" ? r2Binding(env) !== undefined : s3Configured(env);
+  return otherConfigured ? [primary, other] : [primary];
+}
+
+function buildStore(env: object, provider: StorageProvider): StorageStore {
+  if (provider === "s3") {
+    const endpoint = new URL(requireString(env, S3_KEYS.endpoint));
+    return {
+      provider,
+      bucket: s3Bucket(env),
+      label: `S3 (${endpoint.host}/${requireString(env, S3_KEYS.bucket)})`,
+    };
+  }
+  const binding = r2Binding(env);
+  if (!binding) {
+    throw new Error(
+      `${R2_BINDING_KEY} binding not found; set ${STORAGE_PROVIDER_KEY}=s3 to use S3 compatible storage instead`,
+    );
+  }
+  return { provider, bucket: binding, label: `R2 (${R2_BINDING_KEY})` };
+}
+
+/**
+ * Every store the configuration describes, primary first. A provider that is
+ * named but incomplete throws, so a misconfiguration surfaces on the first
+ * storage call rather than as a quiet miss.
+ */
+export function createStorageStores(env: object): StorageStores {
+  const providers = configuredStorageProviders(env);
+  return {
+    primary: providers[0],
+    stores: providers.map((provider) => buildStore(env, provider)),
+  };
+}
+
+const resolvedStores = new WeakMap<object, StorageStores>();
+
+export function resolveStorageStores(env: object): StorageStores {
+  const cached = resolvedStores.get(env);
+  if (cached) return cached;
+  const stores = createStorageStores(env);
+  resolvedStores.set(env, stores);
+  return stores;
+}
+
+/**
+ * Build the bucket the configuration names. New objects go to the provider
+ * `BEUTL_STORAGE_PROVIDER` selects. When the other provider is configured as
+ * well, objects the primary does not hold are read from it, so switching
+ * providers keeps what was stored before the switch reachable without a copy.
+ */
+export function createStorageBucket(env: object): R2BucketLike {
+  const { stores } = createStorageStores(env);
+  const [primary, fallback] = stores;
+  return fallback === undefined
+    ? primary.bucket
+    : createLayeredBucket({ primary: primary.bucket, fallback: fallback.bucket });
+}
+
+const resolved = new WeakMap<object, R2BucketLike>();
+
+/**
+ * The bucket for one Worker env, built once per env object. A signing client
+ * caches its derived keys, so handing out the same instance keeps every
+ * request from re-deriving them.
+ */
+export function resolveStorageBucket(env: object): R2BucketLike {
+  const cached = resolved.get(env);
+  if (cached) return cached;
+  const bucket = createStorageBucket(env);
+  resolved.set(env, bucket);
+  return bucket;
+}

--- a/packages/api/src/storage/bucket-from-env.ts
+++ b/packages/api/src/storage/bucket-from-env.ts
@@ -34,6 +34,7 @@ const S3_KEYS = {
   secretAccessKey: "BEUTL_S3_SECRET_ACCESS_KEY",
   sessionToken: "BEUTL_S3_SESSION_TOKEN",
   forcePathStyle: "BEUTL_S3_FORCE_PATH_STYLE",
+  allowInsecureHttp: "BEUTL_S3_ALLOW_INSECURE_HTTP",
 } as const;
 
 // Worker の vars/secrets は env に、`next dev` の .env は process.env にしか
@@ -90,6 +91,7 @@ function s3Bucket(env: object): R2BucketLike {
     secretAccessKey: requireString(env, S3_KEYS.secretAccessKey),
     sessionToken: readString(env, S3_KEYS.sessionToken),
     forcePathStyle: readBoolean(env, S3_KEYS.forcePathStyle, true),
+    allowInsecureHttp: readBoolean(env, S3_KEYS.allowInsecureHttp, false),
   });
 }
 

--- a/packages/api/src/storage/layered-bucket.ts
+++ b/packages/api/src/storage/layered-bucket.ts
@@ -1,0 +1,89 @@
+// プロバイダを切り替えた後も、切り替え前に保存したオブジェクトをそのまま読める
+// ようにする層。新しいオブジェクトは primary にだけ書き、primary に無いものは
+// fallback を見に行く。キーは UUID 由来で両者に重複しないので、どちらで見つかった
+// かに曖昧さは無い。削除は両方に出す (どちらも無いキーの削除は成功扱いなので安全)。
+import type { R2BucketLike } from "../ai/r2-provider";
+import { isTerminalMultipartAbortError } from "./multipart-errors";
+
+type MultipartHandle = ReturnType<
+  NonNullable<R2BucketLike["resumeMultipartUpload"]>
+>;
+
+export function createLayeredBucket({
+  primary,
+  fallback,
+}: {
+  primary: R2BucketLike;
+  fallback: R2BucketLike;
+}): R2BucketLike {
+  const bucket: R2BucketLike = {
+    put: (key, value, options) => primary.put(key, value, options),
+  };
+
+  if (primary.get) {
+    const read = primary.get.bind(primary);
+    bucket.get = async (key) => {
+      const found = await read(key);
+      if (found !== null || !fallback.get) return found;
+      return await fallback.get(key);
+    };
+  }
+
+  if (primary.head) {
+    const inspect = primary.head.bind(primary);
+    bucket.head = async (key) => {
+      const found = await inspect(key);
+      if (found !== null || !fallback.head) return found;
+      return await fallback.head(key);
+    };
+  }
+
+  if (primary.delete) {
+    const remove = primary.delete.bind(primary);
+    bucket.delete = async (key) => {
+      await remove(key);
+      if (fallback.delete) await fallback.delete(key);
+    };
+  }
+
+  if (primary.createMultipartUpload) {
+    const create = primary.createMultipartUpload.bind(primary);
+    bucket.createMultipartUpload = (key, options) => create(key, options);
+  }
+
+  if (primary.resumeMultipartUpload) {
+    const resume = primary.resumeMultipartUpload.bind(primary);
+    bucket.resumeMultipartUpload = (key, uploadId): MultipartHandle => {
+      const first = resume(key, uploadId);
+      const second = fallback.resumeMultipartUpload?.(key, uploadId);
+      if (!second) return first;
+      // An upload id the primary has never heard of belongs to a handle that
+      // was opened before the switch. Only the calls without a body can be
+      // repeated against the fallback: a part's stream is consumed by the
+      // first attempt, so a stale handle fails its next part and the client
+      // starts over on the primary.
+      const orFallback = async <T>(
+        run: (handle: MultipartHandle) => Promise<T>,
+      ): Promise<T> => {
+        try {
+          return await run(first);
+        } catch (error) {
+          if (!isTerminalMultipartAbortError(error)) throw error;
+          try {
+            return await run(second);
+          } catch (fallbackError) {
+            throw isTerminalMultipartAbortError(fallbackError) ? error : fallbackError;
+          }
+        }
+      };
+      return {
+        uploadPart: (partNumber, value, options) =>
+          first.uploadPart(partNumber, value, options),
+        complete: (parts) => orFallback((handle) => handle.complete(parts)),
+        abort: () => orFallback((handle) => handle.abort()),
+      };
+    };
+  }
+
+  return bucket;
+}

--- a/packages/api/src/storage/layered-bucket.ts
+++ b/packages/api/src/storage/layered-bucket.ts
@@ -41,8 +41,15 @@ export function createLayeredBucket({
   if (primary.delete) {
     const remove = primary.delete.bind(primary);
     bucket.delete = async (key) => {
-      await remove(key);
-      if (fallback.delete) await fallback.delete(key);
+      if (!fallback.delete) {
+        await remove(key);
+        return;
+      }
+      // Both deletes always run: an unreachable primary must not leave the
+      // fallback's copy behind, and deleting a missing key succeeds anyway.
+      const results = await Promise.allSettled([remove(key), fallback.delete(key)]);
+      const failure = results.find((result) => result.status === "rejected");
+      if (failure?.status === "rejected") throw failure.reason;
     };
   }
 
@@ -76,11 +83,25 @@ export function createLayeredBucket({
           }
         }
       };
+      // Some services answer an abort for an id they never issued with a
+      // plain success (MinIO does), which would hide the stale handle in the
+      // other store. Abort reaches both stores; it succeeds when either one
+      // still knew the upload, and reports the primary's error when neither.
+      const abortBoth = async (): Promise<void> => {
+        const [viaPrimary, viaFallback] = await Promise.allSettled([first.abort(), second.abort()]);
+        for (const result of [viaPrimary, viaFallback]) {
+          if (result.status === "rejected" && !isTerminalMultipartAbortError(result.reason)) {
+            throw result.reason;
+          }
+        }
+        if (viaPrimary.status === "fulfilled" || viaFallback.status === "fulfilled") return;
+        throw viaPrimary.reason;
+      };
       return {
         uploadPart: (partNumber, value, options) =>
           first.uploadPart(partNumber, value, options),
         complete: (parts) => orFallback((handle) => handle.complete(parts)),
-        abort: () => orFallback((handle) => handle.abort()),
+        abort: abortBoth,
       };
     };
   }

--- a/packages/api/src/storage/move-object.ts
+++ b/packages/api/src/storage/move-object.ts
@@ -74,6 +74,28 @@ function sizeAgrees(observed: number | undefined, expected: number | undefined):
   return observed === undefined || expected === undefined || observed === expected;
 }
 
+// A copy whose size cannot be read is not a verified copy.
+function measuredAs(observed: number | undefined, expected: number): boolean {
+  return observed === expected;
+}
+
+// Two moves of the same object in one isolate run one after the other, so an
+// opposing pair cannot each delete the copy the other relies on. Separate
+// isolates still race across the short window between the final check and
+// the delete; the check below narrows it.
+const inFlight = new Map<string, Promise<unknown>>();
+
+async function serialized<T>(objectKey: string, run: () => Promise<T>): Promise<T> {
+  const previous = inFlight.get(objectKey) ?? Promise.resolve();
+  const current = previous.catch(() => undefined).then(run);
+  inFlight.set(objectKey, current);
+  try {
+    return await current;
+  } finally {
+    if (inFlight.get(objectKey) === current) inFlight.delete(objectKey);
+  }
+}
+
 /**
  * Move one object into the `to` store from wherever it currently is.
  *
@@ -98,6 +120,26 @@ export async function moveStorageObject({
   if (!destination) {
     throw new StorageMoveError("no-destination", `The ${to} store is not configured`);
   }
+  return await serialized(objectKey, () =>
+    moveLocatedObject({ objectKey, to, stores, destination, expectedSize, contentType }),
+  );
+}
+
+async function moveLocatedObject({
+  objectKey,
+  to,
+  stores,
+  destination,
+  expectedSize,
+  contentType,
+}: {
+  objectKey: string;
+  to: StorageProvider;
+  stores: readonly StorageStore[];
+  destination: StorageStore;
+  expectedSize?: number;
+  contentType?: string;
+}): Promise<MoveOutcome> {
   const locations = await locateStorageObject(objectKey, stores);
   const atDestination = locations.find((location) => location.provider === to);
   const elsewhere = locations.filter((location) => location.provider !== to);
@@ -105,16 +147,26 @@ export async function moveStorageObject({
   if (atDestination) {
     if (elsewhere.length === 0) return { kind: "already-there", to, removedFrom: [] };
     // A copy that a previous move left behind. Only remove it once the
-    // destination copy is known to be the right size.
-    if (!sizeAgrees(atDestination.size, expectedSize)) {
+    // destination copy is measured and, when the record says how large the
+    // object is, agrees with it.
+    if (atDestination.size === undefined || !sizeAgrees(atDestination.size, expectedSize)) {
       throw new StorageMoveError(
         "size-mismatch",
-        `${objectKey} in ${to} is ${atDestination.size} bytes, not the recorded ${expectedSize}`,
+        `${objectKey} in ${to} is ${atDestination.size ?? "of unknown size"}, not the recorded ${expectedSize}`,
       );
     }
     const removedFrom: StorageProvider[] = [];
     for (const location of elsewhere) {
       const store = stores.find((candidate) => candidate.provider === location.provider)!;
+      // An opposing move may have taken the destination copy since it was
+      // located; never remove the last copy.
+      const stillThere = await inspector(destination)(objectKey);
+      if (!stillThere || !measuredAs(stillThere.size, atDestination.size)) {
+        throw new StorageMoveError(
+          "verification-failed",
+          `${objectKey} in ${to} changed while its copy in ${location.provider} was about to be removed`,
+        );
+      }
       await remover(store)(objectKey);
       removedFrom.push(location.provider);
     }
@@ -139,11 +191,14 @@ export async function moveStorageObject({
 
   const object = await source.bucket.get(objectKey);
   if (!object) return { kind: "missing" };
-  const size = object.size ?? sourceLocation.size ?? expectedSize;
-  if (size === undefined) {
+  const size = object.size ?? sourceLocation.size;
+  // The object may have been replaced between HEAD and GET; what is copied
+  // must be what the record describes.
+  if (size === undefined || !sizeAgrees(size, expectedSize)) {
+    await object.body?.cancel().catch(() => undefined);
     throw new StorageMoveError(
       "size-mismatch",
-      `${objectKey} in ${source.provider} has no measurable size`,
+      `${objectKey} in ${source.provider} reads as ${size ?? "an unknown size"}, not the recorded ${expectedSize}`,
     );
   }
   const body: ArrayBuffer | ReadableStream =
@@ -154,7 +209,7 @@ export async function moveStorageObject({
   });
 
   const copied = await inspector(destination)(objectKey);
-  if (!copied || !sizeAgrees(copied.size, size)) {
+  if (!copied || !measuredAs(copied.size, size)) {
     // Leave the source untouched and do not keep a copy of unknown shape.
     await remover(destination)(objectKey).catch(() => undefined);
     throw new StorageMoveError(
@@ -206,7 +261,7 @@ export async function moveStorageObjectsBatch({
   nextPage,
   cursor,
   limits,
-  onMoved,
+  onObjectChanged,
   now = () => Date.now(),
 }: {
   to: StorageProvider;
@@ -214,7 +269,12 @@ export async function moveStorageObjectsBatch({
   nextPage: (cursor: string | undefined) => Promise<MovableFile[]>;
   cursor: string | undefined;
   limits: { moves: number; scanned: number; milliseconds: number };
-  onMoved?: (file: MovableFile, outcome: Extract<MoveOutcome, { kind: "moved" }>) => Promise<void>;
+  /** Called for every outcome that deleted something: a move, or a leftover
+   * copy removed from another store. Nothing is reported for a no-op. */
+  onObjectChanged?: (
+    file: MovableFile,
+    outcome: Extract<MoveOutcome, { kind: "moved" | "already-there" }>,
+  ) => Promise<void>;
   now?: () => number;
 }): Promise<MoveBatchOutcome> {
   if (!stores.some((store) => store.provider === to)) {
@@ -236,6 +296,7 @@ export async function moveStorageObjectsBatch({
     now() >= deadline;
 
   for (;;) {
+    if (exhausted()) return outcome;
     const page = await nextPage(outcome.nextCursor);
     if (page.length === 0) {
       outcome.done = true;
@@ -279,9 +340,10 @@ export async function moveStorageObjectsBatch({
         });
         if (result.kind === "moved") {
           outcome.moved++;
-          await onMoved?.(entry.file, result);
+          await onObjectChanged?.(entry.file, result);
         } else if (result.kind === "already-there") {
           outcome.alreadyThere++;
+          if (result.removedFrom.length > 0) await onObjectChanged?.(entry.file, result);
         } else {
           outcome.missing++;
         }

--- a/packages/api/src/storage/move-object.ts
+++ b/packages/api/src/storage/move-object.ts
@@ -30,9 +30,16 @@ export type MoveOutcome =
  */
 export type StorageMoveLease = {
   acquire(): Promise<"acquired" | "busy" | "gone">;
+  /** Verify this move still holds the lease and extend it. Asked right
+   * before anything is deleted and periodically while a copy is in flight;
+   * false means the lease expired or was taken, and nothing may be deleted. */
+  confirm(): Promise<boolean>;
   stillExists(): Promise<boolean>;
   release(): Promise<void>;
 };
+
+// How often a copy in flight renews the lease it holds.
+const LEASE_HEARTBEAT_MILLISECONDS = 60 * 1000;
 
 export class StorageMoveError extends Error {
   readonly reason:
@@ -156,6 +163,7 @@ export async function moveStorageObject({
         expectedSize,
         contentType,
         stillExists: lease?.stillExists,
+        confirm: lease?.confirm,
       });
     } finally {
       await lease?.release();
@@ -171,6 +179,7 @@ async function moveLocatedObject({
   expectedSize,
   contentType,
   stillExists,
+  confirm,
 }: {
   objectKey: string;
   to: StorageProvider;
@@ -179,7 +188,19 @@ async function moveLocatedObject({
   expectedSize?: number;
   contentType?: string;
   stillExists?: () => Promise<boolean>;
+  confirm?: () => Promise<boolean>;
 }): Promise<MoveOutcome> {
+  // Nothing is deleted by a move whose lease has lapsed: another move may
+  // hold it by now and rely on the copy this one is about to remove.
+  const deleteFrom = async (store: StorageStore): Promise<void> => {
+    if (confirm && !(await confirm())) {
+      throw new StorageMoveError(
+        "contended",
+        `${objectKey}: the move lease was lost before ${store.provider} could be cleaned up; nothing was deleted`,
+      );
+    }
+    await remover(store)(objectKey);
+  };
   const locations = await locateStorageObject(objectKey, stores);
   let atDestination = locations.find((location) => location.provider === to);
   const elsewhere = locations.filter((location) => location.provider !== to);
@@ -193,12 +214,22 @@ async function moveLocatedObject({
     // A copy an earlier move wrote but never verified, next to a source that
     // does match the record. It would shadow the good copy on reads, so it
     // is replaced: removed here, then copied afresh below.
-    await remover(destination)(objectKey);
+    await deleteFrom(destination);
     atDestination = undefined;
   }
 
   if (atDestination) {
-    if (elsewhere.length === 0) return { kind: "already-there", to, removedFrom: [] };
+    if (elsewhere.length === 0) {
+      // The only copy there is. It counts as settled only when it is measured
+      // and matches the record; otherwise there is nothing to repair it from.
+      if (!measuredAgainstRecord(atDestination.size, expectedSize)) {
+        throw new StorageMoveError(
+          "size-mismatch",
+          `${objectKey} in ${to} is ${atDestination.size ?? "of unknown size"}, not the recorded ${expectedSize}, and no other store holds a copy`,
+        );
+      }
+      return { kind: "already-there", to, removedFrom: [] };
+    }
     // A copy that a previous move left behind. Only remove it once the
     // destination copy is measured and, when the record says how large the
     // object is, agrees with it.
@@ -220,7 +251,7 @@ async function moveLocatedObject({
           `${objectKey} in ${to} changed while its copy in ${location.provider} was about to be removed`,
         );
       }
-      await remover(store)(objectKey);
+      await deleteFrom(store);
       removedFrom.push(location.provider);
     }
     return { kind: "already-there", to, removedFrom };
@@ -256,10 +287,13 @@ async function moveLocatedObject({
   }
   const body: ArrayBuffer | ReadableStream =
     object.body ?? (object.arrayBuffer ? await object.arrayBuffer() : new ArrayBuffer(0));
-  await destination.bucket.put(objectKey, body, {
-    httpMetadata: contentType ? { contentType } : undefined,
-    contentLength: size,
-  });
+  await withLeaseHeartbeat(
+    destination.bucket.put(objectKey, body, {
+      httpMetadata: contentType ? { contentType } : undefined,
+      contentLength: size,
+    }),
+    confirm,
+  );
 
   const copied = await inspector(destination)(objectKey);
   if (!copied || !measuredAs(copied.size, size)) {
@@ -268,7 +302,7 @@ async function moveLocatedObject({
     // source on reads until the next run replaces it.
     const problem = `${objectKey} was copied to ${to} but reads back as ${copied?.size ?? "absent"} rather than ${size} bytes`;
     try {
-      await remover(destination)(objectKey);
+      await deleteFrom(destination);
     } catch (error) {
       throw new StorageMoveError(
         "verification-failed",
@@ -287,7 +321,7 @@ async function moveLocatedObject({
       // a deleted file. The fresh copy must not stay behind unnoticed: try to
       // remove it now, and if that fails too say exactly which key is loose.
       try {
-        await remover(destination)(objectKey);
+        await deleteFrom(destination);
       } catch (removeError) {
         throw new StorageMoveError(
           "verification-failed",
@@ -300,7 +334,8 @@ async function moveLocatedObject({
       // The record is gone; its deletion has already swept the stores, so the
       // copy written since is the only thing left and would otherwise leak.
       // stillExists has queued a durable cleanup for the key by now, so a
-      // failure of this delete is retried later.
+      // failure of this delete is retried later. The lease cannot be
+      // confirmed against a deleted row, so this delete is not fenced.
       await remover(destination)(objectKey);
       return { kind: "missing" };
     }
@@ -308,8 +343,9 @@ async function moveLocatedObject({
 
   let sourceRemoved = true;
   try {
-    await remover(source)(objectKey);
+    await deleteFrom(source);
   } catch (error) {
+    if (error instanceof StorageMoveError) throw error;
     console.error(`Moved ${objectKey} to ${to} but could not delete it from ${source.provider}`, error);
     sourceRemoved = false;
   }
@@ -416,8 +452,13 @@ export async function moveStorageObjectsBatch({
         outcome.failed.push({ id: entry.file.id, name: entry.file.name, error: describe(entry.error) });
         continue;
       }
+      // Only a destination copy that is measured and matches the record
+      // counts as settled; anything else goes through the mover, which
+      // either repairs it or reports why it cannot.
       const settled =
-        entry.locations.length === 1 && entry.locations[0].provider === to;
+        entry.locations.length === 1 &&
+        entry.locations[0].provider === to &&
+        measuredAgainstRecord(entry.locations[0].size, entry.file.size);
       if (settled) {
         outcome.alreadyThere++;
         continue;
@@ -464,4 +505,28 @@ export async function moveStorageObjectsBatch({
 
 function describe(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
+}
+
+// Keep the lease alive while a long copy is in flight. A failed renewal is
+// not acted on here: the copy cannot be cancelled midway, and the confirm
+// before the next delete refuses to proceed without the lease.
+async function withLeaseHeartbeat<T>(
+  work: Promise<T>,
+  confirm: (() => Promise<boolean>) | undefined,
+): Promise<T> {
+  if (!confirm) return await work;
+  let stopped = false;
+  const heartbeat = (async () => {
+    while (!stopped) {
+      await new Promise((resolve) => setTimeout(resolve, LEASE_HEARTBEAT_MILLISECONDS));
+      if (stopped) break;
+      await confirm().catch(() => false);
+    }
+  })();
+  try {
+    return await work;
+  } finally {
+    stopped = true;
+    void heartbeat;
+  }
 }

--- a/packages/api/src/storage/move-object.ts
+++ b/packages/api/src/storage/move-object.ts
@@ -278,13 +278,32 @@ async function moveLocatedObject({
     throw new StorageMoveError("verification-failed", problem);
   }
 
-  if (stillExists && !(await stillExists())) {
-    // The record is gone; its deletion has already swept the stores, so the
-    // copy written since is the only thing left and would otherwise leak.
-    // The caller's stillExists is expected to have queued a durable cleanup
-    // for the key, so a failure here is retried later.
-    await remover(destination)(objectKey);
-    return { kind: "missing" };
+  if (stillExists) {
+    let exists: boolean;
+    try {
+      exists = await stillExists();
+    } catch (error) {
+      // The caller could not tell, or could not queue a durable cleanup for
+      // a deleted file. The fresh copy must not stay behind unnoticed: try to
+      // remove it now, and if that fails too say exactly which key is loose.
+      try {
+        await remover(destination)(objectKey);
+      } catch (removeError) {
+        throw new StorageMoveError(
+          "verification-failed",
+          `${objectKey}: could not confirm the file still exists (${describe(error)}) and the copy in ${to} could not be removed (${describe(removeError)}); that copy is untracked`,
+        );
+      }
+      throw error;
+    }
+    if (!exists) {
+      // The record is gone; its deletion has already swept the stores, so the
+      // copy written since is the only thing left and would otherwise leak.
+      // stillExists has queued a durable cleanup for the key by now, so a
+      // failure of this delete is retried later.
+      await remover(destination)(objectKey);
+      return { kind: "missing" };
+    }
   }
 
   let sourceRemoved = true;
@@ -368,7 +387,7 @@ export async function moveStorageObjectsBatch({
     now() >= deadline;
 
   for (;;) {
-    if (exhausted()) return outcome;
+    if (outcome.scanned > 0 && exhausted()) return outcome;
     const page = await nextPage(outcome.nextCursor);
     if (page.length === 0) {
       outcome.done = true;
@@ -388,7 +407,9 @@ export async function moveStorageObjectsBatch({
       }),
     );
     for (const entry of located) {
-      if (exhausted()) return outcome;
+      // Locating a slow store can spend the whole budget before the first
+      // entry; still settle one so every call advances the cursor.
+      if (outcome.scanned > 0 && exhausted()) return outcome;
       outcome.scanned++;
       outcome.nextCursor = entry.file.cursor;
       if ("error" in entry) {

--- a/packages/api/src/storage/move-object.ts
+++ b/packages/api/src/storage/move-object.ts
@@ -22,11 +22,14 @@ export type MoveOutcome =
   | { kind: "already-there"; to: StorageProvider; removedFrom: StorageProvider[] }
   | { kind: "missing" };
 
+export type StorageMoveClaim = "claimed" | "lost" | "gone";
+
 export class StorageMoveError extends Error {
   readonly reason:
     | "no-destination"
     | "size-mismatch"
     | "verification-failed"
+    | "contended"
     | "unsupported";
 
   constructor(reason: StorageMoveError["reason"], message: string) {
@@ -79,10 +82,9 @@ function measuredAs(observed: number | undefined, expected: number): boolean {
   return observed === expected;
 }
 
-// Two moves of the same object in one isolate run one after the other, so an
-// opposing pair cannot each delete the copy the other relies on. Separate
-// isolates still race across the short window between the final check and
-// the delete; the check below narrows it.
+// Two moves of the same object in one isolate run one after the other. Across
+// isolates the caller's `claim` is what serializes them: a durable
+// compare-and-set that exactly one move wins before anything is deleted.
 const inFlight = new Map<string, Promise<unknown>>();
 
 async function serialized<T>(objectKey: string, run: () => Promise<T>): Promise<T> {
@@ -109,26 +111,44 @@ export async function moveStorageObject({
   stores,
   expectedSize,
   contentType,
-  stillWanted,
+  claim,
 }: {
   objectKey: string;
   to: StorageProvider;
   stores: readonly StorageStore[];
   expectedSize?: number;
   contentType?: string;
-  /** Asked after the copy is verified and before the source is deleted. The
-   * file may have been deleted while the copy was in flight, in which case
-   * its deletion already removed every copy that existed at the time and the
-   * fresh copy must not survive it. */
-  stillWanted?: () => Promise<boolean>;
+  /**
+   * Asked once, right before the move deletes anything. It must be a durable
+   * compare-and-set on the file's record: "claimed" when this move won the
+   * right to delete, "lost" when another move (or an edit of the record)
+   * got there first, and "gone" when the record no longer exists. A file
+   * deleted while the copy was in flight has had every earlier copy swept
+   * by that deletion, so a fresh copy must not survive it.
+   */
+  claim?: () => Promise<StorageMoveClaim>;
 }): Promise<MoveOutcome> {
   const destination = stores.find((store) => store.provider === to);
   if (!destination) {
     throw new StorageMoveError("no-destination", `The ${to} store is not configured`);
   }
   return await serialized(objectKey, () =>
-    moveLocatedObject({ objectKey, to, stores, destination, expectedSize, contentType, stillWanted }),
+    moveLocatedObject({ objectKey, to, stores, destination, expectedSize, contentType, claim }),
   );
+}
+
+async function claimOrThrow(
+  claim: (() => Promise<StorageMoveClaim>) | undefined,
+  objectKey: string,
+): Promise<"claimed" | "gone"> {
+  const outcome = (await claim?.()) ?? "claimed";
+  if (outcome === "lost") {
+    throw new StorageMoveError(
+      "contended",
+      `${objectKey} is being moved or edited elsewhere; nothing was deleted`,
+    );
+  }
+  return outcome;
 }
 
 async function moveLocatedObject({
@@ -138,7 +158,7 @@ async function moveLocatedObject({
   destination,
   expectedSize,
   contentType,
-  stillWanted,
+  claim,
 }: {
   objectKey: string;
   to: StorageProvider;
@@ -146,7 +166,7 @@ async function moveLocatedObject({
   destination: StorageStore;
   expectedSize?: number;
   contentType?: string;
-  stillWanted?: () => Promise<boolean>;
+  claim?: () => Promise<StorageMoveClaim>;
 }): Promise<MoveOutcome> {
   const locations = await locateStorageObject(objectKey, stores);
   const atDestination = locations.find((location) => location.provider === to);
@@ -163,11 +183,14 @@ async function moveLocatedObject({
         `${objectKey} in ${to} is ${atDestination.size ?? "of unknown size"}, not the recorded ${expectedSize}`,
       );
     }
+    // Exactly one move may delete: an opposing move in another isolate that
+    // also saw both copies loses the claim and leaves them alone.
+    if ((await claimOrThrow(claim, objectKey)) === "gone") return { kind: "missing" };
     const removedFrom: StorageProvider[] = [];
     for (const location of elsewhere) {
       const store = stores.find((candidate) => candidate.provider === location.provider)!;
-      // An opposing move may have taken the destination copy since it was
-      // located; never remove the last copy.
+      // Never remove the last copy: check the destination copy once more
+      // right before deleting.
       const stillThere = await inspector(destination)(objectKey);
       if (!stillThere || !measuredAs(stillThere.size, atDestination.size)) {
         throw new StorageMoveError(
@@ -226,7 +249,7 @@ async function moveLocatedObject({
     );
   }
 
-  if (stillWanted && !(await stillWanted())) {
+  if ((await claimOrThrow(claim, objectKey)) === "gone") {
     // The record is gone; its deletion has already swept the stores, so the
     // copy written since is the only thing left and would otherwise leak.
     await remover(destination)(objectKey);
@@ -249,6 +272,8 @@ export type MovableFile = {
   objectKey: string;
   size: number;
   mimeType: string;
+  /** The record's version the claim compares against. */
+  updatedAt: Date;
   /** Opaque position of this file in the scan, handed back as `nextCursor`. */
   cursor: string;
 };
@@ -277,7 +302,7 @@ export async function moveStorageObjectsBatch({
   cursor,
   limits,
   onObjectChanged,
-  stillWanted,
+  claim,
   now = () => Date.now(),
 }: {
   to: StorageProvider;
@@ -291,8 +316,8 @@ export async function moveStorageObjectsBatch({
     file: MovableFile,
     outcome: Extract<MoveOutcome, { kind: "moved" | "already-there" }>,
   ) => Promise<void>;
-  /** See moveStorageObject; asked per file before its source is deleted. */
-  stillWanted?: (file: MovableFile) => Promise<boolean>;
+  /** See moveStorageObject; asked per file before anything is deleted. */
+  claim?: (file: MovableFile) => Promise<StorageMoveClaim>;
   now?: () => number;
 }): Promise<MoveBatchOutcome> {
   if (!stores.some((store) => store.provider === to)) {
@@ -358,11 +383,22 @@ export async function moveStorageObjectsBatch({
           stores,
           expectedSize: entry.file.size,
           contentType: entry.file.mimeType,
-          stillWanted: stillWanted ? () => stillWanted(entry.file) : undefined,
+          claim: claim ? () => claim(entry.file) : undefined,
         });
         if (result.kind === "moved") {
-          outcome.moved++;
           await onObjectChanged?.(entry.file, result);
+          if (result.sourceRemoved) {
+            outcome.moved++;
+          } else {
+            // The copy is in place, but the old store still holds one. Report
+            // it as unfinished so the old store is not decommissioned on the
+            // strength of a clean-looking batch; the next run removes it.
+            outcome.failed.push({
+              id: entry.file.id,
+              name: entry.file.name,
+              error: `copied to ${to} but the copy in ${result.from} could not be removed; run again`,
+            });
+          }
         } else if (result.kind === "already-there") {
           outcome.alreadyThere++;
           if (result.removedFrom.length > 0) await onObjectChanged?.(entry.file, result);

--- a/packages/api/src/storage/move-object.ts
+++ b/packages/api/src/storage/move-object.ts
@@ -109,19 +109,25 @@ export async function moveStorageObject({
   stores,
   expectedSize,
   contentType,
+  stillWanted,
 }: {
   objectKey: string;
   to: StorageProvider;
   stores: readonly StorageStore[];
   expectedSize?: number;
   contentType?: string;
+  /** Asked after the copy is verified and before the source is deleted. The
+   * file may have been deleted while the copy was in flight, in which case
+   * its deletion already removed every copy that existed at the time and the
+   * fresh copy must not survive it. */
+  stillWanted?: () => Promise<boolean>;
 }): Promise<MoveOutcome> {
   const destination = stores.find((store) => store.provider === to);
   if (!destination) {
     throw new StorageMoveError("no-destination", `The ${to} store is not configured`);
   }
   return await serialized(objectKey, () =>
-    moveLocatedObject({ objectKey, to, stores, destination, expectedSize, contentType }),
+    moveLocatedObject({ objectKey, to, stores, destination, expectedSize, contentType, stillWanted }),
   );
 }
 
@@ -132,6 +138,7 @@ async function moveLocatedObject({
   destination,
   expectedSize,
   contentType,
+  stillWanted,
 }: {
   objectKey: string;
   to: StorageProvider;
@@ -139,6 +146,7 @@ async function moveLocatedObject({
   destination: StorageStore;
   expectedSize?: number;
   contentType?: string;
+  stillWanted?: () => Promise<boolean>;
 }): Promise<MoveOutcome> {
   const locations = await locateStorageObject(objectKey, stores);
   const atDestination = locations.find((location) => location.provider === to);
@@ -218,6 +226,13 @@ async function moveLocatedObject({
     );
   }
 
+  if (stillWanted && !(await stillWanted())) {
+    // The record is gone; its deletion has already swept the stores, so the
+    // copy written since is the only thing left and would otherwise leak.
+    await remover(destination)(objectKey);
+    return { kind: "missing" };
+  }
+
   let sourceRemoved = true;
   try {
     await remover(source)(objectKey);
@@ -262,6 +277,7 @@ export async function moveStorageObjectsBatch({
   cursor,
   limits,
   onObjectChanged,
+  stillWanted,
   now = () => Date.now(),
 }: {
   to: StorageProvider;
@@ -275,6 +291,8 @@ export async function moveStorageObjectsBatch({
     file: MovableFile,
     outcome: Extract<MoveOutcome, { kind: "moved" | "already-there" }>,
   ) => Promise<void>;
+  /** See moveStorageObject; asked per file before its source is deleted. */
+  stillWanted?: (file: MovableFile) => Promise<boolean>;
   now?: () => number;
 }): Promise<MoveBatchOutcome> {
   if (!stores.some((store) => store.provider === to)) {
@@ -303,8 +321,11 @@ export async function moveStorageObjectsBatch({
       outcome.nextCursor = undefined;
       return outcome;
     }
+    // Only as many files as the scan limit still allows are looked up; the
+    // rest of the page is reached again through the cursor.
+    const remaining = Math.max(0, limits.scanned - outcome.scanned);
     const located = await Promise.all(
-      page.map(async (file) => {
+      page.slice(0, remaining).map(async (file) => {
         try {
           return { file, locations: await locateStorageObject(file.objectKey, stores) };
         } catch (error) {
@@ -337,6 +358,7 @@ export async function moveStorageObjectsBatch({
           stores,
           expectedSize: entry.file.size,
           contentType: entry.file.mimeType,
+          stillWanted: stillWanted ? () => stillWanted(entry.file) : undefined,
         });
         if (result.kind === "moved") {
           outcome.moved++;

--- a/packages/api/src/storage/move-object.ts
+++ b/packages/api/src/storage/move-object.ts
@@ -22,7 +22,17 @@ export type MoveOutcome =
   | { kind: "already-there"; to: StorageProvider; removedFrom: StorageProvider[] }
   | { kind: "missing" };
 
-export type StorageMoveClaim = "claimed" | "lost" | "gone";
+/**
+ * Durable coordination the caller provides for one file. The lease is held
+ * for the whole move so that moves of the same object in different isolates
+ * cannot interleave; `stillExists` guards against the file being deleted
+ * while the copy was in flight.
+ */
+export type StorageMoveLease = {
+  acquire(): Promise<"acquired" | "busy" | "gone">;
+  stillExists(): Promise<boolean>;
+  release(): Promise<void>;
+};
 
 export class StorageMoveError extends Error {
   readonly reason:
@@ -82,9 +92,13 @@ function measuredAs(observed: number | undefined, expected: number): boolean {
   return observed === expected;
 }
 
+// Measured, and equal to the record when the record says how large it is.
+function measuredAgainstRecord(observed: number | undefined, expected: number | undefined): boolean {
+  return observed !== undefined && sizeAgrees(observed, expected);
+}
+
 // Two moves of the same object in one isolate run one after the other. Across
-// isolates the caller's `claim` is what serializes them: a durable
-// compare-and-set that exactly one move wins before anything is deleted.
+// isolates the caller's lease is what serializes them.
 const inFlight = new Map<string, Promise<unknown>>();
 
 async function serialized<T>(objectKey: string, run: () => Promise<T>): Promise<T> {
@@ -111,44 +125,42 @@ export async function moveStorageObject({
   stores,
   expectedSize,
   contentType,
-  claim,
+  lease,
 }: {
   objectKey: string;
   to: StorageProvider;
   stores: readonly StorageStore[];
   expectedSize?: number;
   contentType?: string;
-  /**
-   * Asked once, right before the move deletes anything. It must be a durable
-   * compare-and-set on the file's record: "claimed" when this move won the
-   * right to delete, "lost" when another move (or an edit of the record)
-   * got there first, and "gone" when the record no longer exists. A file
-   * deleted while the copy was in flight has had every earlier copy swept
-   * by that deletion, so a fresh copy must not survive it.
-   */
-  claim?: () => Promise<StorageMoveClaim>;
+  lease?: StorageMoveLease;
 }): Promise<MoveOutcome> {
   const destination = stores.find((store) => store.provider === to);
   if (!destination) {
     throw new StorageMoveError("no-destination", `The ${to} store is not configured`);
   }
-  return await serialized(objectKey, () =>
-    moveLocatedObject({ objectKey, to, stores, destination, expectedSize, contentType, claim }),
-  );
-}
-
-async function claimOrThrow(
-  claim: (() => Promise<StorageMoveClaim>) | undefined,
-  objectKey: string,
-): Promise<"claimed" | "gone"> {
-  const outcome = (await claim?.()) ?? "claimed";
-  if (outcome === "lost") {
-    throw new StorageMoveError(
-      "contended",
-      `${objectKey} is being moved or edited elsewhere; nothing was deleted`,
-    );
-  }
-  return outcome;
+  return await serialized(objectKey, async () => {
+    const held = (await lease?.acquire()) ?? "acquired";
+    if (held === "gone") return { kind: "missing" };
+    if (held === "busy") {
+      throw new StorageMoveError(
+        "contended",
+        `${objectKey} is being moved elsewhere; nothing was changed`,
+      );
+    }
+    try {
+      return await moveLocatedObject({
+        objectKey,
+        to,
+        stores,
+        destination,
+        expectedSize,
+        contentType,
+        stillExists: lease?.stillExists,
+      });
+    } finally {
+      await lease?.release();
+    }
+  });
 }
 
 async function moveLocatedObject({
@@ -158,7 +170,7 @@ async function moveLocatedObject({
   destination,
   expectedSize,
   contentType,
-  claim,
+  stillExists,
 }: {
   objectKey: string;
   to: StorageProvider;
@@ -166,11 +178,24 @@ async function moveLocatedObject({
   destination: StorageStore;
   expectedSize?: number;
   contentType?: string;
-  claim?: () => Promise<StorageMoveClaim>;
+  stillExists?: () => Promise<boolean>;
 }): Promise<MoveOutcome> {
   const locations = await locateStorageObject(objectKey, stores);
-  const atDestination = locations.find((location) => location.provider === to);
+  let atDestination = locations.find((location) => location.provider === to);
   const elsewhere = locations.filter((location) => location.provider !== to);
+
+  if (
+    atDestination &&
+    elsewhere.length > 0 &&
+    !measuredAgainstRecord(atDestination.size, expectedSize) &&
+    elsewhere.some((location) => measuredAgainstRecord(location.size, expectedSize))
+  ) {
+    // A copy an earlier move wrote but never verified, next to a source that
+    // does match the record. It would shadow the good copy on reads, so it
+    // is replaced: removed here, then copied afresh below.
+    await remover(destination)(objectKey);
+    atDestination = undefined;
+  }
 
   if (atDestination) {
     if (elsewhere.length === 0) return { kind: "already-there", to, removedFrom: [] };
@@ -183,9 +208,6 @@ async function moveLocatedObject({
         `${objectKey} in ${to} is ${atDestination.size ?? "of unknown size"}, not the recorded ${expectedSize}`,
       );
     }
-    // Exactly one move may delete: an opposing move in another isolate that
-    // also saw both copies loses the claim and leaves them alone.
-    if ((await claimOrThrow(claim, objectKey)) === "gone") return { kind: "missing" };
     const removedFrom: StorageProvider[] = [];
     for (const location of elsewhere) {
       const store = stores.find((candidate) => candidate.provider === location.provider)!;
@@ -241,17 +263,26 @@ async function moveLocatedObject({
 
   const copied = await inspector(destination)(objectKey);
   if (!copied || !measuredAs(copied.size, size)) {
-    // Leave the source untouched and do not keep a copy of unknown shape.
-    await remover(destination)(objectKey).catch(() => undefined);
-    throw new StorageMoveError(
-      "verification-failed",
-      `${objectKey} was copied to ${to} but reads back as ${copied?.size ?? "absent"} rather than ${size} bytes`,
-    );
+    // Leave the source untouched and do not keep a copy of unknown shape. A
+    // copy that could not be removed is reported too: it would shadow the
+    // source on reads until the next run replaces it.
+    const problem = `${objectKey} was copied to ${to} but reads back as ${copied?.size ?? "absent"} rather than ${size} bytes`;
+    try {
+      await remover(destination)(objectKey);
+    } catch (error) {
+      throw new StorageMoveError(
+        "verification-failed",
+        `${problem}; removing that copy failed as well (${describe(error)}), run the move again`,
+      );
+    }
+    throw new StorageMoveError("verification-failed", problem);
   }
 
-  if ((await claimOrThrow(claim, objectKey)) === "gone") {
+  if (stillExists && !(await stillExists())) {
     // The record is gone; its deletion has already swept the stores, so the
     // copy written since is the only thing left and would otherwise leak.
+    // The caller's stillExists is expected to have queued a durable cleanup
+    // for the key, so a failure here is retried later.
     await remover(destination)(objectKey);
     return { kind: "missing" };
   }
@@ -272,8 +303,6 @@ export type MovableFile = {
   objectKey: string;
   size: number;
   mimeType: string;
-  /** The record's version the claim compares against. */
-  updatedAt: Date;
   /** Opaque position of this file in the scan, handed back as `nextCursor`. */
   cursor: string;
 };
@@ -302,7 +331,7 @@ export async function moveStorageObjectsBatch({
   cursor,
   limits,
   onObjectChanged,
-  claim,
+  lease,
   now = () => Date.now(),
 }: {
   to: StorageProvider;
@@ -316,8 +345,8 @@ export async function moveStorageObjectsBatch({
     file: MovableFile,
     outcome: Extract<MoveOutcome, { kind: "moved" | "already-there" }>,
   ) => Promise<void>;
-  /** See moveStorageObject; asked per file before anything is deleted. */
-  claim?: (file: MovableFile) => Promise<StorageMoveClaim>;
+  /** See moveStorageObject; one lease per file. */
+  lease?: (file: MovableFile) => StorageMoveLease;
   now?: () => number;
 }): Promise<MoveBatchOutcome> {
   if (!stores.some((store) => store.provider === to)) {
@@ -383,7 +412,7 @@ export async function moveStorageObjectsBatch({
           stores,
           expectedSize: entry.file.size,
           contentType: entry.file.mimeType,
-          claim: claim ? () => claim(entry.file) : undefined,
+          lease: lease?.(entry.file),
         });
         if (result.kind === "moved") {
           await onObjectChanged?.(entry.file, result);

--- a/packages/api/src/storage/move-object.ts
+++ b/packages/api/src/storage/move-object.ts
@@ -1,0 +1,297 @@
+// プロバイダ間でオブジェクトを移す。File 行は objectKey しか持たず、どの
+// ストアに実体があるかは HEAD で確かめる。移動は「コピー → 行き先を計測して
+// 確認 → 元を削除」の順で、確認が取れるまで元には触らない。
+import type { R2BucketLike } from "../ai/r2-provider";
+import type { StorageProvider, StorageStore } from "./bucket-from-env";
+
+export type ObjectLocation = {
+  provider: StorageProvider;
+  size: number | undefined;
+};
+
+export type MoveOutcome =
+  | {
+      kind: "moved";
+      from: StorageProvider;
+      to: StorageProvider;
+      size: number;
+      /** false when the copy succeeded but the source could not be deleted;
+       * running the move again finishes the job. */
+      sourceRemoved: boolean;
+    }
+  | { kind: "already-there"; to: StorageProvider; removedFrom: StorageProvider[] }
+  | { kind: "missing" };
+
+export class StorageMoveError extends Error {
+  readonly reason:
+    | "no-destination"
+    | "size-mismatch"
+    | "verification-failed"
+    | "unsupported";
+
+  constructor(reason: StorageMoveError["reason"], message: string) {
+    super(message);
+    this.name = "StorageMoveError";
+    this.reason = reason;
+  }
+}
+
+function inspector(store: StorageStore): NonNullable<R2BucketLike["head"]> {
+  if (!store.bucket.head) {
+    throw new StorageMoveError(
+      "unsupported",
+      `The ${store.provider} store cannot inspect objects`,
+    );
+  }
+  return store.bucket.head.bind(store.bucket);
+}
+
+function remover(store: StorageStore): NonNullable<R2BucketLike["delete"]> {
+  if (!store.bucket.delete) {
+    throw new StorageMoveError(
+      "unsupported",
+      `The ${store.provider} store cannot delete objects`,
+    );
+  }
+  return store.bucket.delete.bind(store.bucket);
+}
+
+/** Which configured stores hold the object, in store order. */
+export async function locateStorageObject(
+  objectKey: string,
+  stores: readonly StorageStore[],
+): Promise<ObjectLocation[]> {
+  const found = await Promise.all(
+    stores.map(async (store) => {
+      const object = await inspector(store)(objectKey);
+      return object ? { provider: store.provider, size: object.size } : null;
+    }),
+  );
+  return found.filter((location): location is ObjectLocation => location !== null);
+}
+
+function sizeAgrees(observed: number | undefined, expected: number | undefined): boolean {
+  return observed === undefined || expected === undefined || observed === expected;
+}
+
+/**
+ * Move one object into the `to` store from wherever it currently is.
+ *
+ * `expectedSize` is what the File record says; a source object of another
+ * size is refused rather than copied, since the record and the object then
+ * disagree and the move would only spread the disagreement.
+ */
+export async function moveStorageObject({
+  objectKey,
+  to,
+  stores,
+  expectedSize,
+  contentType,
+}: {
+  objectKey: string;
+  to: StorageProvider;
+  stores: readonly StorageStore[];
+  expectedSize?: number;
+  contentType?: string;
+}): Promise<MoveOutcome> {
+  const destination = stores.find((store) => store.provider === to);
+  if (!destination) {
+    throw new StorageMoveError("no-destination", `The ${to} store is not configured`);
+  }
+  const locations = await locateStorageObject(objectKey, stores);
+  const atDestination = locations.find((location) => location.provider === to);
+  const elsewhere = locations.filter((location) => location.provider !== to);
+
+  if (atDestination) {
+    if (elsewhere.length === 0) return { kind: "already-there", to, removedFrom: [] };
+    // A copy that a previous move left behind. Only remove it once the
+    // destination copy is known to be the right size.
+    if (!sizeAgrees(atDestination.size, expectedSize)) {
+      throw new StorageMoveError(
+        "size-mismatch",
+        `${objectKey} in ${to} is ${atDestination.size} bytes, not the recorded ${expectedSize}`,
+      );
+    }
+    const removedFrom: StorageProvider[] = [];
+    for (const location of elsewhere) {
+      const store = stores.find((candidate) => candidate.provider === location.provider)!;
+      await remover(store)(objectKey);
+      removedFrom.push(location.provider);
+    }
+    return { kind: "already-there", to, removedFrom };
+  }
+
+  const sourceLocation = elsewhere[0];
+  if (!sourceLocation) return { kind: "missing" };
+  const source = stores.find((store) => store.provider === sourceLocation.provider)!;
+  if (!source.bucket.get) {
+    throw new StorageMoveError(
+      "unsupported",
+      `The ${source.provider} store cannot read objects`,
+    );
+  }
+  if (!sizeAgrees(sourceLocation.size, expectedSize)) {
+    throw new StorageMoveError(
+      "size-mismatch",
+      `${objectKey} in ${source.provider} is ${sourceLocation.size} bytes, not the recorded ${expectedSize}`,
+    );
+  }
+
+  const object = await source.bucket.get(objectKey);
+  if (!object) return { kind: "missing" };
+  const size = object.size ?? sourceLocation.size ?? expectedSize;
+  if (size === undefined) {
+    throw new StorageMoveError(
+      "size-mismatch",
+      `${objectKey} in ${source.provider} has no measurable size`,
+    );
+  }
+  const body: ArrayBuffer | ReadableStream =
+    object.body ?? (object.arrayBuffer ? await object.arrayBuffer() : new ArrayBuffer(0));
+  await destination.bucket.put(objectKey, body, {
+    httpMetadata: contentType ? { contentType } : undefined,
+    contentLength: size,
+  });
+
+  const copied = await inspector(destination)(objectKey);
+  if (!copied || !sizeAgrees(copied.size, size)) {
+    // Leave the source untouched and do not keep a copy of unknown shape.
+    await remover(destination)(objectKey).catch(() => undefined);
+    throw new StorageMoveError(
+      "verification-failed",
+      `${objectKey} was copied to ${to} but reads back as ${copied?.size ?? "absent"} rather than ${size} bytes`,
+    );
+  }
+
+  let sourceRemoved = true;
+  try {
+    await remover(source)(objectKey);
+  } catch (error) {
+    console.error(`Moved ${objectKey} to ${to} but could not delete it from ${source.provider}`, error);
+    sourceRemoved = false;
+  }
+  return { kind: "moved", from: source.provider, to, size, sourceRemoved };
+}
+
+export type MovableFile = {
+  id: string;
+  name: string;
+  objectKey: string;
+  size: number;
+  mimeType: string;
+  /** Opaque position of this file in the scan, handed back as `nextCursor`. */
+  cursor: string;
+};
+
+export type MoveBatchOutcome = {
+  scanned: number;
+  moved: number;
+  alreadyThere: number;
+  missing: number;
+  failed: { id: string; name: string; error: string }[];
+  /** Resume point for the next call; undefined once every file was seen. */
+  nextCursor: string | undefined;
+  done: boolean;
+};
+
+/**
+ * Walk files page by page and bring each one into the `to` store, within a
+ * bounded amount of work so one call fits inside a request. Each page is
+ * located in parallel (only HEADs), while the copies run one at a time so a
+ * batch never holds more than one object in flight.
+ */
+export async function moveStorageObjectsBatch({
+  to,
+  stores,
+  nextPage,
+  cursor,
+  limits,
+  onMoved,
+  now = () => Date.now(),
+}: {
+  to: StorageProvider;
+  stores: readonly StorageStore[];
+  nextPage: (cursor: string | undefined) => Promise<MovableFile[]>;
+  cursor: string | undefined;
+  limits: { moves: number; scanned: number; milliseconds: number };
+  onMoved?: (file: MovableFile, outcome: Extract<MoveOutcome, { kind: "moved" }>) => Promise<void>;
+  now?: () => number;
+}): Promise<MoveBatchOutcome> {
+  if (!stores.some((store) => store.provider === to)) {
+    throw new StorageMoveError("no-destination", `The ${to} store is not configured`);
+  }
+  const deadline = now() + limits.milliseconds;
+  const outcome: MoveBatchOutcome = {
+    scanned: 0,
+    moved: 0,
+    alreadyThere: 0,
+    missing: 0,
+    failed: [],
+    nextCursor: cursor,
+    done: false,
+  };
+  const exhausted = () =>
+    outcome.moved >= limits.moves ||
+    outcome.scanned >= limits.scanned ||
+    now() >= deadline;
+
+  for (;;) {
+    const page = await nextPage(outcome.nextCursor);
+    if (page.length === 0) {
+      outcome.done = true;
+      outcome.nextCursor = undefined;
+      return outcome;
+    }
+    const located = await Promise.all(
+      page.map(async (file) => {
+        try {
+          return { file, locations: await locateStorageObject(file.objectKey, stores) };
+        } catch (error) {
+          return { file, error };
+        }
+      }),
+    );
+    for (const entry of located) {
+      if (exhausted()) return outcome;
+      outcome.scanned++;
+      outcome.nextCursor = entry.file.cursor;
+      if ("error" in entry) {
+        outcome.failed.push({ id: entry.file.id, name: entry.file.name, error: describe(entry.error) });
+        continue;
+      }
+      const settled =
+        entry.locations.length === 1 && entry.locations[0].provider === to;
+      if (settled) {
+        outcome.alreadyThere++;
+        continue;
+      }
+      if (entry.locations.length === 0) {
+        outcome.missing++;
+        continue;
+      }
+      try {
+        const result = await moveStorageObject({
+          objectKey: entry.file.objectKey,
+          to,
+          stores,
+          expectedSize: entry.file.size,
+          contentType: entry.file.mimeType,
+        });
+        if (result.kind === "moved") {
+          outcome.moved++;
+          await onMoved?.(entry.file, result);
+        } else if (result.kind === "already-there") {
+          outcome.alreadyThere++;
+        } else {
+          outcome.missing++;
+        }
+      } catch (error) {
+        outcome.failed.push({ id: entry.file.id, name: entry.file.name, error: describe(error) });
+      }
+    }
+  }
+}
+
+function describe(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/packages/api/src/storage/multipart-errors.ts
+++ b/packages/api/src/storage/multipart-errors.ts
@@ -1,0 +1,18 @@
+// Keep this module dependency-free: the layered bucket needs it without
+// pulling the database-backed upload reconcilers along.
+
+/**
+ * Whether a multipart operation failed because the service no longer knows
+ * the upload id: R2 reports error 10024, S3 compatible services NoSuchUpload.
+ * Both mean the handle was already completed or aborted, so retrying it can
+ * never succeed.
+ */
+export function isTerminalMultipartAbortError(error: unknown): boolean {
+  if (typeof error !== "object" || error === null) return false;
+  const record = error as Record<string, unknown>;
+  const code = String(record.code ?? record.name ?? "").toLowerCase();
+  if (code === "nosuchupload") return true;
+  return /(?:\(\s*10024\s*\)|\b10024)\s*$/u.test(
+    String(record.message ?? error),
+  );
+}

--- a/packages/api/src/storage/s3-compatible-bucket.ts
+++ b/packages/api/src/storage/s3-compatible-bucket.ts
@@ -1,0 +1,462 @@
+// S3 互換ストレージ (MinIO / AWS S3 / R2 の S3 API など) を R2 バインディングと
+// 同じ形 (R2BucketLike) で扱うためのアダプタ。署名は aws4fetch (SigV4) に任せ、
+// 本文はハッシュせず UNSIGNED-PAYLOAD で送るので、パートのストリームを
+// メモリに載せずにそのまま流せる。
+import { AwsClient } from "aws4fetch";
+import type { R2BucketLike, StorageStreamOptions } from "../ai/r2-provider";
+
+export type S3CompatibleBucketOptions = {
+  /** `https://host[:port][/prefix]` 形式のエンドポイント。 */
+  endpoint: string;
+  bucket: string;
+  /** 署名に使うリージョン。R2 と MinIO は `auto` を受け付ける。 */
+  region?: string;
+  accessKeyId: string;
+  secretAccessKey: string;
+  sessionToken?: string;
+  /** `https://endpoint/bucket/key` (既定) か `https://bucket.endpoint/key` か。 */
+  forcePathStyle?: boolean;
+  fetch?: typeof globalThis.fetch;
+};
+
+export class S3StorageError extends Error {
+  readonly operation: string;
+  readonly status: number;
+  readonly code: string | undefined;
+  readonly key: string;
+
+  constructor({
+    operation,
+    status,
+    code,
+    key,
+    detail,
+  }: {
+    operation: string;
+    status: number;
+    code?: string;
+    key: string;
+    detail?: string;
+  }) {
+    const parts = [`S3 ${operation} of ${key} failed with HTTP ${status}`];
+    if (code) parts.push(code);
+    if (detail) parts.push(detail);
+    super(parts.join(": "));
+    this.name = "S3StorageError";
+    this.operation = operation;
+    this.status = status;
+    this.code = code;
+    this.key = key;
+  }
+}
+
+const DEFAULT_REGION = "auto";
+const RETRY_ATTEMPTS = 3;
+const RETRY_BASE_MILLISECONDS = 100;
+const MAX_ERROR_BODY_BYTES = 64 * 1024;
+
+type BucketValue = ArrayBuffer | ReadableStream | string;
+
+type MultipartHandle = ReturnType<
+  NonNullable<R2BucketLike["resumeMultipartUpload"]>
+>;
+
+function trimTrailingSlashes(value: string): string {
+  return value.replace(/\/+$/u, "");
+}
+
+function encodeObjectKey(key: string): string {
+  if (key.length === 0) throw new TypeError("An object key must not be empty");
+  return key.split("/").map(encodeURIComponent).join("/");
+}
+
+function decodeXmlEntities(value: string): string {
+  return value.replace(
+    /&(#x[0-9a-fA-F]+|#[0-9]+|amp|lt|gt|quot|apos);/gu,
+    (_match, entity: string) => {
+      switch (entity) {
+        case "amp":
+          return "&";
+        case "lt":
+          return "<";
+        case "gt":
+          return ">";
+        case "quot":
+          return '"';
+        case "apos":
+          return "'";
+        default:
+          return String.fromCodePoint(
+            entity.startsWith("#x")
+              ? Number.parseInt(entity.slice(2), 16)
+              : Number.parseInt(entity.slice(1), 10),
+          );
+      }
+    },
+  );
+}
+
+function escapeXml(value: string): string {
+  return value
+    .replace(/&/gu, "&amp;")
+    .replace(/</gu, "&lt;")
+    .replace(/>/gu, "&gt;")
+    .replace(/"/gu, "&quot;")
+    .replace(/'/gu, "&apos;");
+}
+
+function xmlText(xml: string, tag: string): string | undefined {
+  const match = new RegExp(
+    `<(?:[A-Za-z0-9_-]+:)?${tag}(?:\\s[^>]*)?>([\\s\\S]*?)</(?:[A-Za-z0-9_-]+:)?${tag}>`,
+    "u",
+  ).exec(xml);
+  return match ? decodeXmlEntities(match[1].trim()) : undefined;
+}
+
+function hasXmlElement(xml: string, tag: string): boolean {
+  return new RegExp(`<(?:[A-Za-z0-9_-]+:)?${tag}(?:[\\s>/]|$)`, "u").test(xml);
+}
+
+function stripEtagQuotes(etag: string): string {
+  const trimmed = etag.trim();
+  return trimmed.startsWith('"') && trimmed.endsWith('"') && trimmed.length >= 2
+    ? trimmed.slice(1, -1)
+    : trimmed;
+}
+
+function contentLengthOf(response: Response): number | undefined {
+  const header = response.headers.get("content-length");
+  if (header === null) return undefined;
+  const size = Number(header);
+  return Number.isSafeInteger(size) && size >= 0 ? size : undefined;
+}
+
+async function readErrorBody(response: Response): Promise<string> {
+  if (!response.body) return "";
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  try {
+    while (total < MAX_ERROR_BODY_BYTES) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      chunks.push(value);
+      total += value.byteLength;
+    }
+    if (total >= MAX_ERROR_BODY_BYTES) {
+      await reader.cancel("error body limit exceeded");
+    }
+  } catch {
+    // A truncated error body still leaves the HTTP status to report.
+  } finally {
+    reader.releaseLock();
+  }
+  const combined = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    combined.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return new TextDecoder("utf-8").decode(
+    combined.subarray(0, MAX_ERROR_BODY_BYTES),
+  );
+}
+
+function isRetryableStatus(status: number): boolean {
+  return status === 429 || status >= 500;
+}
+
+// workerd exposes FixedLengthStream, whose length it turns into Content-Length
+// on the outgoing request. Elsewhere (Node, for `next dev` and tests) fetch
+// sends a stream chunked unless the header is given explicitly.
+type FixedLengthStreamConstructor = new (
+  length: number,
+) => TransformStream<Uint8Array, Uint8Array>;
+
+function withKnownLength(
+  value: BucketValue,
+  contentLength: number | undefined,
+): { body: BucketValue; headers: Record<string, string> } {
+  if (!(value instanceof ReadableStream) || contentLength === undefined) {
+    return { body: value, headers: {} };
+  }
+  if (!Number.isSafeInteger(contentLength) || contentLength < 0) {
+    throw new RangeError(`Invalid stream content length: ${contentLength}`);
+  }
+  const FixedLength = (globalThis as { FixedLengthStream?: FixedLengthStreamConstructor })
+    .FixedLengthStream;
+  if (typeof FixedLength === "function") {
+    return {
+      body: value.pipeThrough(new FixedLength(contentLength)),
+      headers: {},
+    };
+  }
+  return { body: value, headers: { "content-length": String(contentLength) } };
+}
+
+function sleep(milliseconds: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+export function createS3CompatibleBucket(
+  options: S3CompatibleBucketOptions,
+): R2BucketLike {
+  const endpoint = new URL(options.endpoint);
+  if (endpoint.protocol !== "https:" && endpoint.protocol !== "http:") {
+    throw new TypeError(
+      `The S3 endpoint must be an http(s) URL, received ${options.endpoint}`,
+    );
+  }
+  if (options.bucket.length === 0 || options.bucket.includes("/")) {
+    throw new TypeError(`Invalid S3 bucket name: ${options.bucket}`);
+  }
+  const bucketName = options.bucket;
+  const forcePathStyle = options.forcePathStyle ?? true;
+  const fetchImpl = options.fetch ?? globalThis.fetch;
+  const client = new AwsClient({
+    accessKeyId: options.accessKeyId,
+    secretAccessKey: options.secretAccessKey,
+    sessionToken: options.sessionToken,
+    service: "s3",
+    region: options.region ?? DEFAULT_REGION,
+  });
+
+  function objectUrl(key: string, query?: string): URL {
+    const url = new URL(endpoint.toString());
+    const prefix = trimTrailingSlashes(url.pathname);
+    if (forcePathStyle) {
+      url.pathname = `${prefix}/${encodeURIComponent(bucketName)}/${encodeObjectKey(key)}`;
+    } else {
+      url.hostname = `${bucketName}.${url.hostname}`;
+      url.pathname = `${prefix}/${encodeObjectKey(key)}`;
+    }
+    url.search = query ?? "";
+    return url;
+  }
+
+  async function failure(
+    operation: string,
+    key: string,
+    response: Response,
+  ): Promise<S3StorageError> {
+    const body = await readErrorBody(response);
+    return new S3StorageError({
+      operation,
+      key,
+      status: response.status,
+      code: xmlText(body, "Code"),
+      detail: xmlText(body, "Message"),
+    });
+  }
+
+  async function send({
+    method,
+    url,
+    headers,
+    body,
+  }: {
+    method: string;
+    url: URL;
+    headers?: Record<string, string>;
+    body?: BucketValue;
+  }): Promise<Response> {
+    // A stream can be sent once, so only buffered bodies get another attempt.
+    const attempts =
+      body instanceof ReadableStream ? 1 : RETRY_ATTEMPTS;
+    for (let attempt = 1; ; attempt++) {
+      const request = await client.sign(url.toString(), {
+        method,
+        headers,
+        body,
+      });
+      let response: Response;
+      try {
+        response = await fetchImpl(request);
+      } catch (error) {
+        if (attempt >= attempts) throw error;
+        await sleep(RETRY_BASE_MILLISECONDS * 2 ** (attempt - 1) * Math.random());
+        continue;
+      }
+      if (attempt < attempts && isRetryableStatus(response.status)) {
+        await response.body?.cancel().catch(() => undefined);
+        await sleep(RETRY_BASE_MILLISECONDS * 2 ** (attempt - 1) * Math.random());
+        continue;
+      }
+      return response;
+    }
+  }
+
+  async function head(key: string): Promise<{ size?: number } | null> {
+    const response = await send({
+      method: "HEAD",
+      url: objectUrl(key),
+    });
+    await response.body?.cancel().catch(() => undefined);
+    if (response.status === 404) return null;
+    if (!response.ok) {
+      throw new S3StorageError({ operation: "head", key, status: response.status });
+    }
+    return { size: contentLengthOf(response) };
+  }
+
+  function resumeMultipartUpload(key: string, uploadId: string): MultipartHandle {
+    const query = `?uploadId=${encodeURIComponent(uploadId)}`;
+    return {
+      async uploadPart(partNumber, value, partOptions?: StorageStreamOptions) {
+        if (!Number.isSafeInteger(partNumber) || partNumber < 1) {
+          throw new RangeError(`Invalid multipart part number: ${partNumber}`);
+        }
+        const sized = withKnownLength(value, partOptions?.contentLength);
+        const response = await send({
+          method: "PUT",
+          url: objectUrl(key, `?partNumber=${partNumber}&uploadId=${encodeURIComponent(uploadId)}`),
+          headers: sized.headers,
+          body: sized.body,
+        });
+        if (!response.ok) throw await failure("uploadPart", key, response);
+        await response.body?.cancel().catch(() => undefined);
+        const etag = response.headers.get("etag");
+        if (!etag) {
+          throw new S3StorageError({
+            operation: "uploadPart",
+            key,
+            status: response.status,
+            detail: "the response carried no ETag",
+          });
+        }
+        return { partNumber, etag: stripEtagQuotes(etag) };
+      },
+      async complete(parts) {
+        const body =
+          '<CompleteMultipartUpload xmlns="http://s3.amazonaws.com/doc/2006-03-01/">' +
+          parts
+            .map(
+              (part) =>
+                `<Part><PartNumber>${part.partNumber}</PartNumber>` +
+                `<ETag>${escapeXml(`"${stripEtagQuotes(part.etag)}"`)}</ETag></Part>`,
+            )
+            .join("") +
+          "</CompleteMultipartUpload>";
+        const response = await send({
+          method: "POST",
+          url: objectUrl(key, query),
+          headers: { "content-type": "application/xml" },
+          body,
+        });
+        if (!response.ok) {
+          throw await failure("completeMultipartUpload", key, response);
+        }
+        // S3 は結合に時間がかかると 200 を返した後で本文に <Error> を書く。
+        const text = await response.text();
+        if (hasXmlElement(text, "Error")) {
+          throw new S3StorageError({
+            operation: "completeMultipartUpload",
+            key,
+            status: response.status,
+            code: xmlText(text, "Code"),
+            detail: xmlText(text, "Message"),
+          });
+        }
+        if (!hasXmlElement(text, "CompleteMultipartUploadResult")) {
+          throw new S3StorageError({
+            operation: "completeMultipartUpload",
+            key,
+            status: response.status,
+            detail: "the response was not a CompleteMultipartUploadResult",
+          });
+        }
+        // 結合結果はサイズを返さないので、オブジェクトを見に行って測る。
+        const joined = await head(key);
+        if (!joined || typeof joined.size !== "number") {
+          throw new S3StorageError({
+            operation: "completeMultipartUpload",
+            key,
+            status: response.status,
+            detail: "the joined object could not be measured",
+          });
+        }
+        return { size: joined.size };
+      },
+      async abort() {
+        const response = await send({
+          method: "DELETE",
+          url: objectUrl(key, query),
+        });
+        if (response.status === 204 || response.status === 200) {
+          await response.body?.cancel().catch(() => undefined);
+          return;
+        }
+        throw await failure("abortMultipartUpload", key, response);
+      },
+    };
+  }
+
+  return {
+    async put(key, value, putOptions) {
+      const contentType = putOptions?.httpMetadata?.contentType;
+      const sized = withKnownLength(value, putOptions?.contentLength);
+      const response = await send({
+        method: "PUT",
+        url: objectUrl(key),
+        headers: {
+          ...sized.headers,
+          ...(contentType ? { "content-type": contentType } : {}),
+        },
+        body: sized.body,
+      });
+      if (!response.ok) throw await failure("put", key, response);
+      await response.body?.cancel().catch(() => undefined);
+      return { key, etag: stripEtagQuotes(response.headers.get("etag") ?? "") };
+    },
+    async get(key) {
+      const response = await send({
+        method: "GET",
+        url: objectUrl(key),
+      });
+      if (response.status === 404) {
+        await response.body?.cancel().catch(() => undefined);
+        return null;
+      }
+      if (!response.ok) throw await failure("get", key, response);
+      return {
+        body: response.body ?? undefined,
+        size: contentLengthOf(response),
+        arrayBuffer: () => response.arrayBuffer(),
+      };
+    },
+    async delete(key) {
+      const response = await send({
+        method: "DELETE",
+        url: objectUrl(key),
+      });
+      // R2 と同じく、無いものを消しても成功として扱う。
+      if (response.ok || response.status === 404) {
+        await response.body?.cancel().catch(() => undefined);
+        return;
+      }
+      throw await failure("delete", key, response);
+    },
+    head,
+    async createMultipartUpload(key, createOptions) {
+      const contentType = createOptions?.httpMetadata?.contentType;
+      const response = await send({
+        method: "POST",
+        url: objectUrl(key, "?uploads"),
+        headers: contentType ? { "content-type": contentType } : undefined,
+      });
+      if (!response.ok) throw await failure("createMultipartUpload", key, response);
+      const text = await response.text();
+      const uploadId = xmlText(text, "UploadId");
+      if (!uploadId) {
+        throw new S3StorageError({
+          operation: "createMultipartUpload",
+          key,
+          status: response.status,
+          detail: "the response carried no UploadId",
+        });
+      }
+      return { uploadId };
+    },
+    resumeMultipartUpload,
+  };
+}

--- a/packages/api/src/storage/s3-compatible-bucket.ts
+++ b/packages/api/src/storage/s3-compatible-bucket.ts
@@ -16,6 +16,9 @@ export type S3CompatibleBucketOptions = {
   sessionToken?: string;
   /** `https://endpoint/bucket/key` (既定) か `https://bucket.endpoint/key` か。 */
   forcePathStyle?: boolean;
+  /** 署名済み要求と資格情報を平文で送ることになるので、ローカルの MinIO など
+   * 開発用途に限って明示的に許す。 */
+  allowInsecureHttp?: boolean;
   fetch?: typeof globalThis.fetch;
 };
 
@@ -65,9 +68,16 @@ function trimTrailingSlashes(value: string): string {
   return value.replace(/\/+$/u, "");
 }
 
+// URL.pathname collapses "." and ".." segments, so a key containing them
+// would address a different object than the one recorded. No key this
+// service issues has such a segment; refuse rather than silently rewrite.
 function encodeObjectKey(key: string): string {
   if (key.length === 0) throw new TypeError("An object key must not be empty");
-  return key.split("/").map(encodeURIComponent).join("/");
+  const segments = key.split("/");
+  if (segments.some((segment) => segment === "" || segment === "." || segment === "..")) {
+    throw new TypeError(`Unsupported object key: ${key}`);
+  }
+  return segments.map(encodeURIComponent).join("/");
 }
 
 function decodeXmlEntities(value: string): string {
@@ -166,6 +176,17 @@ function isRetryableStatus(status: number): boolean {
   return status === 429 || status >= 500;
 }
 
+// Error codes S3 documents as transient. Anything else in a 200 completion
+// body describes the request itself and will not pass on a retry.
+const RETRYABLE_ERROR_CODES = new Set([
+  "InternalError",
+  "ServiceUnavailable",
+  "SlowDown",
+  "RequestTimeout",
+  "Throttling",
+  "ThrottlingException",
+]);
+
 // workerd exposes FixedLengthStream, whose length it turns into Content-Length
 // on the outgoing request. Elsewhere (Node, for `next dev` and tests) fetch
 // sends a stream chunked unless the header is given explicitly.
@@ -205,6 +226,11 @@ export function createS3CompatibleBucket(
   if (endpoint.protocol !== "https:" && endpoint.protocol !== "http:") {
     throw new TypeError(
       `The S3 endpoint must be an http(s) URL, received ${options.endpoint}`,
+    );
+  }
+  if (endpoint.protocol === "http:" && !options.allowInsecureHttp) {
+    throw new TypeError(
+      `The S3 endpoint ${options.endpoint} is not https; set allowInsecureHttp only for local development`,
     );
   }
   if (options.bucket.length === 0 || options.bucket.includes("/")) {
@@ -254,15 +280,18 @@ export function createS3CompatibleBucket(
     url,
     headers,
     body,
+    retry = true,
   }: {
     method: string;
     url: URL;
     headers?: Record<string, string>;
     body?: BucketValue;
+    /** Whether a transient failure may be tried again. A stream can be sent
+     * once, and a request whose success creates something the caller must
+     * be told about (a multipart upload id) must not be repeated blindly. */
+    retry?: boolean;
   }): Promise<Response> {
-    // A stream can be sent once, so only buffered bodies get another attempt.
-    const attempts =
-      body instanceof ReadableStream ? 1 : RETRY_ATTEMPTS;
+    const attempts = retry && !(body instanceof ReadableStream) ? RETRY_ATTEMPTS : 1;
     for (let attempt = 1; ; attempt++) {
       const request = await client.sign(url.toString(), {
         method,
@@ -291,11 +320,12 @@ export function createS3CompatibleBucket(
       method: "HEAD",
       url: objectUrl(key),
     });
-    await response.body?.cancel().catch(() => undefined);
-    if (response.status === 404) return null;
-    if (!response.ok) {
-      throw new S3StorageError({ operation: "head", key, status: response.status });
+    if (response.status === 404) {
+      await response.body?.cancel().catch(() => undefined);
+      return null;
     }
+    if (!response.ok) throw await failure("head", key, response);
+    await response.body?.cancel().catch(() => undefined);
     return { size: contentLengthOf(response) };
   }
 
@@ -337,23 +367,32 @@ export function createS3CompatibleBucket(
             )
             .join("") +
           "</CompleteMultipartUpload>";
-        const response = await send({
-          method: "POST",
-          url: objectUrl(key, query),
-          headers: { "content-type": "application/xml" },
-          body,
-        });
-        if (!response.ok) {
-          throw await failure("completeMultipartUpload", key, response);
-        }
+        let response: Response;
+        let text: string;
         // S3 は結合に時間がかかると 200 を返した後で本文に <Error> を書く。
-        const text = await response.text();
-        if (hasXmlElement(text, "Error")) {
+        // その中身が一時的な失敗なら、HTTP 5xx と同じように送り直す。
+        for (let attempt = 1; ; attempt++) {
+          response = await send({
+            method: "POST",
+            url: objectUrl(key, query),
+            headers: { "content-type": "application/xml" },
+            body,
+          });
+          if (!response.ok) {
+            throw await failure("completeMultipartUpload", key, response);
+          }
+          text = await response.text();
+          if (!hasXmlElement(text, "Error")) break;
+          const code = xmlText(text, "Code");
+          if (attempt < RETRY_ATTEMPTS && code !== undefined && RETRYABLE_ERROR_CODES.has(code)) {
+            await sleep(RETRY_BASE_MILLISECONDS * 2 ** (attempt - 1) * Math.random());
+            continue;
+          }
           throw new S3StorageError({
             operation: "completeMultipartUpload",
             key,
             status: response.status,
-            code: xmlText(text, "Code"),
+            code,
             detail: xmlText(text, "Message"),
           });
         }
@@ -406,7 +445,8 @@ export function createS3CompatibleBucket(
       });
       if (!response.ok) throw await failure("put", key, response);
       await response.body?.cancel().catch(() => undefined);
-      return { key, etag: stripEtagQuotes(response.headers.get("etag") ?? "") };
+      const etag = response.headers.get("etag");
+      return etag === null ? { key } : { key, etag: stripEtagQuotes(etag) };
     },
     async get(key) {
       const response = await send({
@@ -439,10 +479,13 @@ export function createS3CompatibleBucket(
     head,
     async createMultipartUpload(key, createOptions) {
       const contentType = createOptions?.httpMetadata?.contentType;
+      // A repeated initiation whose first answer was lost would leave an
+      // upload id nobody can abort, so this request is never tried twice.
       const response = await send({
         method: "POST",
         url: objectUrl(key, "?uploads"),
         headers: contentType ? { "content-type": contentType } : undefined,
+        retry: false,
       });
       if (!response.ok) throw await failure("createMultipartUpload", key, response);
       const text = await response.text();

--- a/packages/api/src/worker.ts
+++ b/packages/api/src/worker.ts
@@ -25,6 +25,7 @@ import {
   abandonStaleStorageUploads,
   reconcileStorageMultipartCleanups,
 } from "./storage-uploads";
+import { resolveStorageBucket } from "./storage/bucket-from-env";
 
 export interface Env {
   BEUTL_DATABASE_HYPERDRIVE: {
@@ -44,7 +45,17 @@ export interface Env {
   BEUTL_LATEST_VERSION?: string;
   BEUTL_REQUIRED_VERSION?: string;
   ADMIN_USER_IDS?: string;
+  // オブジェクトストレージ。既定は R2 バインディング。BEUTL_STORAGE_PROVIDER=s3
+  // のときは BEUTL_S3_* から S3 互換ストレージへ接続する (docs/deployment.md)。
   BEUTL_R2_BUCKET?: R2BucketLike;
+  BEUTL_STORAGE_PROVIDER?: string;
+  BEUTL_S3_ENDPOINT?: string;
+  BEUTL_S3_BUCKET?: string;
+  BEUTL_S3_REGION?: string;
+  BEUTL_S3_ACCESS_KEY_ID?: string;
+  BEUTL_S3_SECRET_ACCESS_KEY?: string;
+  BEUTL_S3_SESSION_TOKEN?: string;
+  BEUTL_S3_FORCE_PATH_STYLE?: string;
   STRIPE_SECRET_KEY?: string;
   OPENROUTER_API_KEY?: string;
   OPENROUTER_WEBHOOK_SECRET?: string;
@@ -79,9 +90,9 @@ function configureRuntime(env: Env): void {
     }
   }
   setDbProvider(createProvider(env));
-  if (env.BEUTL_R2_BUCKET) {
-    setR2BucketProvider(() => env.BEUTL_R2_BUCKET as R2BucketLike);
-  }
+  // 解決は最初のストレージ呼び出しまで遅らせる。ストレージを使わない
+  // ルートまで設定不備で落とさないため。
+  setR2BucketProvider(() => resolveStorageBucket(env));
 }
 
 // Only GET and HEAD are bodyless. Other methods may carry a body that the

--- a/packages/api/wrangler.jsonc
+++ b/packages/api/wrangler.jsonc
@@ -38,6 +38,10 @@
       "id": "34ad44345f2f45ea97c3608b0567a878"
     }
   ],
+  // MUST MATCH beutl-web: both Workers read and write the same objects.
+  // BEUTL_STORAGE_PROVIDER=s3 (vars) + BEUTL_S3_* (vars/secrets) sends new
+  // objects to S3 compatible storage; keep this binding so objects already in
+  // R2 stay readable. See docs/deployment.md#object-storage.
   "r2_buckets": [
     {
       "binding": "BEUTL_R2_BUCKET",

--- a/packages/db/src/audit-log.ts
+++ b/packages/db/src/audit-log.ts
@@ -61,6 +61,7 @@ export const auditLogActions = {
     storageUploadInterventionResumed: "admin.storageUploadInterventionResumed",
     storageUploadInterventionTerminalized: "admin.storageUploadInterventionTerminalized",
     packagePaymentRefundInterventionResumed: "admin.packagePaymentRefundInterventionResumed",
+    storageObjectMoved: "admin.storageObjectMoved",
   },
 } as const;
 

--- a/packages/db/src/file.ts
+++ b/packages/db/src/file.ts
@@ -693,6 +693,29 @@ export async function acquireFileStorageMoveLease({
   return exists ? "busy" : "gone";
 }
 
+// 持っているリースを確かめて延ばす。期限切れや別の持ち主なら false。
+// 移動は何かを消す直前に必ずこれを通し、負けていれば何も消さない。
+export async function renewFileStorageMoveLease({
+  id,
+  leaseToken,
+  now = new Date(),
+  leaseMilliseconds = FILE_STORAGE_MOVE_LEASE_MILLISECONDS,
+  prisma,
+}: {
+  id: string;
+  leaseToken: string;
+  now?: Date;
+  leaseMilliseconds?: number;
+  prisma?: PrismaTransaction;
+}): Promise<boolean> {
+  const db = prisma ?? (await getDb());
+  const renewed = await db.file.updateMany({
+    where: { id, storageMoveLeaseToken: leaseToken, storageMoveLeaseUntil: { gt: now } },
+    data: { storageMoveLeaseUntil: new Date(now.getTime() + leaseMilliseconds) },
+  });
+  return renewed.count === 1;
+}
+
 export async function releaseFileStorageMoveLease({
   id,
   leaseToken,

--- a/packages/db/src/file.ts
+++ b/packages/db/src/file.ts
@@ -654,8 +654,35 @@ const adminFileSelect = {
   mimeType: true,
   objectKey: true,
   createdAt: true,
+  updatedAt: true,
   user: { select: { id: true, email: true, name: true } },
 } as const;
+
+export type StorageMoveClaim = "claimed" | "lost" | "gone";
+
+// ストア間の移動で「削除してよいのはこの呼び出しだけ」を取るための CAS。
+// updatedAt を期待値付きで進めるので、別の isolate で同じファイルを動かして
+// いる移動や、その間の改名・削除があれば負ける。負けた側は何も消さない。
+export async function claimFileForStorageMove({
+  id,
+  expectedUpdatedAt,
+  now = new Date(),
+  prisma,
+}: {
+  id: string;
+  expectedUpdatedAt: Date;
+  now?: Date;
+  prisma?: PrismaTransaction;
+}): Promise<StorageMoveClaim> {
+  const db = prisma ?? (await getDb());
+  const updated = await db.file.updateMany({
+    where: { id, updatedAt: expectedUpdatedAt },
+    data: { updatedAt: now },
+  });
+  if (updated.count === 1) return "claimed";
+  const exists = await db.file.findUnique({ where: { id }, select: { id: true } });
+  return exists ? "lost" : "gone";
+}
 
 export type AdminFileOrder = "asc" | "desc";
 

--- a/packages/db/src/file.ts
+++ b/packages/db/src/file.ts
@@ -644,3 +644,92 @@ export async function createFileAndSettleStorageWrite({
   };
   return prisma ? run(prisma) : startRetryableTransaction(run);
 }
+
+// 管理画面のストレージ一覧。所有者を引けるようにし、古い順を既定にする
+// (プロバイダ切替前のファイルほど古いので、移動の対象を先頭に出す)。
+const adminFileSelect = {
+  id: true,
+  name: true,
+  size: true,
+  mimeType: true,
+  objectKey: true,
+  createdAt: true,
+  user: { select: { id: true, email: true, name: true } },
+} as const;
+
+export type AdminFileOrder = "asc" | "desc";
+
+export async function listFilesForAdmin({
+  query,
+  page,
+  pageSize,
+  order = "asc",
+  prisma,
+}: {
+  query?: string;
+  page: number;
+  pageSize: number;
+  order?: AdminFileOrder;
+  prisma?: PrismaTransaction;
+}) {
+  const db = prisma ?? (await getDb());
+  const queryMode = "insensitive" as const;
+  const where =
+    query && query.length > 0
+      ? {
+          OR: [
+            { name: { contains: query, mode: queryMode } },
+            { user: { email: { contains: query, mode: queryMode } } },
+          ],
+        }
+      : {};
+  const [items, total] = await Promise.all([
+    db.file.findMany({
+      where,
+      select: adminFileSelect,
+      // createdAt だけではページ境界で同時刻の行が重複・欠落するため id で確定させる。
+      orderBy: [{ createdAt: order }, { id: order }],
+      skip: (page - 1) * pageSize,
+      take: pageSize,
+    }),
+    db.file.count({ where }),
+  ]);
+  return { items, total };
+}
+
+// 一括移動の走査。(createdAt, id) の位置から古い順に次の一連を返す。
+export async function listFilesForAdminAfter({
+  after,
+  limit,
+  prisma,
+}: {
+  after?: { createdAt: Date; id: string };
+  limit: number;
+  prisma?: PrismaTransaction;
+}) {
+  const db = prisma ?? (await getDb());
+  return await db.file.findMany({
+    where: after
+      ? {
+          OR: [
+            { createdAt: { gt: after.createdAt } },
+            { createdAt: after.createdAt, id: { gt: after.id } },
+          ],
+        }
+      : {},
+    select: adminFileSelect,
+    orderBy: [{ createdAt: "asc" }, { id: "asc" }],
+    take: limit,
+  });
+}
+
+export async function findFileForAdminById({
+  id,
+  prisma,
+}: {
+  id: string;
+  prisma?: PrismaTransaction;
+}) {
+  const db = prisma ?? (await getDb());
+  return await db.file.findUnique({ where: { id }, select: adminFileSelect });
+}

--- a/packages/db/src/file.ts
+++ b/packages/db/src/file.ts
@@ -654,34 +654,71 @@ const adminFileSelect = {
   mimeType: true,
   objectKey: true,
   createdAt: true,
-  updatedAt: true,
   user: { select: { id: true, email: true, name: true } },
 } as const;
 
-export type StorageMoveClaim = "claimed" | "lost" | "gone";
+// ストア間の移動が持つ排他リース。取れるのは誰も持っていないか期限切れのとき
+// だけで、持っている間は別の isolate の移動が同じファイルに触れない。
+export const FILE_STORAGE_MOVE_LEASE_MILLISECONDS = 30 * 60 * 1000;
 
-// ストア間の移動で「削除してよいのはこの呼び出しだけ」を取るための CAS。
-// updatedAt を期待値付きで進めるので、別の isolate で同じファイルを動かして
-// いる移動や、その間の改名・削除があれば負ける。負けた側は何も消さない。
-export async function claimFileForStorageMove({
+export async function acquireFileStorageMoveLease({
   id,
-  expectedUpdatedAt,
+  leaseToken,
   now = new Date(),
+  leaseMilliseconds = FILE_STORAGE_MOVE_LEASE_MILLISECONDS,
   prisma,
 }: {
   id: string;
-  expectedUpdatedAt: Date;
+  leaseToken: string;
   now?: Date;
+  leaseMilliseconds?: number;
   prisma?: PrismaTransaction;
-}): Promise<StorageMoveClaim> {
+}): Promise<"acquired" | "busy" | "gone"> {
   const db = prisma ?? (await getDb());
   const updated = await db.file.updateMany({
-    where: { id, updatedAt: expectedUpdatedAt },
-    data: { updatedAt: now },
+    where: {
+      id,
+      OR: [
+        { storageMoveLeaseUntil: null },
+        { storageMoveLeaseUntil: { lte: now } },
+      ],
+    },
+    data: {
+      storageMoveLeaseToken: leaseToken,
+      storageMoveLeaseUntil: new Date(now.getTime() + leaseMilliseconds),
+    },
   });
-  if (updated.count === 1) return "claimed";
+  if (updated.count === 1) return "acquired";
   const exists = await db.file.findUnique({ where: { id }, select: { id: true } });
-  return exists ? "lost" : "gone";
+  return exists ? "busy" : "gone";
+}
+
+export async function releaseFileStorageMoveLease({
+  id,
+  leaseToken,
+  prisma,
+}: {
+  id: string;
+  leaseToken: string;
+  prisma?: PrismaTransaction;
+}): Promise<boolean> {
+  const db = prisma ?? (await getDb());
+  const released = await db.file.updateMany({
+    where: { id, storageMoveLeaseToken: leaseToken },
+    data: { storageMoveLeaseToken: null, storageMoveLeaseUntil: null },
+  });
+  return released.count === 1;
+}
+
+export async function existsFileById({
+  id,
+  prisma,
+}: {
+  id: string;
+  prisma?: PrismaTransaction;
+}): Promise<boolean> {
+  const db = prisma ?? (await getDb());
+  return (await db.file.findUnique({ where: { id }, select: { id: true } })) !== null;
 }
 
 export type AdminFileOrder = "asc" | "desc";

--- a/packages/i18n/src/locales/en/admin.json
+++ b/packages/i18n/src/locales/en/admin.json
@@ -4,6 +4,7 @@
     "users": "Users",
     "feedback": "Feedback",
     "ai": "AI",
+    "storage": "Storage",
     "auditLog": "Audit log",
     "signOut": "Sign out"
   },
@@ -383,6 +384,68 @@
       "saveSuccess": "Saved {{total}} settings",
       "saveFailed": "Failed to save the settings",
       "saveConflict": "The AI model settings changed elsewhere. Reload and review before saving."
+    }
+  },
+  "storage": {
+    "title": "Storage",
+    "description": "Where each file's object lives and how to move it between the configured stores. New uploads go to the primary store; a file missing from the primary is served from the other store.",
+    "stores": {
+      "heading": "Configured stores",
+      "primary": "Primary (new uploads)",
+      "fallback": "Also read from",
+      "none": "Not configured",
+      "configError": "Storage is not configured correctly: {{error}}"
+    },
+    "providers": {
+      "r2": "R2",
+      "s3": "S3"
+    },
+    "search": {
+      "placeholder": "Search by file name or owner email",
+      "submit": "Search",
+      "order": "Order",
+      "oldestFirst": "Oldest first",
+      "newestFirst": "Newest first"
+    },
+    "columns": {
+      "name": "File",
+      "owner": "Owner",
+      "size": "Size",
+      "createdAt": "Created",
+      "location": "Location",
+      "actions": "Actions"
+    },
+    "location": {
+      "missing": "Not found",
+      "unknown": "Could not check: {{error}}"
+    },
+    "noResults": "No files found",
+    "moveTo": "Move to {{provider}}",
+    "moving": "Moving",
+    "batch": {
+      "heading": "Move files in bulk",
+      "description": "Scans files from the oldest and moves every object that is not yet in the destination. Each run is bounded; keep running to continue from where the last run stopped.",
+      "destination": "Destination",
+      "run": "Move next batch",
+      "keepRunning": "Keep running until every file has been scanned",
+      "stop": "Stop after this batch",
+      "reset": "Start over from the oldest file",
+      "running": "Running",
+      "progress": "Scanned {{scanned}}, moved {{moved}}, already there {{alreadyThere}}, not found {{missing}}, failed {{failed}}",
+      "done": "Every file has been scanned.",
+      "paused": "Stopped. Run again to continue from the last file.",
+      "failures": "Failures"
+    },
+    "messages": {
+      "moved": "Moved {{name}} from {{from}} to {{to}}.",
+      "movedSourceLeft": "Copied {{name}} to {{to}}, but the copy in {{from}} could not be removed. Run the move again to remove it.",
+      "alreadyThere": "{{name}} is already in {{to}}.",
+      "missing": "No object was found for {{name}} in any store.",
+      "invalidInput": "Invalid request.",
+      "notConfigured": "That store is not configured.",
+      "unauthenticated": "You are signed out. Sign in again.",
+      "forbidden": "This account does not have administrator access.",
+      "failed": "The move failed."
     }
   },
   "category": {

--- a/packages/i18n/src/locales/en/admin.json
+++ b/packages/i18n/src/locales/en/admin.json
@@ -434,7 +434,8 @@
       "progress": "Scanned {{scanned}}, moved {{moved}}, already there {{alreadyThere}}, not found {{missing}}, failed {{failed}}",
       "done": "Every file has been scanned.",
       "paused": "Stopped. Run again to continue from the last file.",
-      "failures": "Failures"
+      "failures": "Failures",
+      "noProgress": "The last run made no progress; the store may be slow or unavailable. Run again to retry from the same file."
     },
     "messages": {
       "moved": "Moved {{name}} from {{from}} to {{to}}.",

--- a/packages/i18n/src/locales/ja/admin.json
+++ b/packages/i18n/src/locales/ja/admin.json
@@ -434,7 +434,8 @@
       "progress": "走査 {{scanned}} 件、移動 {{moved}} 件、移動済み {{alreadyThere}} 件、見つからず {{missing}} 件、失敗 {{failed}} 件",
       "done": "すべてのファイルを走査しました。",
       "paused": "停止しました。再実行すると最後のファイルの続きから進みます。",
-      "failures": "失敗"
+      "failures": "失敗",
+      "noProgress": "前回の実行は進みませんでした。ストアが遅いか利用できない可能性があります。再実行すると同じファイルからやり直します。"
     },
     "messages": {
       "moved": "{{name}} を {{from}} から {{to}} へ移動しました。",

--- a/packages/i18n/src/locales/ja/admin.json
+++ b/packages/i18n/src/locales/ja/admin.json
@@ -4,6 +4,7 @@
     "users": "ユーザー",
     "feedback": "フィードバック",
     "ai": "AI",
+    "storage": "ストレージ",
     "auditLog": "監査ログ",
     "signOut": "サインアウト"
   },
@@ -383,6 +384,68 @@
       "saveSuccess": "{{total}} 件の設定を保存しました",
       "saveFailed": "設定の保存に失敗しました",
       "saveConflict": "AI モデル設定が別の管理者によって変更されました。再読み込みして内容を確認してから保存してください。"
+    }
+  },
+  "storage": {
+    "title": "ストレージ",
+    "description": "各ファイルの実体がどのストアにあるかを確認し、設定済みのストア間で移動します。新しいアップロードは主ストアに保存され、主ストアに無いファイルはもう一方のストアから配信されます。",
+    "stores": {
+      "heading": "設定済みのストア",
+      "primary": "主ストア (新規アップロード先)",
+      "fallback": "読み取りの代替",
+      "none": "未設定",
+      "configError": "ストレージの設定に問題があります: {{error}}"
+    },
+    "providers": {
+      "r2": "R2",
+      "s3": "S3"
+    },
+    "search": {
+      "placeholder": "ファイル名または所有者のメールアドレスで検索",
+      "submit": "検索",
+      "order": "並び順",
+      "oldestFirst": "古い順",
+      "newestFirst": "新しい順"
+    },
+    "columns": {
+      "name": "ファイル",
+      "owner": "所有者",
+      "size": "サイズ",
+      "createdAt": "作成日",
+      "location": "所在",
+      "actions": "操作"
+    },
+    "location": {
+      "missing": "見つかりません",
+      "unknown": "確認できません: {{error}}"
+    },
+    "noResults": "ファイルが見つかりません",
+    "moveTo": "{{provider}} へ移動",
+    "moving": "移動中",
+    "batch": {
+      "heading": "まとめて移動",
+      "description": "古いファイルから順に走査し、移動先にまだ無いオブジェクトを移します。1 回の実行には上限があり、続けて実行すると前回の続きから進みます。",
+      "destination": "移動先",
+      "run": "次の一連を移動",
+      "keepRunning": "すべてのファイルを走査し終えるまで続ける",
+      "stop": "この一連で止める",
+      "reset": "最も古いファイルからやり直す",
+      "running": "実行中",
+      "progress": "走査 {{scanned}} 件、移動 {{moved}} 件、移動済み {{alreadyThere}} 件、見つからず {{missing}} 件、失敗 {{failed}} 件",
+      "done": "すべてのファイルを走査しました。",
+      "paused": "停止しました。再実行すると最後のファイルの続きから進みます。",
+      "failures": "失敗"
+    },
+    "messages": {
+      "moved": "{{name}} を {{from}} から {{to}} へ移動しました。",
+      "movedSourceLeft": "{{name}} を {{to}} へコピーしましたが、{{from}} 側の削除に失敗しました。もう一度移動を実行すると削除されます。",
+      "alreadyThere": "{{name}} は既に {{to}} にあります。",
+      "missing": "{{name}} のオブジェクトはどのストアにも見つかりません。",
+      "invalidInput": "不正な要求です。",
+      "notConfigured": "そのストアは設定されていません。",
+      "unauthenticated": "サインアウトしています。もう一度サインインしてください。",
+      "forbidden": "このアカウントには管理者権限がありません。",
+      "failed": "移動に失敗しました。"
     }
   },
   "category": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -296,6 +296,9 @@ importers:
       '@prisma/client':
         specifier: ^7.9.1
         version: 7.9.1(prisma@7.9.1(@types/react-dom@19.1.1(@types/react@19.1.0))(@types/react@19.1.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.7.3))(typescript@5.7.3)
+      aws4fetch:
+        specifier: ^1.0.20
+        version: 1.0.20
       country-to-currency:
         specifier: ^2.0.2
         version: 2.0.2

--- a/tests/contract/cloudflare-memory-footprint.test.ts
+++ b/tests/contract/cloudflare-memory-footprint.test.ts
@@ -30,8 +30,13 @@ describe("Cloudflare Worker memory footprint", () => {
 
     expect(apiPackage.exports?.["./ai/r2-provider"])
       .toBe("./src/ai/r2-provider.ts");
+    expect(apiPackage.exports?.["./storage/bucket-from-env"])
+      .toBe("./src/storage/bucket-from-env.ts");
     expect(prisma).toContain(
       'import { setR2BucketProvider } from "@beutl/api/ai/r2-provider";',
+    );
+    expect(prisma).toContain(
+      'import { resolveStorageBucket } from "@beutl/api/storage/bucket-from-env";',
     );
     expect(prisma).not.toMatch(/from "@beutl\/api"/u);
     expect(provider).not.toMatch(/^import\s/mu);

--- a/tests/contract/content-route-security.test.ts
+++ b/tests/contract/content-route-security.test.ts
@@ -1,5 +1,5 @@
-import { createRequire } from "node:module";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { setR2BucketProvider } from "@beutl/api/ai/r2-provider";
 
 const dbMocks = vi.hoisted(() => ({
   findFileForContentAccess: vi.fn(),
@@ -30,16 +30,7 @@ type ContentGet =
 let GET: ContentGet;
 
 beforeAll(async () => {
-  const requireFromWeb = createRequire(
-    new URL("../../apps/web/package.json", import.meta.url),
-  );
-  vi.doMock(requireFromWeb.resolve("@opennextjs/cloudflare"), () => ({
-    getCloudflareContext: () => ({
-      env: {
-        BEUTL_R2_BUCKET: bucketMocks,
-      },
-    }),
-  }));
+  setR2BucketProvider(() => bucketMocks as never);
   ({ GET } = await import(
     "../../apps/web/src/app/api/contents/[fileId]/route"
   ));

--- a/tests/contract/file-storage-move-lease.test.ts
+++ b/tests/contract/file-storage-move-lease.test.ts
@@ -4,6 +4,7 @@ import {
   existsFileById,
   FILE_STORAGE_MOVE_LEASE_MILLISECONDS,
   releaseFileStorageMoveLease,
+  renewFileStorageMoveLease,
 } from "../../packages/db/src/file";
 
 const now = new Date("2026-09-09T00:00:00.000Z");
@@ -36,6 +37,17 @@ describe("the lease a storage move holds on a File row", () => {
     const prisma = { file: { updateMany, findUnique } } as never;
     expect(await acquireFileStorageMoveLease({ id: "file-1", leaseToken: "t", now, prisma })).toBe("busy");
     expect(await acquireFileStorageMoveLease({ id: "file-1", leaseToken: "t", now, prisma })).toBe("gone");
+  });
+
+  it("renews only a lease it still holds and that has not run out", async () => {
+    const updateMany = vi.fn().mockResolvedValueOnce({ count: 1 }).mockResolvedValueOnce({ count: 0 });
+    const prisma = { file: { updateMany } } as never;
+    expect(await renewFileStorageMoveLease({ id: "file-1", leaseToken: "t", now, prisma })).toBe(true);
+    expect(updateMany).toHaveBeenCalledWith({
+      where: { id: "file-1", storageMoveLeaseToken: "t", storageMoveLeaseUntil: { gt: now } },
+      data: { storageMoveLeaseUntil: new Date(now.getTime() + FILE_STORAGE_MOVE_LEASE_MILLISECONDS) },
+    });
+    expect(await renewFileStorageMoveLease({ id: "file-1", leaseToken: "t", now, prisma })).toBe(false);
   });
 
   it("releases only the lease it holds", async () => {

--- a/tests/contract/file-storage-move-lease.test.ts
+++ b/tests/contract/file-storage-move-lease.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  acquireFileStorageMoveLease,
+  existsFileById,
+  FILE_STORAGE_MOVE_LEASE_MILLISECONDS,
+  releaseFileStorageMoveLease,
+} from "../../packages/db/src/file";
+
+const now = new Date("2026-09-09T00:00:00.000Z");
+
+describe("the lease a storage move holds on a File row", () => {
+  it("is taken only when nobody holds it or the holder's time is up", async () => {
+    const updateMany = vi.fn().mockResolvedValue({ count: 1 });
+    const outcome = await acquireFileStorageMoveLease({
+      id: "file-1",
+      leaseToken: "token-1",
+      now,
+      prisma: { file: { updateMany } } as never,
+    });
+    expect(outcome).toBe("acquired");
+    expect(updateMany).toHaveBeenCalledWith({
+      where: {
+        id: "file-1",
+        OR: [{ storageMoveLeaseUntil: null }, { storageMoveLeaseUntil: { lte: now } }],
+      },
+      data: {
+        storageMoveLeaseToken: "token-1",
+        storageMoveLeaseUntil: new Date(now.getTime() + FILE_STORAGE_MOVE_LEASE_MILLISECONDS),
+      },
+    });
+  });
+
+  it("tells a held lease apart from a deleted file", async () => {
+    const updateMany = vi.fn().mockResolvedValue({ count: 0 });
+    const findUnique = vi.fn().mockResolvedValueOnce({ id: "file-1" }).mockResolvedValueOnce(null);
+    const prisma = { file: { updateMany, findUnique } } as never;
+    expect(await acquireFileStorageMoveLease({ id: "file-1", leaseToken: "t", now, prisma })).toBe("busy");
+    expect(await acquireFileStorageMoveLease({ id: "file-1", leaseToken: "t", now, prisma })).toBe("gone");
+  });
+
+  it("releases only the lease it holds", async () => {
+    const updateMany = vi.fn().mockResolvedValue({ count: 0 });
+    expect(await releaseFileStorageMoveLease({ id: "file-1", leaseToken: "t", prisma: { file: { updateMany } } as never })).toBe(false);
+    expect(updateMany).toHaveBeenCalledWith({
+      where: { id: "file-1", storageMoveLeaseToken: "t" },
+      data: { storageMoveLeaseToken: null, storageMoveLeaseUntil: null },
+    });
+  });
+
+  it("reports whether the row still exists", async () => {
+    const findUnique = vi.fn().mockResolvedValueOnce({ id: "file-1" }).mockResolvedValueOnce(null);
+    const prisma = { file: { findUnique } } as never;
+    expect(await existsFileById({ id: "file-1", prisma })).toBe(true);
+    expect(await existsFileById({ id: "file-1", prisma })).toBe(false);
+  });
+});

--- a/tests/contract/storage-bucket-from-env.test.ts
+++ b/tests/contract/storage-bucket-from-env.test.ts
@@ -1,0 +1,129 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  configuredStorageProviders,
+  createStorageBucket,
+  resolveStorageBucket,
+  storageProviderOf,
+} from "@beutl/api";
+
+const binding = { put: vi.fn(), get: vi.fn(), delete: vi.fn(), head: vi.fn() };
+
+const s3Env = {
+  BEUTL_STORAGE_PROVIDER: "s3",
+  BEUTL_S3_ENDPOINT: "https://s3.example.test",
+  BEUTL_S3_BUCKET: "beutl",
+  BEUTL_S3_ACCESS_KEY_ID: "AKIAEXAMPLE",
+  BEUTL_S3_SECRET_ACCESS_KEY: "secret",
+};
+
+describe("choosing the storage provider from the environment", () => {
+  beforeEach(() => {
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+    binding.put.mockReset();
+    binding.get.mockReset();
+  });
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+  });
+
+  it("uses the R2 binding when nothing else is configured", () => {
+    expect(storageProviderOf({})).toBe("r2");
+    expect(createStorageBucket({ BEUTL_R2_BUCKET: binding })).toBe(binding);
+  });
+
+  it("explains a missing R2 binding instead of falling back", () => {
+    expect(() => createStorageBucket({})).toThrow(/BEUTL_R2_BUCKET binding not found/u);
+  });
+
+  it("rejects an unknown provider name", () => {
+    expect(() => createStorageBucket({ BEUTL_STORAGE_PROVIDER: "gcs", BEUTL_R2_BUCKET: binding }))
+      .toThrow(/BEUTL_STORAGE_PROVIDER must be one of r2, s3/u);
+  });
+
+  it("names every S3 value that is missing", () => {
+    expect(() => createStorageBucket({ BEUTL_STORAGE_PROVIDER: "s3" }))
+      .toThrow(/BEUTL_S3_ENDPOINT is required for S3 compatible storage/u);
+    expect(() => createStorageBucket({ ...s3Env, BEUTL_S3_SECRET_ACCESS_KEY: "  " }))
+      .toThrow(/BEUTL_S3_SECRET_ACCESS_KEY is required/u);
+    expect(() => createStorageBucket({ ...s3Env, BEUTL_S3_FORCE_PATH_STYLE: "maybe" }))
+      .toThrow(/BEUTL_S3_FORCE_PATH_STYLE must be true or false/u);
+  });
+
+  it("talks to the configured S3 endpoint and ignores the R2 binding", async () => {
+    const fetchMock = vi.fn(async () => new Response(null, { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+    const bucket = createStorageBucket({ ...s3Env, BEUTL_R2_BUCKET: binding });
+    expect(bucket).not.toBe(binding);
+
+    await bucket.put("k", "v");
+    expect(binding.put).not.toHaveBeenCalled();
+    const request = fetchMock.mock.calls[0][0] as unknown as Request;
+    expect(request.url).toBe("https://s3.example.test/beutl/k");
+    expect(request.headers.get("authorization")).toMatch(/\/auto\/s3\/aws4_request/u);
+  });
+
+  it("falls back to process.env for values the binding env lacks", () => {
+    vi.stubEnv("BEUTL_STORAGE_PROVIDER", "s3");
+    vi.stubEnv("BEUTL_S3_ENDPOINT", s3Env.BEUTL_S3_ENDPOINT);
+    vi.stubEnv("BEUTL_S3_BUCKET", s3Env.BEUTL_S3_BUCKET);
+    vi.stubEnv("BEUTL_S3_ACCESS_KEY_ID", s3Env.BEUTL_S3_ACCESS_KEY_ID);
+    vi.stubEnv("BEUTL_S3_SECRET_ACCESS_KEY", s3Env.BEUTL_S3_SECRET_ACCESS_KEY);
+    expect(storageProviderOf({})).toBe("s3");
+    expect(() => createStorageBucket({})).not.toThrow();
+  });
+
+  it("prefers the binding env over process.env", () => {
+    vi.stubEnv("BEUTL_STORAGE_PROVIDER", "s3");
+    expect(storageProviderOf({ BEUTL_STORAGE_PROVIDER: "r2" })).toBe("r2");
+  });
+
+  it("keeps reading from R2 after new objects move to S3", async () => {
+    const fetchMock = vi.fn(async (request: Request) =>
+      new Response(null, { status: request.method === "GET" ? 404 : 200 }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    binding.get.mockResolvedValueOnce({ size: 5 });
+    const env = { ...s3Env, BEUTL_R2_BUCKET: binding };
+    expect(configuredStorageProviders(env)).toEqual(["s3", "r2"]);
+
+    const bucket = createStorageBucket(env);
+    expect(await bucket.get!("old-key")).toEqual({ size: 5 });
+    expect((fetchMock.mock.calls[0][0] as unknown as Request).url).toBe("https://s3.example.test/beutl/old-key");
+    expect(binding.get).toHaveBeenCalledWith("old-key");
+
+    await bucket.put("new-key", "v");
+    expect(binding.put).not.toHaveBeenCalled();
+  });
+
+  it("keeps reading from S3 after new objects move back to R2", async () => {
+    const fetchMock = vi.fn(async () => new Response(null, { status: 200, headers: { "content-length": "3" } }));
+    vi.stubGlobal("fetch", fetchMock);
+    const env = { ...s3Env, BEUTL_STORAGE_PROVIDER: "r2", BEUTL_R2_BUCKET: binding };
+    expect(configuredStorageProviders(env)).toEqual(["r2", "s3"]);
+
+    const bucket = createStorageBucket(env);
+    binding.get.mockResolvedValueOnce(null);
+    expect(await bucket.get!("s3-key")).toMatchObject({ size: 3 });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses the primary alone when the other provider is absent", () => {
+    expect(configuredStorageProviders({ BEUTL_R2_BUCKET: binding })).toEqual(["r2"]);
+    expect(configuredStorageProviders(s3Env)).toEqual(["s3"]);
+    expect(createStorageBucket({ BEUTL_R2_BUCKET: binding })).toBe(binding);
+  });
+
+  it("refuses a half-configured fallback rather than skipping it", () => {
+    expect(() => createStorageBucket({ BEUTL_R2_BUCKET: binding, BEUTL_S3_ENDPOINT: "https://s3.example.test" }))
+      .toThrow(/BEUTL_S3_BUCKET is required/u);
+  });
+
+  it("builds one bucket per env object", () => {
+    const env = { ...s3Env };
+    const first = resolveStorageBucket(env);
+    expect(resolveStorageBucket(env)).toBe(first);
+    expect(resolveStorageBucket({ ...s3Env })).not.toBe(first);
+  });
+});

--- a/tests/contract/storage-bucket-from-env.test.ts
+++ b/tests/contract/storage-bucket-from-env.test.ts
@@ -115,6 +115,12 @@ describe("choosing the storage provider from the environment", () => {
     expect(createStorageBucket({ BEUTL_R2_BUCKET: binding })).toBe(binding);
   });
 
+  it("only allows a plain http endpoint when the setting says so", () => {
+    const insecure = { ...s3Env, BEUTL_S3_ENDPOINT: "http://minio.local:9000" };
+    expect(() => createStorageBucket(insecure)).toThrow(/not https/u);
+    expect(() => createStorageBucket({ ...insecure, BEUTL_S3_ALLOW_INSECURE_HTTP: "true" })).not.toThrow();
+  });
+
   it("refuses a half-configured fallback rather than skipping it", () => {
     expect(() => createStorageBucket({ BEUTL_R2_BUCKET: binding, BEUTL_S3_ENDPOINT: "https://s3.example.test" }))
       .toThrow(/BEUTL_S3_BUCKET is required/u);

--- a/tests/contract/storage-layered-bucket.test.ts
+++ b/tests/contract/storage-layered-bucket.test.ts
@@ -1,0 +1,125 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createLayeredBucket, type R2BucketLike } from "@beutl/api";
+
+function fakeBucket() {
+  const handle = {
+    uploadPart: vi.fn(async (partNumber: number) => ({ partNumber, etag: "e" })),
+    complete: vi.fn(async () => ({ size: 1 })),
+    abort: vi.fn(async () => undefined),
+  };
+  const bucket = {
+    put: vi.fn(async () => ({ stored: true })),
+    get: vi.fn(async () => null as { size?: number } | null),
+    head: vi.fn(async () => null as { size?: number } | null),
+    delete: vi.fn(async () => undefined),
+    createMultipartUpload: vi.fn(async () => ({ uploadId: "id" })),
+    resumeMultipartUpload: vi.fn(() => handle),
+  };
+  return { bucket, handle };
+}
+
+const missing = () => Object.assign(new Error("R2 multipart error (10024)"), { code: "NoSuchUpload" });
+
+describe("a bucket layered over the store objects used to live in", () => {
+  let primary: ReturnType<typeof fakeBucket>;
+  let fallback: ReturnType<typeof fakeBucket>;
+  let layered: R2BucketLike;
+
+  beforeEach(() => {
+    primary = fakeBucket();
+    fallback = fakeBucket();
+    layered = createLayeredBucket({
+      primary: primary.bucket as unknown as R2BucketLike,
+      fallback: fallback.bucket as unknown as R2BucketLike,
+    });
+  });
+
+  it("writes only to the primary", async () => {
+    const value = new Uint8Array([1]).buffer;
+    await layered.put("k", value, { httpMetadata: { contentType: "text/plain" } });
+    await layered.createMultipartUpload!("k", { httpMetadata: { contentType: "video/mp4" } });
+    expect(primary.bucket.put).toHaveBeenCalledWith("k", value, { httpMetadata: { contentType: "text/plain" } });
+    expect(primary.bucket.createMultipartUpload).toHaveBeenCalledWith("k", { httpMetadata: { contentType: "video/mp4" } });
+    expect(fallback.bucket.put).not.toHaveBeenCalled();
+    expect(fallback.bucket.createMultipartUpload).not.toHaveBeenCalled();
+  });
+
+  it("reads from the fallback only when the primary has no such object", async () => {
+    primary.bucket.get.mockResolvedValueOnce({ size: 3 });
+    expect(await layered.get!("new")).toEqual({ size: 3 });
+    expect(fallback.bucket.get).not.toHaveBeenCalled();
+
+    fallback.bucket.get.mockResolvedValueOnce({ size: 7 });
+    expect(await layered.get!("old")).toEqual({ size: 7 });
+    expect(fallback.bucket.get).toHaveBeenCalledWith("old");
+
+    expect(await layered.get!("gone")).toBeNull();
+  });
+
+  it("measures through the same order as it reads", async () => {
+    fallback.bucket.head.mockResolvedValueOnce({ size: 9 });
+    expect(await layered.head!("old")).toEqual({ size: 9 });
+    expect(primary.bucket.head).toHaveBeenCalledWith("old");
+    expect(await layered.head!("gone")).toBeNull();
+  });
+
+  it("does not hide a failing primary behind the fallback", async () => {
+    primary.bucket.get.mockRejectedValueOnce(new Error("primary down"));
+    fallback.bucket.get.mockResolvedValueOnce({ size: 1 });
+    await expect(layered.get!("k")).rejects.toThrow("primary down");
+    expect(fallback.bucket.get).not.toHaveBeenCalled();
+  });
+
+  it("deletes from both stores", async () => {
+    await layered.delete!("k");
+    expect(primary.bucket.delete).toHaveBeenCalledWith("k");
+    expect(fallback.bucket.delete).toHaveBeenCalledWith("k");
+
+    fallback.bucket.delete.mockRejectedValueOnce(new Error("fallback down"));
+    await expect(layered.delete!("k")).rejects.toThrow("fallback down");
+  });
+
+  it("finishes or abandons a handle the primary never opened", async () => {
+    primary.handle.complete.mockRejectedValueOnce(missing());
+    fallback.handle.complete.mockResolvedValueOnce({ size: 42 });
+    const handle = layered.resumeMultipartUpload!("k", "old-upload");
+    expect(await handle.complete([{ partNumber: 1, etag: "e" }])).toEqual({ size: 42 });
+    expect(fallback.handle.complete).toHaveBeenCalledWith([{ partNumber: 1, etag: "e" }]);
+
+    primary.handle.abort.mockRejectedValueOnce(missing());
+    await expect(handle.abort()).resolves.toBeUndefined();
+    expect(fallback.handle.abort).toHaveBeenCalled();
+  });
+
+  it("reports the primary's terminal error when neither store knows the handle", async () => {
+    const original = missing();
+    primary.handle.abort.mockRejectedValueOnce(original);
+    fallback.handle.abort.mockRejectedValueOnce(missing());
+    await expect(layered.resumeMultipartUpload!("k", "id").abort()).rejects.toBe(original);
+  });
+
+  it("passes other multipart failures through untouched", async () => {
+    primary.handle.complete.mockRejectedValueOnce(new Error("EntityTooSmall"));
+    await expect(layered.resumeMultipartUpload!("k", "id").complete([])).rejects.toThrow("EntityTooSmall");
+    expect(fallback.handle.complete).not.toHaveBeenCalled();
+  });
+
+  it("never replays a part against the fallback", async () => {
+    primary.handle.uploadPart.mockRejectedValueOnce(missing());
+    const stream = new ReadableStream<Uint8Array>();
+    await expect(layered.resumeMultipartUpload!("k", "id").uploadPart(1, stream, { contentLength: 0 }))
+      .rejects.toMatchObject({ code: "NoSuchUpload" });
+    expect(primary.handle.uploadPart).toHaveBeenCalledWith(1, stream, { contentLength: 0 });
+    expect(fallback.handle.uploadPart).not.toHaveBeenCalled();
+  });
+
+  it("offers only what the primary can do", () => {
+    const readOnly = createLayeredBucket({
+      primary: { put: primary.bucket.put, get: primary.bucket.get } as unknown as R2BucketLike,
+      fallback: fallback.bucket as unknown as R2BucketLike,
+    });
+    expect(readOnly.delete).toBeUndefined();
+    expect(readOnly.head).toBeUndefined();
+    expect(readOnly.resumeMultipartUpload).toBeUndefined();
+  });
+});

--- a/tests/contract/storage-layered-bucket.test.ts
+++ b/tests/contract/storage-layered-bucket.test.ts
@@ -70,13 +70,17 @@ describe("a bucket layered over the store objects used to live in", () => {
     expect(fallback.bucket.get).not.toHaveBeenCalled();
   });
 
-  it("deletes from both stores", async () => {
+  it("deletes from both stores even when one of them fails", async () => {
     await layered.delete!("k");
     expect(primary.bucket.delete).toHaveBeenCalledWith("k");
     expect(fallback.bucket.delete).toHaveBeenCalledWith("k");
 
     fallback.bucket.delete.mockRejectedValueOnce(new Error("fallback down"));
     await expect(layered.delete!("k")).rejects.toThrow("fallback down");
+
+    primary.bucket.delete.mockRejectedValueOnce(new Error("primary down"));
+    await expect(layered.delete!("k")).rejects.toThrow("primary down");
+    expect(fallback.bucket.delete).toHaveBeenCalledTimes(3);
   });
 
   it("finishes or abandons a handle the primary never opened", async () => {
@@ -89,6 +93,18 @@ describe("a bucket layered over the store objects used to live in", () => {
     primary.handle.abort.mockRejectedValueOnce(missing());
     await expect(handle.abort()).resolves.toBeUndefined();
     expect(fallback.handle.abort).toHaveBeenCalled();
+  });
+
+  it("aborts in both stores even when the primary claims success", async () => {
+    // MinIO answers 204 for an id it never issued; the stale R2 handle must
+    // still be aborted.
+    const handle = layered.resumeMultipartUpload!("k", "old-upload");
+    await expect(handle.abort()).resolves.toBeUndefined();
+    expect(primary.handle.abort).toHaveBeenCalledTimes(1);
+    expect(fallback.handle.abort).toHaveBeenCalledTimes(1);
+
+    fallback.handle.abort.mockRejectedValueOnce(new Error("fallback down"));
+    await expect(handle.abort()).rejects.toThrow("fallback down");
   });
 
   it("reports the primary's terminal error when neither store knows the handle", async () => {

--- a/tests/contract/storage-move-object.test.ts
+++ b/tests/contract/storage-move-object.test.ts
@@ -161,6 +161,22 @@ describe("moving one object between stores", () => {
     expect(r2.data.has("key")).toBe(true);
   });
 
+  it("drops the fresh copy when the file was deleted while it was in flight", async () => {
+    const s3 = memoryStore("s3");
+    const r2 = memoryStore("r2", { key: bytes(8, 14) });
+    const outcome = await moveStorageObject({
+      objectKey: "key",
+      to: "s3",
+      stores: [s3.store, r2.store],
+      expectedSize: 8,
+      stillWanted: async () => false,
+    });
+    expect(outcome).toEqual({ kind: "missing" });
+    expect(s3.data.has("key")).toBe(false);
+    // The file's own deletion is what sweeps the source; the move leaves it.
+    expect(r2.bucket.delete).not.toHaveBeenCalled();
+  });
+
   it("reports an object that no store holds", async () => {
     const s3 = memoryStore("s3");
     const r2 = memoryStore("r2");
@@ -311,6 +327,27 @@ describe("moving files in bulk", () => {
     });
     expect(second).toMatchObject({ moved: 4, scanned: 4, nextCursor: undefined, done: true });
     expect(s3.data.size).toBe(6);
+  });
+
+  it("looks up no more files than the scan limit allows", async () => {
+    const all = files(5);
+    const r2 = memoryStore("r2", Object.fromEntries(all.map((file, index) => [file.objectKey, bytes(4, index)])));
+    const s3 = memoryStore("s3");
+    const asked: string[] = [];
+    const outcome = await moveStorageObjectsBatch({
+      to: "s3",
+      stores: [s3.store, r2.store],
+      nextPage: pager(all, 5),
+      cursor: undefined,
+      limits: { moves: 10, scanned: 2, milliseconds: 60_000 },
+      stillWanted: async (file) => {
+        asked.push(file.id);
+        return true;
+      },
+    });
+    expect(outcome).toMatchObject({ scanned: 2, moved: 2, nextCursor: "c1", done: false });
+    expect(r2.bucket.head).toHaveBeenCalledTimes(2 + 2);
+    expect(asked).toEqual(["file-0", "file-1"]);
   });
 
   it("stops when the time budget is spent", async () => {

--- a/tests/contract/storage-move-object.test.ts
+++ b/tests/contract/storage-move-object.test.ts
@@ -105,6 +105,62 @@ describe("moving one object between stores", () => {
     expect(s3.data.has("key")).toBe(true);
   });
 
+  it("treats an unmeasurable destination copy as unverified", async () => {
+    const s3 = memoryStore("s3");
+    const r2 = memoryStore("r2", { key: bytes(16, 9) });
+    s3.bucket.head.mockResolvedValueOnce(null).mockResolvedValue({ size: undefined });
+    await expect(moveStorageObject({ objectKey: "key", to: "s3", stores: [s3.store, r2.store], expectedSize: 16 }))
+      .rejects.toMatchObject({ reason: "verification-failed" });
+    expect(r2.data.has("key")).toBe(true);
+  });
+
+  it("does not remove a leftover when the destination copy cannot be measured", async () => {
+    const s3 = memoryStore("s3", { key: bytes(8, 10) });
+    const r2 = memoryStore("r2", { key: bytes(8, 10) });
+    s3.bucket.head.mockResolvedValue({ size: undefined });
+    await expect(moveStorageObject({ objectKey: "key", to: "s3", stores: [s3.store, r2.store], expectedSize: 8 }))
+      .rejects.toMatchObject({ reason: "size-mismatch" });
+    expect(r2.data.has("key")).toBe(true);
+  });
+
+  it("keeps the last copy when the destination vanished before the leftover was removed", async () => {
+    const s3 = memoryStore("s3", { key: bytes(8, 11) });
+    const r2 = memoryStore("r2", { key: bytes(8, 11) });
+    s3.bucket.head.mockResolvedValueOnce({ size: 8 }).mockResolvedValueOnce(null);
+    await expect(moveStorageObject({ objectKey: "key", to: "s3", stores: [s3.store, r2.store], expectedSize: 8 }))
+      .rejects.toMatchObject({ reason: "verification-failed" });
+    expect(r2.data.has("key")).toBe(true);
+    expect(r2.bucket.delete).not.toHaveBeenCalled();
+  });
+
+  it("runs opposing moves of one object one after the other", async () => {
+    const payload = bytes(8, 12);
+    const s3 = memoryStore("s3", { key: payload });
+    const r2 = memoryStore("r2", { key: payload });
+    const stores = [s3.store, r2.store];
+    const [toS3, toR2] = await Promise.all([
+      moveStorageObject({ objectKey: "key", to: "s3", stores, expectedSize: 8 }),
+      moveStorageObject({ objectKey: "key", to: "r2", stores, expectedSize: 8 }),
+    ]);
+    expect(toS3).toEqual({ kind: "already-there", to: "s3", removedFrom: ["r2"] });
+    expect(toR2).toMatchObject({ kind: "moved", from: "s3", to: "r2", sourceRemoved: true });
+    expect(r2.data.get("key")).toEqual(payload);
+    expect(s3.data.has("key")).toBe(false);
+  });
+
+  it("refuses a source that changed size between HEAD and GET", async () => {
+    const s3 = memoryStore("s3");
+    const r2 = memoryStore("r2", { key: bytes(8, 13) });
+    r2.bucket.get.mockImplementationOnce(async () => ({
+      size: 9,
+      body: new ReadableStream<Uint8Array>({ start: (c) => { c.enqueue(bytes(9, 13)); c.close(); } }),
+    }));
+    await expect(moveStorageObject({ objectKey: "key", to: "s3", stores: [s3.store, r2.store], expectedSize: 8 }))
+      .rejects.toMatchObject({ reason: "size-mismatch" });
+    expect(s3.bucket.put).not.toHaveBeenCalled();
+    expect(r2.data.has("key")).toBe(true);
+  });
+
   it("reports an object that no store holds", async () => {
     const s3 = memoryStore("s3");
     const r2 = memoryStore("r2");
@@ -190,7 +246,7 @@ describe("moving files in bulk", () => {
       nextPage: pager(all, 2),
       cursor: undefined,
       limits: { moves: 10, scanned: 100, milliseconds: 60_000 },
-      onMoved: async (file) => {
+      onObjectChanged: async (file) => {
         moved.push(file.id);
       },
     });
@@ -209,19 +265,42 @@ describe("moving files in bulk", () => {
     expect(r2.data.size).toBe(0);
   });
 
+  it("reports a leftover copy it removed along the way", async () => {
+    const all = files(1);
+    const r2 = memoryStore("r2", { "key-0": bytes(4, 0) });
+    const s3 = memoryStore("s3", { "key-0": bytes(4, 0) });
+    const changed: string[] = [];
+    const outcome = await moveStorageObjectsBatch({
+      to: "s3",
+      stores: [s3.store, r2.store],
+      nextPage: pager(all, 10),
+      cursor: undefined,
+      limits: { moves: 10, scanned: 100, milliseconds: 60_000 },
+      onObjectChanged: async (file, result) => {
+        changed.push(`${file.id}:${result.kind}`);
+      },
+    });
+    expect(outcome).toMatchObject({ moved: 0, alreadyThere: 1, done: true });
+    expect(changed).toEqual(["file-0:already-there"]);
+    expect(r2.data.size).toBe(0);
+  });
+
   it("stops at the move limit and hands back where to resume", async () => {
     const all = files(6);
     const r2 = memoryStore("r2", Object.fromEntries(all.map((file, index) => [file.objectKey, bytes(4, index)])));
     const s3 = memoryStore("s3");
+    const pages = vi.fn(pager(all, 2));
 
     const first = await moveStorageObjectsBatch({
       to: "s3",
       stores: [s3.store, r2.store],
-      nextPage: pager(all, 4),
+      nextPage: pages,
       cursor: undefined,
       limits: { moves: 2, scanned: 100, milliseconds: 60_000 },
     });
     expect(first).toMatchObject({ moved: 2, scanned: 2, nextCursor: "c1", done: false });
+    // The limit was reached on the last file of a page; no further page is read.
+    expect(pages).toHaveBeenCalledTimes(1);
 
     const second = await moveStorageObjectsBatch({
       to: "s3",
@@ -245,11 +324,10 @@ describe("moving files in bulk", () => {
       nextPage: pager(all, 10),
       cursor: undefined,
       limits: { moves: 10, scanned: 100, milliseconds: 5 },
-      now: () => (clock += 3),
+      now: () => (clock += 2),
     });
     expect(outcome.done).toBe(false);
-    expect(outcome.scanned).toBeLessThan(3);
-    expect(outcome.nextCursor).toBeDefined();
+    expect(outcome).toMatchObject({ scanned: 1, moved: 1, nextCursor: "c0" });
   });
 
   it("records a failure and carries on with the next file", async () => {

--- a/tests/contract/storage-move-object.test.ts
+++ b/tests/contract/storage-move-object.test.ts
@@ -169,12 +169,42 @@ describe("moving one object between stores", () => {
       to: "s3",
       stores: [s3.store, r2.store],
       expectedSize: 8,
-      stillWanted: async () => false,
+      claim: async () => "gone",
     });
     expect(outcome).toEqual({ kind: "missing" });
     expect(s3.data.has("key")).toBe(false);
     // The file's own deletion is what sweeps the source; the move leaves it.
     expect(r2.bucket.delete).not.toHaveBeenCalled();
+  });
+
+  it("deletes nothing when another move holds the claim", async () => {
+    const payload = bytes(8, 15);
+    const s3 = memoryStore("s3");
+    const r2 = memoryStore("r2", { key: payload });
+    await expect(moveStorageObject({ objectKey: "key", to: "s3", stores: [s3.store, r2.store], expectedSize: 8, claim: async () => "lost" }))
+      .rejects.toMatchObject({ reason: "contended" });
+    // The copy stays for whichever move won; the source is untouched.
+    expect(s3.data.get("key")).toEqual(payload);
+    expect(r2.data.get("key")).toEqual(payload);
+
+    const both = memoryStore("s3", { key: payload });
+    const claim = vi.fn(async () => "lost" as const);
+    await expect(moveStorageObject({ objectKey: "key", to: "s3", stores: [both.store, r2.store], expectedSize: 8, claim }))
+      .rejects.toMatchObject({ reason: "contended" });
+    expect(claim).toHaveBeenCalledTimes(1);
+    expect(r2.data.has("key")).toBe(true);
+    expect(r2.bucket.delete).not.toHaveBeenCalled();
+  });
+
+  it("claims exactly once before the first deletion of a leftover", async () => {
+    const payload = bytes(8, 16);
+    const s3 = memoryStore("s3", { key: payload });
+    const r2 = memoryStore("r2", { key: payload });
+    const claim = vi.fn(async () => "claimed" as const);
+    expect(await moveStorageObject({ objectKey: "key", to: "s3", stores: [s3.store, r2.store], expectedSize: 8, claim }))
+      .toEqual({ kind: "already-there", to: "s3", removedFrom: ["r2"] });
+    expect(claim).toHaveBeenCalledTimes(1);
+    expect(claim.mock.invocationCallOrder[0]).toBeLessThan(r2.bucket.delete.mock.invocationCallOrder[0]);
   });
 
   it("reports an object that no store holds", async () => {
@@ -239,6 +269,7 @@ describe("moving files in bulk", () => {
       objectKey: `key-${index}`,
       size: 4,
       mimeType: "application/octet-stream",
+      updatedAt: new Date("2026-09-01T00:00:00.000Z"),
       cursor: `c${index}`,
     }));
   }
@@ -340,9 +371,9 @@ describe("moving files in bulk", () => {
       nextPage: pager(all, 5),
       cursor: undefined,
       limits: { moves: 10, scanned: 2, milliseconds: 60_000 },
-      stillWanted: async (file) => {
+      claim: async (file) => {
         asked.push(file.id);
-        return true;
+        return "claimed";
       },
     });
     expect(outcome).toMatchObject({ scanned: 2, moved: 2, nextCursor: "c1", done: false });
@@ -365,6 +396,32 @@ describe("moving files in bulk", () => {
     });
     expect(outcome.done).toBe(false);
     expect(outcome).toMatchObject({ scanned: 1, moved: 1, nextCursor: "c0" });
+  });
+
+  it("reports a copy whose source could not be removed as unfinished", async () => {
+    const all = files(1);
+    const r2 = memoryStore("r2", { "key-0": bytes(4, 0) });
+    const s3 = memoryStore("s3");
+    r2.bucket.delete.mockRejectedValueOnce(new Error("r2 down"));
+    const changed: string[] = [];
+    const outcome = await moveStorageObjectsBatch({
+      to: "s3",
+      stores: [s3.store, r2.store],
+      nextPage: pager(all, 10),
+      cursor: undefined,
+      limits: { moves: 10, scanned: 100, milliseconds: 60_000 },
+      onObjectChanged: async (file, result) => {
+        changed.push(`${file.id}:${result.kind}`);
+      },
+    });
+    expect(outcome.moved).toBe(0);
+    expect(outcome.failed).toEqual([
+      { id: "file-0", name: "file 0", error: expect.stringContaining("could not be removed") },
+    ]);
+    expect(outcome.done).toBe(true);
+    // The copy did land and is audited even though the batch reports it unfinished.
+    expect(changed).toEqual(["file-0:moved"]);
+    expect(s3.data.has("key-0")).toBe(true);
   });
 
   it("records a failure and carries on with the next file", async () => {

--- a/tests/contract/storage-move-object.test.ts
+++ b/tests/contract/storage-move-object.test.ts
@@ -53,6 +53,15 @@ function memoryStore(provider: StorageProvider, objects: Record<string, Uint8Arr
   return { store, bucket, data };
 }
 
+function fakeLease(acquire: "acquired" | "busy" | "gone" = "acquired", exists = true) {
+  const lease = {
+    acquire: vi.fn(async () => acquire),
+    stillExists: vi.fn(async () => exists),
+    release: vi.fn(async () => undefined),
+  };
+  return lease;
+}
+
 describe("moving one object between stores", () => {
   it("copies, verifies, then deletes the source", async () => {
     const payload = bytes(4096, 1);
@@ -96,9 +105,9 @@ describe("moving one object between stores", () => {
     expect(s3.data.get("key")).toEqual(payload);
   });
 
-  it("keeps both copies when the destination copy has the wrong size", async () => {
+  it("keeps both copies when neither agrees with the record", async () => {
     const s3 = memoryStore("s3", { key: bytes(4, 4) });
-    const r2 = memoryStore("r2", { key: bytes(8, 4) });
+    const r2 = memoryStore("r2", { key: bytes(6, 4) });
     await expect(moveStorageObject({ objectKey: "key", to: "s3", stores: [s3.store, r2.store], expectedSize: 8 }))
       .rejects.toMatchObject({ name: "StorageMoveError", reason: "size-mismatch" });
     expect(r2.data.has("key")).toBe(true);
@@ -114,13 +123,16 @@ describe("moving one object between stores", () => {
     expect(r2.data.has("key")).toBe(true);
   });
 
-  it("does not remove a leftover when the destination copy cannot be measured", async () => {
+  it("never removes the source while the destination copy cannot be measured", async () => {
     const s3 = memoryStore("s3", { key: bytes(8, 10) });
     const r2 = memoryStore("r2", { key: bytes(8, 10) });
     s3.bucket.head.mockResolvedValue({ size: undefined });
+    // The unmeasurable copy is replaced from the good source, but the fresh
+    // copy cannot be verified either, so it is discarded and the source stays.
     await expect(moveStorageObject({ objectKey: "key", to: "s3", stores: [s3.store, r2.store], expectedSize: 8 }))
-      .rejects.toMatchObject({ reason: "size-mismatch" });
+      .rejects.toMatchObject({ reason: "verification-failed" });
     expect(r2.data.has("key")).toBe(true);
+    expect(r2.bucket.delete).not.toHaveBeenCalled();
   });
 
   it("keeps the last copy when the destination vanished before the leftover was removed", async () => {
@@ -169,7 +181,7 @@ describe("moving one object between stores", () => {
       to: "s3",
       stores: [s3.store, r2.store],
       expectedSize: 8,
-      claim: async () => "gone",
+      lease: fakeLease("acquired", false),
     });
     expect(outcome).toEqual({ kind: "missing" });
     expect(s3.data.has("key")).toBe(false);
@@ -177,34 +189,68 @@ describe("moving one object between stores", () => {
     expect(r2.bucket.delete).not.toHaveBeenCalled();
   });
 
-  it("deletes nothing when another move holds the claim", async () => {
+  it("does nothing at all for a file that is already gone", async () => {
+    const s3 = memoryStore("s3");
+    const r2 = memoryStore("r2", { key: bytes(8, 17) });
+    const lease = fakeLease("gone");
+    expect(await moveStorageObject({ objectKey: "key", to: "s3", stores: [s3.store, r2.store], expectedSize: 8, lease }))
+      .toEqual({ kind: "missing" });
+    expect(s3.bucket.put).not.toHaveBeenCalled();
+    expect(lease.release).not.toHaveBeenCalled();
+  });
+
+  it("changes nothing while another move holds the lease", async () => {
     const payload = bytes(8, 15);
     const s3 = memoryStore("s3");
     const r2 = memoryStore("r2", { key: payload });
-    await expect(moveStorageObject({ objectKey: "key", to: "s3", stores: [s3.store, r2.store], expectedSize: 8, claim: async () => "lost" }))
+    const lease = fakeLease("busy");
+    await expect(moveStorageObject({ objectKey: "key", to: "s3", stores: [s3.store, r2.store], expectedSize: 8, lease }))
       .rejects.toMatchObject({ reason: "contended" });
-    // The copy stays for whichever move won; the source is untouched.
-    expect(s3.data.get("key")).toEqual(payload);
-    expect(r2.data.get("key")).toEqual(payload);
-
-    const both = memoryStore("s3", { key: payload });
-    const claim = vi.fn(async () => "lost" as const);
-    await expect(moveStorageObject({ objectKey: "key", to: "s3", stores: [both.store, r2.store], expectedSize: 8, claim }))
-      .rejects.toMatchObject({ reason: "contended" });
-    expect(claim).toHaveBeenCalledTimes(1);
-    expect(r2.data.has("key")).toBe(true);
+    expect(s3.bucket.put).not.toHaveBeenCalled();
     expect(r2.bucket.delete).not.toHaveBeenCalled();
+    expect(r2.bucket.head).not.toHaveBeenCalled();
+    expect(lease.release).not.toHaveBeenCalled();
   });
 
-  it("claims exactly once before the first deletion of a leftover", async () => {
+  it("holds the lease from before the first lookup until after the last delete", async () => {
     const payload = bytes(8, 16);
     const s3 = memoryStore("s3", { key: payload });
     const r2 = memoryStore("r2", { key: payload });
-    const claim = vi.fn(async () => "claimed" as const);
-    expect(await moveStorageObject({ objectKey: "key", to: "s3", stores: [s3.store, r2.store], expectedSize: 8, claim }))
+    const lease = fakeLease();
+    expect(await moveStorageObject({ objectKey: "key", to: "s3", stores: [s3.store, r2.store], expectedSize: 8, lease }))
       .toEqual({ kind: "already-there", to: "s3", removedFrom: ["r2"] });
-    expect(claim).toHaveBeenCalledTimes(1);
-    expect(claim.mock.invocationCallOrder[0]).toBeLessThan(r2.bucket.delete.mock.invocationCallOrder[0]);
+    expect(lease.acquire.mock.invocationCallOrder[0]).toBeLessThan(r2.bucket.head.mock.invocationCallOrder[0]);
+    expect(lease.release.mock.invocationCallOrder[0]).toBeGreaterThan(r2.bucket.delete.mock.invocationCallOrder[0]);
+    expect(lease.release).toHaveBeenCalledTimes(1);
+  });
+
+  it("releases the lease when the move fails", async () => {
+    const s3 = memoryStore("s3", { key: bytes(4, 18) });
+    const r2 = memoryStore("r2", { key: bytes(6, 18) });
+    const lease = fakeLease();
+    await expect(moveStorageObject({ objectKey: "key", to: "s3", stores: [s3.store, r2.store], expectedSize: 8, lease }))
+      .rejects.toBeInstanceOf(StorageMoveError);
+    expect(lease.release).toHaveBeenCalledTimes(1);
+  });
+
+  it("replaces an unverified destination copy with a fresh one from a good source", async () => {
+    const good = bytes(8, 19);
+    const s3 = memoryStore("s3", { key: bytes(4, 19) });
+    const r2 = memoryStore("r2", { key: good });
+    expect(await moveStorageObject({ objectKey: "key", to: "s3", stores: [s3.store, r2.store], expectedSize: 8 }))
+      .toMatchObject({ kind: "moved", from: "r2", to: "s3", size: 8, sourceRemoved: true });
+    expect(s3.data.get("key")).toEqual(good);
+    expect(r2.data.has("key")).toBe(false);
+  });
+
+  it("reports a bad copy it could not remove", async () => {
+    const s3 = memoryStore("s3");
+    const r2 = memoryStore("r2", { key: bytes(16, 20) });
+    s3.bucket.head.mockResolvedValueOnce(null).mockResolvedValue({ size: 15 });
+    s3.bucket.delete.mockRejectedValueOnce(new Error("s3 down"));
+    await expect(moveStorageObject({ objectKey: "key", to: "s3", stores: [s3.store, r2.store], expectedSize: 16 }))
+      .rejects.toThrow(/removing that copy failed as well \(s3 down\)/u);
+    expect(r2.data.has("key")).toBe(true);
   });
 
   it("reports an object that no store holds", async () => {
@@ -269,7 +315,6 @@ describe("moving files in bulk", () => {
       objectKey: `key-${index}`,
       size: 4,
       mimeType: "application/octet-stream",
-      updatedAt: new Date("2026-09-01T00:00:00.000Z"),
       cursor: `c${index}`,
     }));
   }
@@ -371,9 +416,9 @@ describe("moving files in bulk", () => {
       nextPage: pager(all, 5),
       cursor: undefined,
       limits: { moves: 10, scanned: 2, milliseconds: 60_000 },
-      claim: async (file) => {
+      lease: (file) => {
         asked.push(file.id);
-        return "claimed";
+        return fakeLease();
       },
     });
     expect(outcome).toMatchObject({ scanned: 2, moved: 2, nextCursor: "c1", done: false });

--- a/tests/contract/storage-move-object.test.ts
+++ b/tests/contract/storage-move-object.test.ts
@@ -1,0 +1,272 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  locateStorageObject,
+  moveStorageObject,
+  moveStorageObjectsBatch,
+  StorageMoveError,
+  type MovableFile,
+  type StorageProvider,
+  type StorageStore,
+} from "@beutl/api";
+
+function bytes(length: number, seed: number): Uint8Array {
+  const out = new Uint8Array(length);
+  for (let i = 0; i < length; i++) out[i] = (i * 7 + seed) & 0xff;
+  return out;
+}
+
+async function drain(value: ArrayBuffer | ReadableStream | string): Promise<Uint8Array> {
+  if (typeof value === "string") return new TextEncoder().encode(value);
+  if (value instanceof ArrayBuffer) return new Uint8Array(value);
+  return new Uint8Array(await new Response(value).arrayBuffer());
+}
+
+// An in-memory store shaped like the R2 binding, with hooks a test can break.
+function memoryStore(provider: StorageProvider, objects: Record<string, Uint8Array> = {}) {
+  const data = new Map<string, Uint8Array>(Object.entries(objects));
+  const bucket = {
+    put: vi.fn(async (key: string, value: ArrayBuffer | ReadableStream | string) => {
+      data.set(key, await drain(value));
+    }),
+    get: vi.fn(async (key: string) => {
+      const found = data.get(key);
+      if (!found) return null;
+      return {
+        size: found.byteLength,
+        body: new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.enqueue(found);
+            controller.close();
+          },
+        }),
+      };
+    }),
+    head: vi.fn(async (key: string) => {
+      const found = data.get(key);
+      return found ? { size: found.byteLength } : null;
+    }),
+    delete: vi.fn(async (key: string) => {
+      data.delete(key);
+    }),
+  };
+  const store: StorageStore = { provider, bucket, label: provider.toUpperCase() };
+  return { store, bucket, data };
+}
+
+describe("moving one object between stores", () => {
+  it("copies, verifies, then deletes the source", async () => {
+    const payload = bytes(4096, 1);
+    const r2 = memoryStore("r2", { key: payload });
+    const s3 = memoryStore("s3");
+
+    const outcome = await moveStorageObject({
+      objectKey: "key",
+      to: "s3",
+      stores: [s3.store, r2.store],
+      expectedSize: 4096,
+      contentType: "video/mp4",
+    });
+
+    expect(outcome).toEqual({ kind: "moved", from: "r2", to: "s3", size: 4096, sourceRemoved: true });
+    expect(s3.data.get("key")).toEqual(payload);
+    expect(r2.data.has("key")).toBe(false);
+    expect(s3.bucket.put).toHaveBeenCalledWith("key", expect.any(ReadableStream), {
+      httpMetadata: { contentType: "video/mp4" },
+      contentLength: 4096,
+    });
+    // The source is only removed after the copy was measured.
+    expect(s3.bucket.head.mock.invocationCallOrder[1]).toBeLessThan(r2.bucket.delete.mock.invocationCallOrder[0]);
+  });
+
+  it("does nothing when the object is already in the destination", async () => {
+    const s3 = memoryStore("s3", { key: bytes(8, 2) });
+    const r2 = memoryStore("r2");
+    expect(await moveStorageObject({ objectKey: "key", to: "s3", stores: [s3.store, r2.store], expectedSize: 8 }))
+      .toEqual({ kind: "already-there", to: "s3", removedFrom: [] });
+    expect(s3.bucket.put).not.toHaveBeenCalled();
+  });
+
+  it("removes the copy a failed earlier move left behind", async () => {
+    const payload = bytes(8, 3);
+    const s3 = memoryStore("s3", { key: payload });
+    const r2 = memoryStore("r2", { key: payload });
+    expect(await moveStorageObject({ objectKey: "key", to: "s3", stores: [s3.store, r2.store], expectedSize: 8 }))
+      .toEqual({ kind: "already-there", to: "s3", removedFrom: ["r2"] });
+    expect(r2.data.has("key")).toBe(false);
+    expect(s3.data.get("key")).toEqual(payload);
+  });
+
+  it("keeps both copies when the destination copy has the wrong size", async () => {
+    const s3 = memoryStore("s3", { key: bytes(4, 4) });
+    const r2 = memoryStore("r2", { key: bytes(8, 4) });
+    await expect(moveStorageObject({ objectKey: "key", to: "s3", stores: [s3.store, r2.store], expectedSize: 8 }))
+      .rejects.toMatchObject({ name: "StorageMoveError", reason: "size-mismatch" });
+    expect(r2.data.has("key")).toBe(true);
+    expect(s3.data.has("key")).toBe(true);
+  });
+
+  it("reports an object that no store holds", async () => {
+    const s3 = memoryStore("s3");
+    const r2 = memoryStore("r2");
+    expect(await moveStorageObject({ objectKey: "key", to: "s3", stores: [s3.store, r2.store] }))
+      .toEqual({ kind: "missing" });
+  });
+
+  it("refuses to copy a source that disagrees with the record", async () => {
+    const s3 = memoryStore("s3");
+    const r2 = memoryStore("r2", { key: bytes(10, 5) });
+    await expect(moveStorageObject({ objectKey: "key", to: "s3", stores: [s3.store, r2.store], expectedSize: 11 }))
+      .rejects.toMatchObject({ reason: "size-mismatch" });
+    expect(s3.bucket.put).not.toHaveBeenCalled();
+    expect(r2.data.has("key")).toBe(true);
+  });
+
+  it("discards a copy that does not read back whole and keeps the source", async () => {
+    const s3 = memoryStore("s3");
+    const r2 = memoryStore("r2", { key: bytes(16, 6) });
+    // Absent before the copy, then read back one byte short.
+    s3.bucket.head.mockResolvedValueOnce(null).mockResolvedValue({ size: 15 });
+    await expect(moveStorageObject({ objectKey: "key", to: "s3", stores: [s3.store, r2.store], expectedSize: 16 }))
+      .rejects.toMatchObject({ reason: "verification-failed" });
+    expect(s3.bucket.delete).toHaveBeenCalledWith("key");
+    expect(r2.data.has("key")).toBe(true);
+  });
+
+  it("reports a source that could not be deleted after a good copy", async () => {
+    const s3 = memoryStore("s3");
+    const r2 = memoryStore("r2", { key: bytes(16, 7) });
+    r2.bucket.delete.mockRejectedValueOnce(new Error("r2 down"));
+    const outcome = await moveStorageObject({ objectKey: "key", to: "s3", stores: [s3.store, r2.store], expectedSize: 16 });
+    expect(outcome).toMatchObject({ kind: "moved", sourceRemoved: false });
+    expect(s3.data.has("key")).toBe(true);
+  });
+
+  it("rejects a destination that is not configured", async () => {
+    const r2 = memoryStore("r2");
+    await expect(moveStorageObject({ objectKey: "key", to: "s3", stores: [r2.store] }))
+      .rejects.toBeInstanceOf(StorageMoveError);
+  });
+
+  it("locates an object across stores in store order", async () => {
+    const s3 = memoryStore("s3", { both: bytes(1, 8) });
+    const r2 = memoryStore("r2", { both: bytes(1, 8), old: bytes(2, 8) });
+    expect(await locateStorageObject("both", [s3.store, r2.store])).toEqual([
+      { provider: "s3", size: 1 },
+      { provider: "r2", size: 1 },
+    ]);
+    expect(await locateStorageObject("old", [s3.store, r2.store])).toEqual([{ provider: "r2", size: 2 }]);
+    expect(await locateStorageObject("none", [s3.store, r2.store])).toEqual([]);
+  });
+});
+
+describe("moving files in bulk", () => {
+  function files(count: number): MovableFile[] {
+    return Array.from({ length: count }, (_, index) => ({
+      id: `file-${index}`,
+      name: `file ${index}`,
+      objectKey: `key-${index}`,
+      size: 4,
+      mimeType: "application/octet-stream",
+      cursor: `c${index}`,
+    }));
+  }
+
+  function pager(all: MovableFile[], pageSize: number) {
+    return async (cursor: string | undefined) => {
+      const start = cursor === undefined ? 0 : all.findIndex((file) => file.cursor === cursor) + 1;
+      return all.slice(start, start + pageSize);
+    };
+  }
+
+  it("moves what is not yet at the destination and skips what is", async () => {
+    const all = files(5);
+    const r2 = memoryStore("r2", { "key-0": bytes(4, 0), "key-2": bytes(4, 2), "key-4": bytes(4, 4) });
+    const s3 = memoryStore("s3", { "key-1": bytes(4, 1) });
+    const moved: string[] = [];
+
+    const outcome = await moveStorageObjectsBatch({
+      to: "s3",
+      stores: [s3.store, r2.store],
+      nextPage: pager(all, 2),
+      cursor: undefined,
+      limits: { moves: 10, scanned: 100, milliseconds: 60_000 },
+      onMoved: async (file) => {
+        moved.push(file.id);
+      },
+    });
+
+    expect(outcome).toEqual({
+      scanned: 5,
+      moved: 3,
+      alreadyThere: 1,
+      missing: 1,
+      failed: [],
+      nextCursor: undefined,
+      done: true,
+    });
+    expect(moved).toEqual(["file-0", "file-2", "file-4"]);
+    expect([...s3.data.keys()].sort()).toEqual(["key-0", "key-1", "key-2", "key-4"]);
+    expect(r2.data.size).toBe(0);
+  });
+
+  it("stops at the move limit and hands back where to resume", async () => {
+    const all = files(6);
+    const r2 = memoryStore("r2", Object.fromEntries(all.map((file, index) => [file.objectKey, bytes(4, index)])));
+    const s3 = memoryStore("s3");
+
+    const first = await moveStorageObjectsBatch({
+      to: "s3",
+      stores: [s3.store, r2.store],
+      nextPage: pager(all, 4),
+      cursor: undefined,
+      limits: { moves: 2, scanned: 100, milliseconds: 60_000 },
+    });
+    expect(first).toMatchObject({ moved: 2, scanned: 2, nextCursor: "c1", done: false });
+
+    const second = await moveStorageObjectsBatch({
+      to: "s3",
+      stores: [s3.store, r2.store],
+      nextPage: pager(all, 4),
+      cursor: first.nextCursor,
+      limits: { moves: 10, scanned: 100, milliseconds: 60_000 },
+    });
+    expect(second).toMatchObject({ moved: 4, scanned: 4, nextCursor: undefined, done: true });
+    expect(s3.data.size).toBe(6);
+  });
+
+  it("stops when the time budget is spent", async () => {
+    const all = files(3);
+    const r2 = memoryStore("r2", Object.fromEntries(all.map((file, index) => [file.objectKey, bytes(4, index)])));
+    const s3 = memoryStore("s3");
+    let clock = 0;
+    const outcome = await moveStorageObjectsBatch({
+      to: "s3",
+      stores: [s3.store, r2.store],
+      nextPage: pager(all, 10),
+      cursor: undefined,
+      limits: { moves: 10, scanned: 100, milliseconds: 5 },
+      now: () => (clock += 3),
+    });
+    expect(outcome.done).toBe(false);
+    expect(outcome.scanned).toBeLessThan(3);
+    expect(outcome.nextCursor).toBeDefined();
+  });
+
+  it("records a failure and carries on with the next file", async () => {
+    const all = files(2);
+    const r2 = memoryStore("r2", { "key-0": bytes(9, 0), "key-1": bytes(4, 1) });
+    const s3 = memoryStore("s3");
+    const outcome = await moveStorageObjectsBatch({
+      to: "s3",
+      stores: [s3.store, r2.store],
+      nextPage: pager(all, 10),
+      cursor: undefined,
+      limits: { moves: 10, scanned: 100, milliseconds: 60_000 },
+    });
+    expect(outcome.failed).toEqual([
+      { id: "file-0", name: "file 0", error: expect.stringContaining("not the recorded 4") },
+    ]);
+    expect(outcome.moved).toBe(1);
+    expect(outcome.done).toBe(true);
+  });
+});

--- a/tests/contract/storage-move-object.test.ts
+++ b/tests/contract/storage-move-object.test.ts
@@ -189,6 +189,21 @@ describe("moving one object between stores", () => {
     expect(r2.bucket.delete).not.toHaveBeenCalled();
   });
 
+  it("still removes the fresh copy when it cannot learn whether the file exists", async () => {
+    const s3 = memoryStore("s3");
+    const r2 = memoryStore("r2", { key: bytes(8, 21) });
+    const lease = fakeLease();
+    lease.stillExists.mockRejectedValue(new Error("cleanup row is leased"));
+    await expect(moveStorageObject({ objectKey: "key", to: "s3", stores: [s3.store, r2.store], expectedSize: 8, lease }))
+      .rejects.toThrow("cleanup row is leased");
+    expect(s3.data.has("key")).toBe(false);
+    expect(r2.data.has("key")).toBe(true);
+
+    s3.bucket.delete.mockRejectedValueOnce(new Error("s3 down"));
+    await expect(moveStorageObject({ objectKey: "key", to: "s3", stores: [s3.store, r2.store], expectedSize: 8, lease }))
+      .rejects.toThrow(/that copy is untracked/u);
+  });
+
   it("does nothing at all for a file that is already gone", async () => {
     const s3 = memoryStore("s3");
     const r2 = memoryStore("r2", { key: bytes(8, 17) });
@@ -426,6 +441,20 @@ describe("moving files in bulk", () => {
     expect(asked).toEqual(["file-0", "file-1"]);
   });
 
+  it("settles at least one file even when locating spent the budget", async () => {
+    const all = files(2);
+    const r2 = memoryStore("r2", Object.fromEntries(all.map((file, index) => [file.objectKey, bytes(4, index)])));
+    const s3 = memoryStore("s3");
+    const outcome = await moveStorageObjectsBatch({
+      to: "s3",
+      stores: [s3.store, r2.store],
+      nextPage: pager(all, 10),
+      cursor: undefined,
+      limits: { moves: 10, scanned: 100, milliseconds: 0 },
+    });
+    expect(outcome).toMatchObject({ scanned: 1, moved: 1, nextCursor: "c0", done: false });
+  });
+
   it("stops when the time budget is spent", async () => {
     const all = files(3);
     const r2 = memoryStore("r2", Object.fromEntries(all.map((file, index) => [file.objectKey, bytes(4, index)])));
@@ -437,7 +466,7 @@ describe("moving files in bulk", () => {
       nextPage: pager(all, 10),
       cursor: undefined,
       limits: { moves: 10, scanned: 100, milliseconds: 5 },
-      now: () => (clock += 2),
+      now: () => (clock += 5),
     });
     expect(outcome.done).toBe(false);
     expect(outcome).toMatchObject({ scanned: 1, moved: 1, nextCursor: "c0" });

--- a/tests/contract/storage-move-object.test.ts
+++ b/tests/contract/storage-move-object.test.ts
@@ -56,6 +56,7 @@ function memoryStore(provider: StorageProvider, objects: Record<string, Uint8Arr
 function fakeLease(acquire: "acquired" | "busy" | "gone" = "acquired", exists = true) {
   const lease = {
     acquire: vi.fn(async () => acquire),
+    confirm: vi.fn(async () => true),
     stillExists: vi.fn(async () => exists),
     release: vi.fn(async () => undefined),
   };
@@ -239,6 +240,30 @@ describe("moving one object between stores", () => {
     expect(lease.release).toHaveBeenCalledTimes(1);
   });
 
+  it("confirms the lease right before each delete and deletes nothing once it is lost", async () => {
+    const payload = bytes(8, 22);
+    const s3 = memoryStore("s3", { key: payload });
+    const r2 = memoryStore("r2", { key: payload });
+    const lease = fakeLease();
+    lease.confirm.mockResolvedValueOnce(false);
+    await expect(moveStorageObject({ objectKey: "key", to: "s3", stores: [s3.store, r2.store], expectedSize: 8, lease }))
+      .rejects.toMatchObject({ reason: "contended" });
+    expect(r2.bucket.delete).not.toHaveBeenCalled();
+    expect(s3.bucket.delete).not.toHaveBeenCalled();
+    expect(lease.release).toHaveBeenCalledTimes(1);
+
+    const s3Fresh = memoryStore("s3");
+    const source = memoryStore("r2", { key: payload });
+    const lost = fakeLease();
+    lost.confirm.mockResolvedValue(false);
+    await expect(moveStorageObject({ objectKey: "key", to: "s3", stores: [s3Fresh.store, source.store], expectedSize: 8, lease: lost }))
+      .rejects.toMatchObject({ reason: "contended" });
+    // The copy landed and was verified, but the source stays for the lease's new owner.
+    expect(s3Fresh.data.get("key")).toEqual(payload);
+    expect(source.data.get("key")).toEqual(payload);
+    expect(lost.confirm.mock.invocationCallOrder[0]).toBeGreaterThan(s3Fresh.bucket.put.mock.invocationCallOrder[0]);
+  });
+
   it("releases the lease when the move fails", async () => {
     const s3 = memoryStore("s3", { key: bytes(4, 18) });
     const r2 = memoryStore("r2", { key: bytes(6, 18) });
@@ -340,6 +365,23 @@ describe("moving files in bulk", () => {
       return all.slice(start, start + pageSize);
     };
   }
+
+  it("does not count a destination copy of the wrong size as settled", async () => {
+    const all = files(1);
+    const r2 = memoryStore("r2");
+    const s3 = memoryStore("s3", { "key-0": bytes(3, 0) });
+    const outcome = await moveStorageObjectsBatch({
+      to: "s3",
+      stores: [s3.store, r2.store],
+      nextPage: pager(all, 10),
+      cursor: undefined,
+      limits: { moves: 10, scanned: 100, milliseconds: 60_000 },
+    });
+    expect(outcome.alreadyThere).toBe(0);
+    expect(outcome.failed).toEqual([
+      { id: "file-0", name: "file 0", error: expect.stringContaining("not the recorded 4") },
+    ]);
+  });
 
   it("moves what is not yet at the destination and skips what is", async () => {
     const all = files(5);

--- a/tests/contract/storage-s3-compatible-bucket.live.test.ts
+++ b/tests/contract/storage-s3-compatible-bucket.live.test.ts
@@ -23,6 +23,7 @@ function liveBucket() {
     secretAccessKey: secretAccessKey!,
     region: process.env.BEUTL_S3_TEST_REGION,
     forcePathStyle: process.env.BEUTL_S3_TEST_FORCE_PATH_STYLE !== "false",
+    allowInsecureHttp: true,
   });
 }
 

--- a/tests/contract/storage-s3-compatible-bucket.live.test.ts
+++ b/tests/contract/storage-s3-compatible-bucket.live.test.ts
@@ -1,0 +1,139 @@
+// 実物の S3 互換サービスに対する疎通確認。BEUTL_S3_TEST_ENDPOINT などが無いときは
+// 走らない。ローカルの MinIO なら次のように設定する:
+//   BEUTL_S3_TEST_ENDPOINT=http://127.0.0.1:9000 BEUTL_S3_TEST_BUCKET=beutl-test
+//   BEUTL_S3_TEST_ACCESS_KEY_ID=minioadmin BEUTL_S3_TEST_SECRET_ACCESS_KEY=minioadmin
+import { describe, expect, it } from "vitest";
+import {
+  createS3CompatibleBucket,
+  isTerminalMultipartAbortError,
+  S3StorageError,
+} from "@beutl/api";
+
+const endpoint = process.env.BEUTL_S3_TEST_ENDPOINT;
+const bucketName = process.env.BEUTL_S3_TEST_BUCKET;
+const accessKeyId = process.env.BEUTL_S3_TEST_ACCESS_KEY_ID;
+const secretAccessKey = process.env.BEUTL_S3_TEST_SECRET_ACCESS_KEY;
+const configured = Boolean(endpoint && bucketName && accessKeyId && secretAccessKey);
+
+function liveBucket() {
+  return createS3CompatibleBucket({
+    endpoint: endpoint!,
+    bucket: bucketName!,
+    accessKeyId: accessKeyId!,
+    secretAccessKey: secretAccessKey!,
+    region: process.env.BEUTL_S3_TEST_REGION,
+    forcePathStyle: process.env.BEUTL_S3_TEST_FORCE_PATH_STYLE !== "false",
+  });
+}
+
+function bytes(length: number, seed: number): Uint8Array {
+  const out = new Uint8Array(length);
+  for (let i = 0; i < length; i++) out[i] = (i * 31 + seed) & 0xff;
+  return out;
+}
+
+function streamOf(...chunks: Uint8Array[]): ReadableStream<Uint8Array> {
+  return new ReadableStream({
+    start(controller) {
+      for (const chunk of chunks) controller.enqueue(chunk);
+      controller.close();
+    },
+  });
+}
+
+async function drain(stream: ReadableStream<Uint8Array>): Promise<Uint8Array> {
+  const reader = stream.getReader();
+  const chunks: Uint8Array[] = [];
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    chunks.push(value);
+  }
+  const total = chunks.reduce((sum, chunk) => sum + chunk.byteLength, 0);
+  const out = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    out.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return out;
+}
+
+function same(actual: Uint8Array, expected: Uint8Array): boolean {
+  return Buffer.from(actual.buffer, actual.byteOffset, actual.byteLength)
+    .equals(Buffer.from(expected.buffer, expected.byteOffset, expected.byteLength));
+}
+
+describe.skipIf(!configured)("S3 compatible bucket against a live service", { timeout: 60_000 }, () => {
+  it("round-trips a single object", async () => {
+    const bucket = liveBucket();
+    const key = `live/${crypto.randomUUID()}/name with spaces & symbols.bin`;
+    const payload = bytes(1024, 7);
+    await bucket.put(key, payload.buffer as ArrayBuffer, {
+      httpMetadata: { contentType: "application/octet-stream" },
+    });
+
+    expect(await bucket.head!(key)).toEqual({ size: 1024 });
+    const read = await bucket.get!(key);
+    expect(read?.size).toBe(1024);
+    expect(same(await drain(read!.body!), payload)).toBe(true);
+
+    await bucket.delete!(key);
+    expect(await bucket.head!(key)).toBeNull();
+    expect(await bucket.get!(key)).toBeNull();
+    await expect(bucket.delete!(key)).resolves.toBeUndefined();
+  });
+
+  it("joins streamed parts and measures the result", async () => {
+    const bucket = liveBucket();
+    const key = `live/${crypto.randomUUID()}/multipart.bin`;
+    // S3 requires every part but the last to be at least 5 MiB.
+    const first = bytes(5 * 1024 * 1024, 1);
+    const second = bytes(1024, 2);
+    const { uploadId } = await bucket.createMultipartUpload!(key, {
+      httpMetadata: { contentType: "video/mp4" },
+    });
+    const handle = bucket.resumeMultipartUpload!(key, uploadId);
+    const parts = [
+      await handle.uploadPart(1, streamOf(first.subarray(0, 1 << 20), first.subarray(1 << 20)), { contentLength: first.byteLength }),
+      await handle.uploadPart(2, streamOf(second), { contentLength: second.byteLength }),
+    ];
+    expect(parts.map((part) => part.partNumber)).toEqual([1, 2]);
+    for (const part of parts) expect(part.etag).not.toMatch(/^"/u);
+
+    const joined = await handle.complete(parts);
+    expect(joined.size).toBe(first.byteLength + second.byteLength);
+    const read = await bucket.get!(key);
+    const stored = await drain(read!.body!);
+    expect(stored.byteLength).toBe(first.byteLength + second.byteLength);
+    expect(same(stored.subarray(0, first.byteLength), first)).toBe(true);
+    expect(same(stored.subarray(first.byteLength), second)).toBe(true);
+    await bucket.delete!(key);
+
+    // The joined upload id is gone. AWS S3 and R2 answer NoSuchUpload, which
+    // the reconcilers treat as terminal; MinIO answers 204 instead. Either way
+    // the part must no longer be accepted.
+    let error: unknown;
+    try {
+      await handle.abort();
+    } catch (caught) {
+      error = caught;
+    }
+    if (error !== undefined) {
+      expect(error).toBeInstanceOf(S3StorageError);
+      expect(isTerminalMultipartAbortError(error)).toBe(true);
+    }
+    await expect(handle.uploadPart(1, streamOf(bytes(8, 4)), { contentLength: 8 }))
+      .rejects.toMatchObject({ code: "NoSuchUpload" });
+  });
+
+  it("aborts an upload that was never completed", async () => {
+    const bucket = liveBucket();
+    const key = `live/${crypto.randomUUID()}/abandoned.bin`;
+    const { uploadId } = await bucket.createMultipartUpload!(key);
+    const handle = bucket.resumeMultipartUpload!(key, uploadId);
+    await handle.uploadPart(1, streamOf(bytes(16, 3)), { contentLength: 16 });
+    await expect(handle.abort()).resolves.toBeUndefined();
+    expect(await bucket.head!(key)).toBeNull();
+  });
+});

--- a/tests/contract/storage-s3-compatible-bucket.live.test.ts
+++ b/tests/contract/storage-s3-compatible-bucket.live.test.ts
@@ -15,6 +15,14 @@ const accessKeyId = process.env.BEUTL_S3_TEST_ACCESS_KEY_ID;
 const secretAccessKey = process.env.BEUTL_S3_TEST_SECRET_ACCESS_KEY;
 const configured = Boolean(endpoint && bucketName && accessKeyId && secretAccessKey);
 
+// Signed requests and object bytes travel in clear over http; a local service
+// is the only place that is acceptable without saying so explicitly.
+function insecureHttpAllowed(url: string): boolean {
+  if (process.env.BEUTL_S3_TEST_ALLOW_INSECURE_HTTP === "true") return true;
+  const { protocol, hostname } = new URL(url);
+  return protocol === "https:" || ["127.0.0.1", "localhost", "[::1]", "::1"].includes(hostname);
+}
+
 function liveBucket() {
   return createS3CompatibleBucket({
     endpoint: endpoint!,
@@ -23,7 +31,7 @@ function liveBucket() {
     secretAccessKey: secretAccessKey!,
     region: process.env.BEUTL_S3_TEST_REGION,
     forcePathStyle: process.env.BEUTL_S3_TEST_FORCE_PATH_STYLE !== "false",
-    allowInsecureHttp: true,
+    allowInsecureHttp: insecureHttpAllowed(endpoint!),
   });
 }
 

--- a/tests/contract/storage-s3-compatible-bucket.test.ts
+++ b/tests/contract/storage-s3-compatible-bucket.test.ts
@@ -239,13 +239,14 @@ describe("S3 compatible bucket adapter", () => {
   });
 
   it("treats an error document behind a 200 completion as a failure", async () => {
-    respond(xml("  <Error><Code>InternalError</Code><Message>We encountered an internal error.</Message></Error>"));
+    respond(xml("  <Error><Code>EntityTooSmall</Code><Message>Your proposed upload is smaller than the minimum allowed size</Message></Error>"));
     const handle = bucket().resumeMultipartUpload!("k", "up");
     await expect(handle.complete([{ partNumber: 1, etag: "e1" }])).rejects.toMatchObject({
       name: "S3StorageError",
-      code: "InternalError",
+      code: "EntityTooSmall",
       operation: "completeMultipartUpload",
     });
+    expect(recorded).toHaveLength(1);
   });
 
   it("aborts, and reports a forgotten upload the way the reconcilers expect", async () => {
@@ -271,5 +272,51 @@ describe("S3 compatible bucket adapter", () => {
 
   it("rejects an endpoint that is not an http(s) URL", () => {
     expect(() => bucket({ endpoint: "ftp://files.example.test" })).toThrow(/http\(s\)/u);
+  });
+
+  it("refuses a plain http endpoint unless insecure transport is allowed", async () => {
+    expect(() => bucket({ endpoint: "http://minio.local:9000" })).toThrow(/not https/u);
+    respond(new Response(null, { status: 200 }));
+    await bucket({ endpoint: "http://minio.local:9000", allowInsecureHttp: true }).put("k", "v");
+    expect(recorded[0].url.toString()).toBe("http://minio.local:9000/beutl/k");
+  });
+
+  it("refuses keys with dot segments instead of letting the URL rewrite them", async () => {
+    const s3 = bucket();
+    await expect(s3.put("archive/../current", "v")).rejects.toThrow(/Unsupported object key/u);
+    await expect(s3.head!("./a")).rejects.toThrow(/Unsupported object key/u);
+    await expect(s3.get!("a//b")).rejects.toThrow(/Unsupported object key/u);
+    expect(recorded).toHaveLength(0);
+  });
+
+  it("reports the service error code when HEAD is refused", async () => {
+    respond(new Response(null, { status: 403 }));
+    await expect(bucket().head!("k")).rejects.toMatchObject({
+      name: "S3StorageError",
+      operation: "head",
+      status: 403,
+    });
+  });
+
+  it("omits the etag of a put the service did not tag", async () => {
+    respond(new Response(null, { status: 200 }));
+    expect(await bucket().put("k", "v")).toEqual({ key: "k" });
+  });
+
+  it("never repeats a multipart initiation", async () => {
+    respond(new Response(null, { status: 503 }));
+    await expect(bucket().createMultipartUpload!("k")).rejects.toMatchObject({ status: 503 });
+    expect(recorded).toHaveLength(1);
+  });
+
+  it("retries a completion whose 200 body carries a transient error", async () => {
+    respond(
+      xml("<Error><Code>InternalError</Code><Message>We encountered an internal error.</Message></Error>"),
+      xml("<CompleteMultipartUploadResult><ETag>\"final\"</ETag></CompleteMultipartUploadResult>"),
+      new Response(null, { status: 200, headers: { "content-length": "3" } }),
+    );
+    const handle = bucket().resumeMultipartUpload!("k", "up");
+    expect(await handle.complete([{ partNumber: 1, etag: "e1" }])).toEqual({ size: 3 });
+    expect(recorded.filter((request) => request.method === "POST")).toHaveLength(2);
   });
 });

--- a/tests/contract/storage-s3-compatible-bucket.test.ts
+++ b/tests/contract/storage-s3-compatible-bucket.test.ts
@@ -1,0 +1,275 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createS3CompatibleBucket,
+  isTerminalMultipartAbortError,
+  S3StorageError,
+} from "@beutl/api";
+
+type Recorded = {
+  method: string;
+  url: URL;
+  headers: Headers;
+  body: ReadableStream<Uint8Array> | null;
+  text: () => Promise<string>;
+};
+
+const recorded: Recorded[] = [];
+let responses: Response[] = [];
+
+function respond(...next: Response[]) {
+  responses = next;
+}
+
+async function fakeFetch(input: RequestInfo | URL): Promise<Response> {
+  if (!(input instanceof Request)) throw new Error("expected a signed Request");
+  const request = input;
+  recorded.push({
+    method: request.method,
+    url: new URL(request.url),
+    headers: request.headers,
+    body: request.body,
+    text: () => request.text(),
+  });
+  const response = responses.shift();
+  if (!response) throw new Error("no response was queued");
+  return response;
+}
+
+function xml(body: string, init?: ResponseInit): Response {
+  return new Response(body, {
+    status: 200,
+    headers: { "content-type": "application/xml" },
+    ...init,
+  });
+}
+
+function bucket(overrides: Partial<Parameters<typeof createS3CompatibleBucket>[0]> = {}) {
+  return createS3CompatibleBucket({
+    endpoint: "https://s3.example.test",
+    bucket: "beutl",
+    region: "auto",
+    accessKeyId: "AKIAEXAMPLE",
+    secretAccessKey: "secret",
+    fetch: fakeFetch as typeof fetch,
+    ...overrides,
+  });
+}
+
+function stream(bytes: Uint8Array): ReadableStream<Uint8Array> {
+  return new ReadableStream({
+    start(controller) {
+      controller.enqueue(bytes);
+      controller.close();
+    },
+  });
+}
+
+describe("S3 compatible bucket adapter", () => {
+  beforeEach(() => {
+    recorded.length = 0;
+    responses = [];
+    vi.restoreAllMocks();
+  });
+
+  it("puts an object with a SigV4 signature over an unsigned payload", async () => {
+    respond(new Response(null, { status: 200, headers: { etag: '"abc"' } }));
+    const result = await bucket().put("ai/image/job-1/object 1.png", new Uint8Array([1, 2, 3]).buffer, {
+      httpMetadata: { contentType: "image/png" },
+    });
+
+    expect(result).toEqual({ key: "ai/image/job-1/object 1.png", etag: "abc" });
+    const [request] = recorded;
+    expect(request.method).toBe("PUT");
+    expect(request.url.toString()).toBe("https://s3.example.test/beutl/ai/image/job-1/object%201.png");
+    expect(request.headers.get("content-type")).toBe("image/png");
+    expect(request.headers.get("x-amz-content-sha256")).toBe("UNSIGNED-PAYLOAD");
+    expect(request.headers.get("authorization")).toMatch(
+      /^AWS4-HMAC-SHA256 Credential=AKIAEXAMPLE\/\d{8}\/auto\/s3\/aws4_request, SignedHeaders=host;x-amz-content-sha256;x-amz-date, Signature=[0-9a-f]{64}$/u,
+    );
+  });
+
+  it("addresses the bucket as a host when path style is turned off", async () => {
+    respond(new Response(null, { status: 200 }));
+    await bucket({ forcePathStyle: false }).put("key", "text");
+    expect(recorded[0].url.toString()).toBe("https://beutl.s3.example.test/key");
+  });
+
+  it("keeps an endpoint path prefix in front of the bucket", async () => {
+    respond(new Response(null, { status: 200 }));
+    await bucket({ endpoint: "https://gateway.example.test/storage/" }).put("key", "text");
+    expect(recorded[0].url.toString()).toBe("https://gateway.example.test/storage/beutl/key");
+  });
+
+  it("reads an object as a stream with its size and returns null when absent", async () => {
+    respond(
+      new Response(new Uint8Array([9, 8, 7]), { status: 200, headers: { "content-length": "3" } }),
+      xml("<Error><Code>NoSuchKey</Code></Error>", { status: 404 }),
+    );
+    const s3 = bucket();
+    const present = await s3.get!("present");
+    expect(present?.size).toBe(3);
+    expect(present?.body).toBeInstanceOf(ReadableStream);
+    expect(recorded[0].method).toBe("GET");
+
+    expect(await s3.get!("missing")).toBeNull();
+  });
+
+  it("surfaces the service error code on a failed read", async () => {
+    respond(xml("<Error><Code>AccessDenied</Code><Message>Access Denied</Message></Error>", { status: 403 }));
+    await expect(bucket().get!("secret")).rejects.toMatchObject({
+      name: "S3StorageError",
+      code: "AccessDenied",
+      status: 403,
+      operation: "get",
+    });
+  });
+
+  it("measures an object with HEAD and treats 404 as absent", async () => {
+    respond(
+      new Response(null, { status: 200, headers: { "content-length": "42" } }),
+      new Response(null, { status: 404 }),
+    );
+    const s3 = bucket();
+    expect(await s3.head!("present")).toEqual({ size: 42 });
+    expect(recorded[0].method).toBe("HEAD");
+    expect(await s3.head!("missing")).toBeNull();
+  });
+
+  it("deletes idempotently and rejects other failures", async () => {
+    respond(
+      new Response(null, { status: 204 }),
+      new Response(null, { status: 404 }),
+      xml("<Error><Code>InternalError</Code></Error>", { status: 500 }),
+      xml("<Error><Code>InternalError</Code></Error>", { status: 500 }),
+      xml("<Error><Code>InternalError</Code></Error>", { status: 500 }),
+    );
+    const s3 = bucket();
+    await expect(s3.delete!("a")).resolves.toBeUndefined();
+    await expect(s3.delete!("b")).resolves.toBeUndefined();
+    await expect(s3.delete!("c")).rejects.toBeInstanceOf(S3StorageError);
+    expect(recorded.map((request) => request.method)).toEqual(["DELETE", "DELETE", "DELETE", "DELETE", "DELETE"]);
+  });
+
+  it("retries a buffered request on a transient failure", async () => {
+    respond(
+      new Response(null, { status: 503 }),
+      new Response(null, { status: 200 }),
+    );
+    await bucket().put("key", new Uint8Array([1]).buffer);
+    expect(recorded).toHaveLength(2);
+  });
+
+  it("starts a multipart upload and decodes the upload id", async () => {
+    respond(xml(
+      '<?xml version="1.0" encoding="UTF-8"?>' +
+        '<InitiateMultipartUploadResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">' +
+        "<Bucket>beutl</Bucket><Key>k</Key><UploadId>abc&amp;def.1</UploadId>" +
+        "</InitiateMultipartUploadResult>",
+    ));
+    const created = await bucket().createMultipartUpload!("k", { httpMetadata: { contentType: "video/mp4" } });
+    expect(created).toEqual({ uploadId: "abc&def.1" });
+    expect(recorded[0].method).toBe("POST");
+    expect(recorded[0].url.search).toBe("?uploads");
+    expect(recorded[0].headers.get("content-type")).toBe("video/mp4");
+  });
+
+  it("streams a part without buffering it and strips the ETag quotes", async () => {
+    respond(new Response(null, { status: 200, headers: { etag: '"part-etag"' } }));
+    const handle = bucket().resumeMultipartUpload!("k", "up&1");
+    const part = await handle.uploadPart(2, stream(new Uint8Array([1, 2, 3, 4])));
+
+    expect(part).toEqual({ partNumber: 2, etag: "part-etag" });
+    const [request] = recorded;
+    expect(request.method).toBe("PUT");
+    expect(request.url.search).toBe("?partNumber=2&uploadId=up%261");
+    expect(request.headers.get("x-amz-content-sha256")).toBe("UNSIGNED-PAYLOAD");
+    expect(request.body).toBeInstanceOf(ReadableStream);
+  });
+
+  it("declares the length of a stream it was told about", async () => {
+    respond(
+      new Response(null, { status: 200, headers: { etag: '"p"' } }),
+      new Response(null, { status: 200 }),
+      new Response(null, { status: 200 }),
+    );
+    const s3 = bucket();
+    await s3.resumeMultipartUpload!("k", "up").uploadPart(1, stream(new Uint8Array(4)), { contentLength: 4 });
+    await s3.put("k", stream(new Uint8Array(2)), { contentLength: 2, httpMetadata: { contentType: "text/plain" } });
+    await s3.put("k", new Uint8Array(8).buffer, { contentLength: 8 });
+    expect(recorded[0].headers.get("content-length")).toBe("4");
+    expect(recorded[1].headers.get("content-length")).toBe("2");
+    expect(recorded[1].headers.get("content-type")).toBe("text/plain");
+    // A buffered body already carries its length; the header is left to fetch.
+    expect(recorded[2].headers.get("content-length")).toBeNull();
+    await expect(
+      s3.resumeMultipartUpload!("k", "up").uploadPart(1, stream(new Uint8Array(1)), { contentLength: -1 }),
+    ).rejects.toBeInstanceOf(RangeError);
+  });
+
+  it("does not retry a streamed part", async () => {
+    respond(new Response(null, { status: 503 }));
+    const handle = bucket().resumeMultipartUpload!("k", "up");
+    await expect(handle.uploadPart(1, stream(new Uint8Array([1])))).rejects.toMatchObject({ status: 503 });
+    expect(recorded).toHaveLength(1);
+  });
+
+  it("completes with the ordered part list and measures the joined object", async () => {
+    respond(
+      xml('<CompleteMultipartUploadResult><Location>x</Location><ETag>"final"</ETag></CompleteMultipartUploadResult>'),
+      new Response(null, { status: 200, headers: { "content-length": "1234" } }),
+    );
+    const handle = bucket().resumeMultipartUpload!("k", "up");
+    const joined = await handle.complete([
+      { partNumber: 1, etag: "e1" },
+      { partNumber: 2, etag: '"e2"' },
+    ]);
+
+    expect(joined).toEqual({ size: 1234 });
+    const [complete, head] = recorded;
+    expect(complete.method).toBe("POST");
+    expect(complete.url.search).toBe("?uploadId=up");
+    expect(complete.headers.get("content-type")).toBe("application/xml");
+    expect(await complete.text()).toBe(
+      '<CompleteMultipartUpload xmlns="http://s3.amazonaws.com/doc/2006-03-01/">' +
+        "<Part><PartNumber>1</PartNumber><ETag>&quot;e1&quot;</ETag></Part>" +
+        "<Part><PartNumber>2</PartNumber><ETag>&quot;e2&quot;</ETag></Part>" +
+        "</CompleteMultipartUpload>",
+    );
+    expect(head.method).toBe("HEAD");
+  });
+
+  it("treats an error document behind a 200 completion as a failure", async () => {
+    respond(xml("  <Error><Code>InternalError</Code><Message>We encountered an internal error.</Message></Error>"));
+    const handle = bucket().resumeMultipartUpload!("k", "up");
+    await expect(handle.complete([{ partNumber: 1, etag: "e1" }])).rejects.toMatchObject({
+      name: "S3StorageError",
+      code: "InternalError",
+      operation: "completeMultipartUpload",
+    });
+  });
+
+  it("aborts, and reports a forgotten upload the way the reconcilers expect", async () => {
+    respond(
+      new Response(null, { status: 204 }),
+      xml("<Error><Code>NoSuchUpload</Code><Message>The specified upload does not exist.</Message></Error>", { status: 404 }),
+    );
+    const handle = bucket().resumeMultipartUpload!("k", "up");
+    await expect(handle.abort()).resolves.toBeUndefined();
+    expect(recorded[0].method).toBe("DELETE");
+    expect(recorded[0].url.search).toBe("?uploadId=up");
+
+    let error: unknown;
+    try {
+      await handle.abort();
+    } catch (caught) {
+      error = caught;
+    }
+    expect(error).toBeInstanceOf(S3StorageError);
+    expect((error as S3StorageError).code).toBe("NoSuchUpload");
+    expect(isTerminalMultipartAbortError(error)).toBe(true);
+  });
+
+  it("rejects an endpoint that is not an http(s) URL", () => {
+    expect(() => bucket({ endpoint: "ftp://files.example.test" })).toThrow(/http\(s\)/u);
+  });
+});


### PR DESCRIPTION
## Description

- Add an S3 compatible storage adapter (aws4fetch, SigV4, unsigned streaming payloads) that implements the same shape as the R2 binding, selected with `BEUTL_STORAGE_PROVIDER=s3` and `BEUTL_S3_*`; the default remains the R2 binding so existing deployments are unchanged.
- Layer the two stores: new objects go to the selected provider, objects missing from it are read from the other configured store and deletes cover both, so switching providers keeps files stored before the switch reachable without copying.
- Add `/admin/storage` to the admin console: it shows which store holds each file's object, moves a single file, and moves files in bulk from the oldest onwards with bounded, resumable runs; every move is verified by size before the source is deleted and recorded in the audit log.
- Verified against a live MinIO and under workerd (`wrangler dev`): streamed multipart parts, put/get/head/delete and abort behave as expected. Streams without a known length need `contentLength`, which the web upload path now passes.

## Breaking changes

None. `uploadPart`/`put` gained an optional `contentLength` option; the admin Worker now declares the `BEUTL_R2_BUCKET` binding and needs the same storage settings as the other Workers.

## Fixed issues

None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Cloudflare R2 and S3-compatible object storage.
  * Added an admin storage console with search, sorting, pagination, location tracking, and per-file moves.
  * Added batch migrations with progress reporting, pause/stop controls, summaries, and audit logging.
  * Added fallback reads to keep existing files accessible during provider transitions.
  * Added safeguards against concurrent moves and incomplete transfers.

* **Bug Fixes**
  * Improved object retrieval and streamed upload handling across storage providers.

* **Documentation**
  * Added deployment guidance and configuration examples for object storage providers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->